### PR TITLE
add internal changeset-changelog formatter

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://unpkg.com/@changesets/config@2.3.0/schema.json",
-	"changelog": "@changesets/cli/changelog",
+	"changelog": ["@internal/changeset-changelog", { "repo": "paularmstrong/onerepo" }],
 	"commit": false,
 	"fixed": [],
 	"linked": [],

--- a/config/templates/module/.onegen.cjs
+++ b/config/templates/module/.onegen.cjs
@@ -4,5 +4,5 @@ module.exports = {
 	outDir: path.join(__dirname, '..', '..', '..', 'modules'),
 	nameFormat: (name) => `@onerepo/${name}`,
 	dirnameFormat: (name) => name,
-	prompts: [{ name: 'tacos', type: 'input', message: 'What are tacos' }],
+	prompts: [],
 };

--- a/config/templates/module/src/index.ts.ejs
+++ b/config/templates/module/src/index.ts.ejs
@@ -1,3 +1,3 @@
-export function <%- name %>(): void {
+export function <%- name.replace(/-./g, (x)=> x[1].toUpperCase()) %>(): void {
 	return ;
 }

--- a/internal/changeset-changelog/package.json
+++ b/internal/changeset-changelog/package.json
@@ -1,0 +1,14 @@
+{
+	"name": "@internal/changeset-changelog",
+	"private": true,
+	"type": "module",
+	"main": "./src/index.ts",
+	"devDependencies": {
+		"@changesets/parse": "^0.3.16",
+		"@changesets/types": "^5.2.1",
+		"@internal/tsconfig": "workspace:^"
+	},
+	"dependencies": {
+		"@changesets/get-github-info": "^0.5.2"
+	}
+}

--- a/internal/changeset-changelog/src/index.test.ts
+++ b/internal/changeset-changelog/src/index.test.ts
@@ -1,0 +1,111 @@
+import changelogFunctions from './index';
+import parse from '@changesets/parse';
+
+const getReleaseLine = changelogFunctions.getReleaseLine;
+
+// eslint-disable-next-line @typescript-eslint/consistent-type-imports
+vi.mock('@changesets/get-github-info', (): typeof import('@changesets/get-github-info') => {
+	const data = {
+		commit: 'a085003',
+		user: 'paularmstrong',
+		pull: 1613,
+		repo: 'paularmstrong/onerepo',
+	};
+	const links = {
+		user: `[@${data.user}](https://github.com/${data.user})`,
+		pull: `[#${data.pull}](https://github.com/${data.repo}/pull/${data.pull})`,
+		commit: `[\`${data.commit}\`](https://github.com/${data.repo}/commit/${data.commit})`,
+	};
+	return {
+		async getInfo({ commit, repo }) {
+			expect(commit).toBe(data.commit);
+			expect(repo).toBe(data.repo);
+			return {
+				pull: data.pull,
+				user: data.user,
+				links,
+			};
+		},
+		async getInfoFromPullRequest({ pull, repo }) {
+			expect(pull).toBe(data.pull);
+			expect(repo).toBe(data.repo);
+			return {
+				commit: data.commit,
+				user: data.user,
+				links,
+			};
+		},
+	};
+});
+
+const getChangeset = (content: string, commit: string | undefined) => {
+	return [
+		{
+			...parse(
+				`---
+  pkg: "minor"
+  ---
+
+  something
+  ${content}
+  `
+			),
+			id: 'some-id',
+			commit,
+		},
+		'minor',
+		{ repo: data.repo },
+	] as const;
+};
+
+const data = {
+	commit: 'a085003',
+	user: 'paularmstrong',
+	pull: 1613,
+	repo: 'paularmstrong/onerepo',
+};
+
+describe('changeset-changelog', () => {
+	describe.each([data.commit, 'wrongcommit', undefined])('with commit from changeset of %s', (commitFromChangeset) => {
+		describe.each(['pr', 'pull request', 'pull'])('override pr with %s keyword', (keyword) => {
+			test.each(['with #', 'without #'] as const)('%s', async (kind) => {
+				expect(
+					await getReleaseLine(
+						...getChangeset(`${keyword}: ${kind === 'with #' ? '#' : ''}${data.pull}`, commitFromChangeset)
+					)
+				).toEqual(
+					`\n\n- [#1613](https://github.com/paularmstrong/onerepo/pull/1613) ([@paularmstrong](https://github.com/paularmstrong)): something\n`
+				);
+			});
+		});
+
+		test('override commit with commit keyword', async () => {
+			expect(await getReleaseLine(...getChangeset(`commit: ${data.commit}`, commitFromChangeset))).toEqual(
+				`\n\n- [#1613](https://github.com/paularmstrong/onerepo/pull/1613) ([@paularmstrong](https://github.com/paularmstrong)): something\n`
+			);
+		});
+	});
+
+	describe.each(['author', 'user'])('override author with %s keyword', (keyword) => {
+		test.each(['with @', 'without @'] as const)('%s', async (kind) => {
+			expect(
+				await getReleaseLine(...getChangeset(`${keyword}: ${kind === 'with @' ? '@' : ''}other`, data.commit))
+			).toEqual(
+				`\n\n- [#1613](https://github.com/paularmstrong/onerepo/pull/1613) ([@other](https://github.com/other)): something\n`
+			);
+		});
+	});
+
+	test('with multiple authors', async () => {
+		expect(
+			await getReleaseLine(
+				...getChangeset(['author: @paularmstrong', 'author: @mitchellhamilton'].join('\n'), data.commit)
+			)
+		).toMatchInlineSnapshot(`
+    "
+
+    - [#1613](https://github.com/paularmstrong/onerepo/pull/1613) ([@paularmstrong](https://github.com/paularmstrong), [@mitchellhamilton](https://github.com/mitchellhamilton)): something
+    "
+  `);
+	});
+});

--- a/internal/changeset-changelog/src/index.ts
+++ b/internal/changeset-changelog/src/index.ts
@@ -1,0 +1,108 @@
+import type { ChangelogFunctions } from '@changesets/types';
+import { getInfo, getInfoFromPullRequest } from '@changesets/get-github-info';
+
+const changelogFunctions: ChangelogFunctions = {
+	getDependencyReleaseLine: async (changesets, dependenciesUpdated, options) => {
+		if (!options.repo) {
+			throw new Error(
+				'Please provide a repo to this changelog generator like this:\n"changelog": ["@onerepo/changesets-changelog", { "repo": "org/repo" }]'
+			);
+		}
+		if (dependenciesUpdated.length === 0) return '';
+
+		const changesetLink = `- Updated dependencies [${(
+			await Promise.all(
+				changesets.map(async (cs) => {
+					if (cs.commit) {
+						const { links } = await getInfo({
+							repo: options.repo,
+							commit: cs.commit,
+						});
+						return links.commit;
+					}
+				})
+			)
+		)
+			.filter((_) => _)
+			.join(', ')}]:`;
+
+		const updatedDepenenciesList = dependenciesUpdated.map(
+			(dependency) => `  - ${dependency.name}@${dependency.newVersion}`
+		);
+
+		return [changesetLink, ...updatedDepenenciesList].join('\n');
+	},
+	getReleaseLine: async (changeset, type, options) => {
+		if (!options || !options.repo) {
+			throw new Error(
+				'Please provide a repo to this changelog generator like this:\n"changelog": ["@onerepo/changesets-changelog", { "repo": "org/repo" }]'
+			);
+		}
+
+		let prFromSummary: number | undefined;
+		let commitFromSummary: string | undefined;
+		const usersFromSummary: Array<string> = [];
+
+		const replacedChangelog = changeset.summary
+			.replace(/^\s*(?:pr|pull|pull\s+request):\s*#?(\d+)/im, (_, pr) => {
+				const num = Number(pr);
+				if (!isNaN(num)) prFromSummary = num;
+				return '';
+			})
+			.replace(/^\s*commit:\s*([^\s]+)/im, (_, commit) => {
+				commitFromSummary = commit;
+				return '';
+			})
+			.replace(/^\s*(?:author|user):\s*@?([^\s]+)/gim, (_, user) => {
+				usersFromSummary.push(user);
+				return '';
+			})
+			.trim();
+
+		const [firstLine, ...futureLines] = replacedChangelog.split('\n').map((l) => l.trimRight());
+
+		const links = await (async () => {
+			if (prFromSummary !== undefined) {
+				let { links } = await getInfoFromPullRequest({
+					repo: options.repo,
+					pull: prFromSummary,
+				});
+				if (commitFromSummary) {
+					links = {
+						...links,
+						commit: `[\`${commitFromSummary}\`](https://github.com/${options.repo}/commit/${commitFromSummary})`,
+					};
+				}
+				return links;
+			}
+			const commitToFetchFrom = commitFromSummary || changeset.commit;
+			if (commitToFetchFrom) {
+				const { links } = await getInfo({
+					repo: options.repo,
+					commit: commitToFetchFrom,
+				});
+				return links;
+			}
+			return {
+				commit: null,
+				pull: null,
+				user: null,
+			};
+		})();
+
+		const users = usersFromSummary.length
+			? usersFromSummary
+					.map((userFromSummary) => `[@${userFromSummary}](https://github.com/${userFromSummary})`)
+					.join(', ')
+			: links.user;
+
+		const prefix = [
+			links.pull === null ? (links.commit === null ? '' : ` ${links.commit}`) : ` ${links.pull}`,
+			users === null ? '' : ` (${users})`,
+		].join('');
+
+		return `\n\n-${prefix ? `${prefix}:` : ''} ${firstLine}\n${futureLines.map((l) => `  ${l}`).join('\n')}`;
+	},
+};
+
+export default changelogFunctions;

--- a/internal/changeset-changelog/tsconfig.json
+++ b/internal/changeset-changelog/tsconfig.json
@@ -1,0 +1,8 @@
+{
+	"extends": "@internal/tsconfig/base.json",
+	"compilerOptions": {
+		"outDir": "./dist/",
+		"composite": true
+	},
+	"include": ["./src"]
+}

--- a/internal/eslint-plugin/src/index.cjs
+++ b/internal/eslint-plugin/src/index.cjs
@@ -53,6 +53,9 @@ module.exports = {
 						'@typescript-eslint/no-non-null-assertion': 'off',
 						'@typescript-eslint/no-inferrable-types': 'off',
 						'@typescript-eslint/no-var-requires': 'off',
+
+						'@typescript-eslint/array-type': ['error', { default: 'generic', readonly: 'generic' }],
+						'@typescript-eslint/consistent-indexed-object-style': ['error', 'record'],
 					},
 					settings: {
 						react: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -627,6 +627,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@changesets/get-github-info@npm:^0.5.2":
+  version: 0.5.2
+  resolution: "@changesets/get-github-info@npm:0.5.2"
+  dependencies:
+    dataloader: ^1.4.0
+    node-fetch: ^2.5.0
+  checksum: 067e07eeaecdbedbd1c715513c4aa6206a941bd1d3af292d067792808c6fa6644caad2b35fba614a44892559c031c234df8028f8d2abd4cb2682d48080ef5df3
+  languageName: node
+  linkType: hard
+
 "@changesets/get-release-plan@npm:^3.0.16":
   version: 3.0.16
   resolution: "@changesets/get-release-plan@npm:3.0.16"
@@ -1237,6 +1247,17 @@ __metadata:
   checksum: 17ee033e26a0fd82294de87eae76d32b553a130fdbf0fb8c70d39f2087a3e8a4a5908970a99aa32bd175153efe9b7dfee6b7f99df36f41abed08c1911dbdb19c
   languageName: node
   linkType: hard
+
+"@internal/changeset-changelog@workspace:internal/changeset-changelog":
+  version: 0.0.0-use.local
+  resolution: "@internal/changeset-changelog@workspace:internal/changeset-changelog"
+  dependencies:
+    "@changesets/get-github-info": ^0.5.2
+    "@changesets/parse": ^0.3.16
+    "@changesets/types": ^5.2.1
+    "@internal/tsconfig": "workspace:^"
+  languageName: unknown
+  linkType: soft
 
 "@internal/eslint-plugin@workspace:^, @internal/eslint-plugin@workspace:internal/eslint-plugin":
   version: 0.0.0-use.local
@@ -5752,6 +5773,13 @@ __metadata:
   version: 4.0.1
   resolution: "data-uri-to-buffer@npm:4.0.1"
   checksum: 0d0790b67ffec5302f204c2ccca4494f70b4e2d940fea3d36b09f0bb2b8539c2e86690429eb1f1dc4bcc9e4df0644193073e63d9ee48ac9fce79ec1506e4aa4c
+  languageName: node
+  linkType: hard
+
+"dataloader@npm:^1.4.0":
+  version: 1.4.0
+  resolution: "dataloader@npm:1.4.0"
+  checksum: e2c93d43afde68980efc0cd9ff48e9851116e27a9687f863e02b56d46f7e7868cc762cd6dcbaf4197e1ca850a03651510c165c2ae24b8e9843fd894002ad0e20
   languageName: node
   linkType: hard
 
@@ -12319,7 +12347,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-fetch@npm:^2.3.0, node-fetch@npm:^2.6.0, node-fetch@npm:^2.6.7":
+"node-fetch@npm:^2.3.0, node-fetch@npm:^2.5.0, node-fetch@npm:^2.6.0, node-fetch@npm:^2.6.7":
   version: 2.6.9
   resolution: "node-fetch@npm:2.6.9"
   dependencies:


### PR DESCRIPTION
**Problem:** The default changesets changelog formatter has a weird behavior where it shows multiple update dependencies lines. It's a bit weird. For example:

```md
- Updated dependencies [c1863ba]
- Updated dependencies [6665501]
- Updated dependencies [2f4e19e]
- Updated dependencies [d502f2e]
- Updated dependencies [831ea55]
- Updated dependencies [6431e8d]
- Updated dependencies [65a63cf]
- Updated dependencies [831ea55]
- Updated dependencies [2f4e19e]
- Updated dependencies [2f4e19e]
- Updated dependencies [587b442]
- Updated dependencies [1293372]
- Updated dependencies [4f7433d]
- Updated dependencies [126c514]
- Updated dependencies [04c28b2]
- Updated dependencies [c7ffeaa]
- Updated dependencies [0a3bb03]
- Updated dependencies [65a63cf]
- Updated dependencies [65a63cf]
  - @onerepo/core@0.1.0
  - @onerepo/types@0.0.1
  - @onerepo/logger@0.0.1
  - @onerepo/subprocess@0.0.1
  - @onerepo/graph@0.1.0
  - @onerepo/git@0.0.1
  - @onerepo/file@0.0.1
  - @onerepo/builders@0.0.1
```

Also, the `@changesets/changelog-github` is a little off in how it starts every entry with `Thanks @name!`.

**Solution:** copy the changelog-github code (MIT licensed) and modify it to remove the `Thanks` and `!` and wrap usernames in parentheses..

> **Warning**
> This is not intended for distribution, so the package is marked internal. If others want a similar changelog format, they should fork and/or create their own.
