### PR TITLE
add task meta handling

### DIFF
--- a/.changeset/honest-cameras-divide.md
+++ b/.changeset/honest-cameras-divide.md
@@ -1,0 +1,5 @@
+---
+'@onerepo/plugin-tasks': minor
+---
+
+Allow passing arbitrary meta information from the Task configs to the output information when using `one tasks --list`.

--- a/modules/graph/src/Workspace.ts
+++ b/modules/graph/src/Workspace.ts
@@ -165,7 +165,7 @@ export interface PackageJsonWithLocation extends PackageJson {
 	location: string;
 }
 
-type MatchTask = { match: string; cmd: string };
+type MatchTask = { match?: string; cmd: string; meta?: Record<string, unknown> };
 export type Task = string | MatchTask;
 export type Tasks = {
 	sequential?: Array<Task>;

--- a/plugins/tasks/README.md
+++ b/plugins/tasks/README.md
@@ -34,6 +34,24 @@ export default {
 };
 ```
 
+### Tasks
+
+Each task can either be a `string` or an `object`:
+
+```ts
+type Task = string | { cmd: string; match?: string; meta?: Record<string, unknown> };
+```
+
+For commands that need to run under all circumstancs, you will typically want to use a `string`. If, however, you need to limit a task to only when modified files match a particular glob, you can use the `object` pattern.
+
+For example, to run a `lint` only when TS or JS files have been modified:
+
+```js
+{ match: '**/*.{ts,tsx,js,jsx}', cmd: '$0 lint --add' }
+```
+
+You can also provide `meta` information in tasks. This information will only be available when listing tasks like in [GitHub Actions](#github-actions).
+
 ### Adding more lifecycles
 
 First, configure the extra available `lifecycles` that the task runner should have access to run:
@@ -71,7 +89,7 @@ While the `tasks` command does its best to split out parallel and sequential tas
 
 To do this, we make use of the `task --list` argument to write a JSON-formatted list of tasks to standard output, then read that in with a matrix strategy as a second job.
 
-```yaml title=".github/workflows/pull-request.yaml"
+````yaml title=".github/workflows/pull-request.yaml"
 name: Pull request
 
 on: pull_request
@@ -122,9 +140,7 @@ jobs:
         run: |
           cd ${{ matrix.task.opts.cwd }}
           ${{ matrix.task.cmd }} ${{ join(matrix.task.args, ' ') }}
-```
-
-## Uninstall
+```## Uninstall
 
 So you have decided that `tasks` are not for you? That’s okay. You can deactivate the core plugin by passing `false` to the configuration:
 
@@ -139,7 +155,7 @@ So you have decided that `tasks` are not for you? That’s okay. You can deactiv
 
 	await run();
 })();
-```
+````
 
 <!-- start-onerepo-sentinel -->
 

--- a/plugins/tasks/src/commands/__fixtures__/repo/modules/burritos/onerepo.config.js
+++ b/plugins/tasks/src/commands/__fixtures__/repo/modules/burritos/onerepo.config.js
@@ -1,0 +1,4 @@
+/** @type import('@onerepo/graph').TaskConfig */
+module.exports = {
+	'pre-merge': { sequential: [{ cmd: 'echo "pre-merge" "burritos"', meta: { good: 'yes' } }] },
+};

--- a/plugins/tasks/src/commands/tasks.test.ts
+++ b/plugins/tasks/src/commands/tasks.test.ts
@@ -63,26 +63,43 @@ describe('handler', () => {
 				cmd: expect.stringMatching(/test-runner$/),
 				args: ['lint'],
 				opts: { cwd: '.' },
-				meta: { name: 'fixture-root', slug: 'fixture-root' },
 			}),
 			expect.objectContaining({
 				cmd: expect.stringMatching(/test-runner$/),
 				args: ['tsc'],
 				opts: { cwd: '.' },
-				meta: { name: 'fixture-root', slug: 'fixture-root' },
 			}),
 			expect.objectContaining({ cmd: 'echo', args: ['"commit"'] }),
 			expect.objectContaining({
 				cmd: 'echo',
 				args: ['"post-commit"'],
 				opts: { cwd: '.' },
-				meta: { name: 'fixture-root', slug: 'fixture-root' },
 			}),
 			expect.objectContaining({
 				cmd: 'echo',
 				args: ['"post-commit"', '"tacos"'],
 				opts: { cwd: 'modules/tacos' },
-				meta: { name: 'fixture-tacos', slug: 'fixture-tacos' },
+			}),
+		]);
+	});
+
+	test('includes meta information on task list', async () => {
+		vitest.spyOn(git, 'getModifiedFiles').mockResolvedValue({ all: ['burritos/src/index.ts'] });
+		const graph = getGraph(path.join(__dirname, '__fixtures__', 'repo'));
+
+		let out = '';
+		vitest.spyOn(process.stdout, 'write').mockImplementation((content) => {
+			out += content.toString();
+			return true;
+		});
+
+		await run('--lifecycle pre-merge --list', { graph });
+		expect(JSON.parse(out)).toEqual([
+			expect.objectContaining({
+				cmd: 'echo',
+				args: ['"pre-merge"', '"burritos"'],
+				opts: { cwd: 'modules/burritos' },
+				meta: { good: 'yes', name: 'fixture-burritos', slug: 'fixture-burritos' },
 			}),
 		]);
 	});


### PR DESCRIPTION
Have found some cases where it will be helpful to add some meta information to the tasks run (like during deploy to configure environments, etc and the command is not part of the `one` command system). This should allow arbitrary information to be passed through for utilizing separately, like in GitHub action matrices.