### PR TITLE
fix(git plugin-changesets): merge committed and uncommitted changes

### DIFF
--- a/.changeset/tidy-eggs-unite.md
+++ b/.changeset/tidy-eggs-unite.md
@@ -1,0 +1,6 @@
+---
+'@onerepo/plugin-changesets': patch
+'@onerepo/git': patch
+---
+
+When looking for modified files, merge the current status along with the diff-tree from merge-base. This mostly affects plugin-changesets when running `changsets add` in that adding multiple changesets in a single command will continue to show all affected workspaces each time, regardless of uncommitted status.

--- a/modules/git/src/index.ts
+++ b/modules/git/src/index.ts
@@ -98,26 +98,23 @@ export async function getModifiedFiles(from?: string, through?: string, { step }
 
 		const hasUncommittedChanges = Boolean(currentStatus.trim()) && !from && !through;
 
-		let changes = currentStatus;
-		if (!hasUncommittedChanges) {
-			const [modified] = await run({
-				name: 'Getting modified files',
-				cmd: 'git',
-				args: hasUncommittedChanges
-					? ['diff', '--name-status', base]
-					: [
-							'diff-tree',
-							'-r',
-							'--name-status',
-							'--no-commit-id',
-							isMain ? `${currentSha}^` : base,
-							isMain ? currentSha : 'HEAD',
-							// eslint-disable-next-line no-mixed-spaces-and-tabs
-					  ],
-				step,
-			});
-			changes = modified;
-		}
+		const [modified] = await run({
+			name: 'Getting modified files',
+			cmd: 'git',
+			args: hasUncommittedChanges
+				? ['diff', '--name-status', base]
+				: [
+						'diff-tree',
+						'-r',
+						'--name-status',
+						'--no-commit-id',
+						isMain ? `${currentSha}^` : base,
+						isMain ? currentSha : 'HEAD',
+						// eslint-disable-next-line no-mixed-spaces-and-tabs
+				  ],
+			step,
+		});
+		const changes = `${currentStatus}\n${modified}`;
 
 		const changeMap = changes
 			.trim()

--- a/plugins/changesets/src/commands/add.ts
+++ b/plugins/changesets/src/commands/add.ts
@@ -42,7 +42,7 @@ export const handler: Handler<Argv> = async (argv, { getWorkspaces, graph, logge
 			prefix: '📦',
 			message: `What workspaces would you like to add a changeset for?
 ${pc.dim(
-	'  Keep in mind that each changeset should be related to a single change. If you have made multiple changes, please run this command once for each change.'
+	'  Keep in mind that each changeset entry should be related to a single change. If you have made multiple changes, please run this command once for each change.'
 )}
  `,
 			choices,


### PR DESCRIPTION
To determine modified files, typically we want both the committed and uncommitted state.