### PR TITLE
fix(plugin-changesets): prompt for workspaces included in changesets

### DIFF
--- a/.changeset/orange-wasps-prove.md
+++ b/.changeset/orange-wasps-prove.md
@@ -1,0 +1,5 @@
+---
+'@onerepo/plugin-changesets': patch
+---
+
+When versioning workspaces, check for other workspaces not in the list of those selected for release. If there are more that need to be added outside of the direct dependency chain, warn the user and confirm okay to continue including those workspaces as well.

--- a/plugins/changesets/src/commands/__fixtures__/interconnected/.changeset/baz-bop-qux.md
+++ b/plugins/changesets/src/commands/__fixtures__/interconnected/.changeset/baz-bop-qux.md
@@ -1,0 +1,8 @@
+---
+tortillas: minor
+burritos: minor
+churros: minor
+tacos: minor
+---
+
+Minor bump in tortillas

--- a/plugins/changesets/src/commands/__fixtures__/interconnected/.changeset/config.json
+++ b/plugins/changesets/src/commands/__fixtures__/interconnected/.changeset/config.json
@@ -1,0 +1,11 @@
+{
+	"$schema": "https://unpkg.com/@changesets/config@2.3.0/schema.json",
+	"changelog": "@changesets/cli/changelog",
+	"commit": false,
+	"fixed": [],
+	"linked": [],
+	"access": "restricted",
+	"baseBranch": "main",
+	"updateInternalDependencies": "patch",
+	"ignore": []
+}

--- a/plugins/changesets/src/commands/__fixtures__/interconnected/.changeset/foo-bar-baz.md
+++ b/plugins/changesets/src/commands/__fixtures__/interconnected/.changeset/foo-bar-baz.md
@@ -1,0 +1,5 @@
+---
+burritos: minor
+---
+
+Minor bump in burritos

--- a/plugins/changesets/src/commands/__fixtures__/interconnected/modules/burritos/package.json
+++ b/plugins/changesets/src/commands/__fixtures__/interconnected/modules/burritos/package.json
@@ -1,0 +1,7 @@
+{
+	"name": "burritos",
+	"version": "0.1.7",
+	"dependencies": {
+		"tortillas": "0.4.5"
+	}
+}

--- a/plugins/changesets/src/commands/__fixtures__/interconnected/modules/churros/package.json
+++ b/plugins/changesets/src/commands/__fixtures__/interconnected/modules/churros/package.json
@@ -1,0 +1,8 @@
+{
+	"name": "churros",
+	"version": "0.2.0",
+	"dependencies": {},
+	"publishConfig": {
+		"access": "public"
+	}
+}

--- a/plugins/changesets/src/commands/__fixtures__/interconnected/modules/tacos/package.json
+++ b/plugins/changesets/src/commands/__fixtures__/interconnected/modules/tacos/package.json
@@ -1,0 +1,7 @@
+{
+	"name": "tacos",
+	"version": "0.2.0",
+	"dependencies": {
+		"tortillas": "0.4.5"
+	}
+}

--- a/plugins/changesets/src/commands/__fixtures__/interconnected/modules/tortillas/package.json
+++ b/plugins/changesets/src/commands/__fixtures__/interconnected/modules/tortillas/package.json
@@ -1,0 +1,5 @@
+{
+	"name": "tortillas",
+	"version": "0.4.5",
+	"dependencies": {}
+}

--- a/plugins/changesets/src/commands/__fixtures__/interconnected/package.json
+++ b/plugins/changesets/src/commands/__fixtures__/interconnected/package.json
@@ -1,0 +1,7 @@
+{
+	"name": "repo",
+	"private": true,
+	"workspaces": [
+		"modules/*"
+	]
+}

--- a/plugins/changesets/src/commands/version.test.ts
+++ b/plugins/changesets/src/commands/version.test.ts
@@ -101,4 +101,36 @@ describe('handler', () => {
 		expect(applyReleasePlan.default).not.toHaveBeenCalled();
 		expect(git.updateIndex).not.toHaveBeenCalled();
 	});
+
+	test('when changesets affect un-selected workspaces, prompts for okay to version those as well', async () => {
+		graph = getGraph(path.join(__dirname, '__fixtures__', 'interconnected'));
+		vi.spyOn(inquirer, 'prompt')
+			.mockResolvedValueOnce({ choices: ['churros'] })
+			.mockResolvedValueOnce({ okay: true });
+		await run('', { graph });
+
+		expect(applyReleasePlan.default).toHaveBeenCalledWith(
+			expect.objectContaining({
+				changesets: [expect.objectContaining({ id: 'baz-bop-qux' }), expect.objectContaining({ id: 'foo-bar-baz' })],
+				releases: expect.arrayContaining([
+					expect.objectContaining({ name: 'tortillas' }),
+					expect.objectContaining({ name: 'burritos' }),
+					expect.objectContaining({ name: 'churros' }),
+					expect.objectContaining({ name: 'tacos' }),
+				]),
+			}),
+			expect.any(Object),
+			expect.any(Object)
+		);
+	});
+
+	test('when changesets affect un-selected workspaces, can exit at okay prompt', async () => {
+		graph = getGraph(path.join(__dirname, '__fixtures__', 'interconnected'));
+		vi.spyOn(inquirer, 'prompt')
+			.mockResolvedValueOnce({ choices: ['churros'] })
+			.mockResolvedValueOnce({ okay: false });
+		await run('', { graph });
+
+		expect(applyReleasePlan.default).not.toHaveBeenCalled();
+	});
 });


### PR DESCRIPTION
**Problem:** When selecting workspaces for versioning, other packages were being versioned based on only the changesets related to the selected workspaces. This isn't quite right when there's a single changeset that spans multiple workspaces where one or more of those workspaces is not part of the list of workspaces originally requested to be versioned. This results in incorrectly versioning those extra workspaces and not including all of their changesets in changelogs.

**Solution:** Check for the extra workspaces, prompt that it will be necessary to included them, then do so if okay to proceed. Exit early and fail if not okay.