### PR TITLE
feat(plugin-eslint): respect eslintignore

### DIFF
--- a/.changeset/sweet-hotels-beam.md
+++ b/.changeset/sweet-hotels-beam.md
@@ -1,0 +1,5 @@
+---
+'@onerepo/plugin-eslint': minor
+---
+
+Respect .eslintignore files when linting across files and paths (as opposed to `--all`)

--- a/modules/file/src/index.ts
+++ b/modules/file/src/index.ts
@@ -42,6 +42,17 @@ export async function write(filename: string, contents: string, { step }: Option
 	});
 }
 
+export async function lstat(filename: string, { step }: Options = {}) {
+	return stepWrapper({ step, name: `Stat ${filename}` }, async () => {
+		try {
+			const stat = await fs.lstat(filename);
+			return stat;
+		} catch (e) {
+			return null;
+		}
+	});
+}
+
 export async function format(filename: string, contents: string, { step }: Options = {}) {
 	return stepWrapper({ step, name: `Format ${filename}` }, async (step) => {
 		try {

--- a/modules/test-cli/src/fixtures/repo/modules/burritos/package.json
+++ b/modules/test-cli/src/fixtures/repo/modules/burritos/package.json
@@ -1,4 +1,7 @@
 {
 	"name": "fixture-burritos",
+	"alias": [
+		"burritos"
+	],
 	"version": "4.5.2"
 }

--- a/modules/test-cli/src/fixtures/repo/modules/tacos/package.json
+++ b/modules/test-cli/src/fixtures/repo/modules/tacos/package.json
@@ -1,4 +1,7 @@
 {
 	"name": "fixture-tacos",
+	"alias": [
+		"tacos"
+	],
 	"version": "1.2.3"
 }

--- a/plugins/eslint/package.json
+++ b/plugins/eslint/package.json
@@ -23,7 +23,8 @@
 		"@onerepo/builders": "0.0.0",
 		"@onerepo/git": "0.0.0",
 		"@onerepo/logger": "0.0.0",
-		"@onerepo/subprocess": "0.0.0"
+		"@onerepo/subprocess": "0.0.0",
+		"minimatch": "^6.2.0"
 	},
 	"devDependencies": {
 		"@onerepo/tsconfig": "workspace:^",

--- a/plugins/eslint/src/commands/eslint.test.ts
+++ b/plugins/eslint/src/commands/eslint.test.ts
@@ -1,0 +1,124 @@
+import * as subprocess from '@onerepo/subprocess';
+import * as file from '@onerepo/file';
+import * as git from '@onerepo/git';
+import * as Eslint from './eslint';
+import { getCommand } from '@onerepo/test-cli';
+
+const { run } = getCommand(Eslint);
+
+describe('handler', () => {
+	test('can run across all files', async () => {
+		vi.spyOn(subprocess, 'run').mockResolvedValue(['', '']);
+
+		await run('--all');
+
+		expect(subprocess.run).toHaveBeenCalledWith(
+			expect.objectContaining({
+				cmd: 'npx',
+				args: ['eslint', '--ext', 'js,cjs,mjs', '--cache', '--cache-strategy=content', '--fix', '.'],
+			})
+		);
+	});
+
+	test('can run across individual workspaces', async () => {
+		vi.spyOn(subprocess, 'run').mockResolvedValue(['', '']);
+		vi.spyOn(file, 'exists').mockResolvedValue(false);
+		vi.spyOn(file, 'lstat').mockResolvedValue(
+			// @ts-ignore mock
+			{ isDirectory: () => true }
+		);
+
+		await expect(run('-w burritos -w tacos')).resolves.toBeUndefined();
+
+		expect(subprocess.run).toHaveBeenCalledWith(
+			expect.objectContaining({
+				cmd: 'npx',
+				args: [
+					'eslint',
+					'--ext',
+					'js,cjs,mjs',
+					'--cache',
+					'--cache-strategy=content',
+					'--fix',
+					'modules/burritos',
+					'modules/tacos',
+				],
+			})
+		);
+	});
+
+	test('does not fix in dry-run', async () => {
+		vi.spyOn(subprocess, 'run').mockResolvedValue(['', '']);
+
+		await expect(run('-a --dry-run')).resolves.toBeUndefined();
+
+		expect(subprocess.run).toHaveBeenCalledWith(
+			expect.objectContaining({
+				cmd: 'npx',
+				args: ['eslint', '--ext', 'js,cjs,mjs', '--cache', '--cache-strategy=content', '.'],
+			})
+		);
+	});
+
+	test('does not fix in no-cache', async () => {
+		vi.spyOn(subprocess, 'run').mockResolvedValue(['', '']);
+
+		await expect(run('-a --no-cache')).resolves.toBeUndefined();
+
+		expect(subprocess.run).toHaveBeenCalledWith(
+			expect.objectContaining({
+				cmd: 'npx',
+				args: ['eslint', '--ext', 'js,cjs,mjs', '--fix', '.'],
+			})
+		);
+	});
+
+	test('filters unapproved extensions', async () => {
+		vi.spyOn(subprocess, 'run').mockResolvedValue(['', '']);
+
+		await expect(run('-f foo.xd -f bar.js')).resolves.toBeUndefined();
+
+		expect(subprocess.run).toHaveBeenCalledWith(
+			expect.objectContaining({
+				cmd: 'npx',
+				args: ['eslint', '--ext', 'js,cjs,mjs', '--cache', '--cache-strategy=content', '--fix', 'bar.js'],
+			})
+		);
+	});
+
+	test('filters with .eslintignore', async () => {
+		vi.spyOn(subprocess, 'run').mockResolvedValue(['', '']);
+		vi.spyOn(file, 'exists').mockResolvedValue(true);
+		vi.spyOn(file, 'read').mockResolvedValue(`
+# ignore the comment
+bar/**/*
+`);
+		vi.spyOn(file, 'lstat').mockResolvedValue(
+			// @ts-ignore mock
+			{ isDirectory: () => false }
+		);
+		await expect(run('-f foo.js -f bar/baz/bop.js')).resolves.toBeUndefined();
+
+		expect(subprocess.run).toHaveBeenCalledWith(
+			expect.objectContaining({
+				cmd: 'npx',
+				args: ['eslint', '--ext', 'js,cjs,mjs', '--cache', '--cache-strategy=content', '--fix', 'foo.js'],
+			})
+		);
+	});
+
+	test('updates the git index for filtered paths with --add', async () => {
+		vi.spyOn(subprocess, 'run').mockResolvedValue(['', '']);
+		vi.spyOn(git, 'updateIndex').mockResolvedValue('');
+
+		await expect(run('-f foo.xd -f bar.js --add')).resolves.toBeUndefined();
+
+		expect(subprocess.run).toHaveBeenCalledWith(
+			expect.objectContaining({
+				cmd: 'npx',
+				args: ['eslint', '--ext', 'js,cjs,mjs', '--cache', '--cache-strategy=content', '--fix', 'bar.js'],
+			})
+		);
+		expect(git.updateIndex).toHaveBeenCalledWith(['bar.js']);
+	});
+});

--- a/plugins/eslint/src/commands/eslint.ts
+++ b/plugins/eslint/src/commands/eslint.ts
@@ -1,9 +1,10 @@
 import path from 'node:path';
+import { minimatch } from 'minimatch';
 import { updateIndex } from '@onerepo/git';
+import { exists, lstat, read } from '@onerepo/file';
 import { run } from '@onerepo/subprocess';
 import type { WithAllInputs } from '@onerepo/builders';
 import { withAllInputs } from '@onerepo/builders';
-import { logger } from '@onerepo/logger';
 import type { Builder, Handler } from '@onerepo/types';
 
 export const command = 'eslint';
@@ -40,14 +41,40 @@ export const builder: Builder<Args> = (yargs) =>
 			default: ['js', 'cjs', 'mjs'],
 		});
 
-export const handler: Handler<Args> = async function handler(argv, { getFilepaths }) {
+export const handler: Handler<Args> = async function handler(argv, { getFilepaths, graph, logger }) {
 	const { add, all, cache, 'dry-run': isDry, extensions, fix } = argv;
 
-	const paths = await getFilepaths();
-	const filteredPaths = paths.filter((filepath) => {
-		const ext = path.extname(filepath);
-		return !ext || extensions.includes(ext.replace(/^\./, ''));
-	});
+	const filteredPaths = [];
+	if (!all) {
+		const ignoreStep = logger.createStep('Filtering ignored files');
+		const ignoreFile = graph.root.resolve('.eslintignore');
+		const hasIgnores = await exists(ignoreFile, { step: ignoreStep });
+		const rawIgnores = await (hasIgnores ? read(ignoreFile, 'r', { step: ignoreStep }) : '');
+		const ignores = rawIgnores.split('\n').filter((line) => Boolean(line.trim()) && !line.trim().startsWith('#'));
+
+		const paths = await getFilepaths();
+		for (const filepath of paths) {
+			const ext = path.extname(filepath);
+			if (!ext) {
+				const stat = await lstat(graph.root.resolve(filepath), { step: ignoreStep });
+				const isDirectory = stat && stat.isDirectory();
+				if (isDirectory) {
+					filteredPaths.push(filepath);
+				}
+				continue;
+			}
+
+			if (!extensions.includes(ext.replace(/^\./, ''))) {
+				continue;
+			}
+
+			if (!ignores.some((pattern) => minimatch(filepath, pattern))) {
+				filteredPaths.push(filepath);
+			}
+		}
+
+		await ignoreStep.end();
+	}
 
 	if (!all && !filteredPaths.length) {
 		logger.warn('No files have been selected to lint. Exiting early.');
@@ -62,12 +89,13 @@ export const handler: Handler<Args> = async function handler(argv, { getFilepath
 			'--ext',
 			extensions.join(','),
 			cache ? '--cache' : '',
+			cache ? '--cache-strategy=content' : '',
 			!isDry && fix ? '--fix' : '',
 			...(all ? ['.'] : filteredPaths),
 		].filter(Boolean),
 	});
 
-	if (add) {
-		await updateIndex(paths);
+	if (add && filteredPaths.length) {
+		await updateIndex(filteredPaths);
 	}
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1397,6 +1397,7 @@ __metadata:
     "@onerepo/vitest": "workspace:^"
     "@types/eslint": ^8
     eslint: ^8.34.0
+    minimatch: ^6.2.0
     typescript: ^4.9.5
   peerDependencies:
     eslint: ^8


### PR DESCRIPTION
* Switches to use cache-strategy=content (should allow shared cache in CI)
* Adds lstat to file helpers
* Fixes potential issue with `--add` that could have been adding too many files

fixes #58