### PR TITLE
feat: use both cpus when cpus.length === 2 in batch()

### DIFF
--- a/.changeset/cuddly-dryers-confess.md
+++ b/.changeset/cuddly-dryers-confess.md
@@ -1,0 +1,6 @@
+---
+'onerepo': minor
+'@onerepo/subprocess': minor
+---
+
+When running a `batch()` process, if there are only 2-CPUs available, use both CPUs instead of `cpus.length - 1`. While we normally encourage using one less than available to avoid locking up the main processes, it should still be faster to spawn a separate process to the same CPU than to do all tasks synchronously.

--- a/modules/subprocess/src/index.ts
+++ b/modules/subprocess/src/index.ts
@@ -249,7 +249,8 @@ export async function batch(processes: Array<RunSpec>): Promise<Array<[string, s
 	});
 
 	let failing = false;
-	const maxParallel = Math.min(os.cpus().length - 1, tasks.length);
+	const cpus = os.cpus().length;
+	const maxParallel = Math.min(cpus === 2 ? 2 : cpus - 1, tasks.length);
 
 	return new Promise((resolve, reject) => {
 		logger.debug(`Running ${tasks.length} processes with max parallelism ${maxParallel}`);


### PR DESCRIPTION
eg, for oneRepo itself running `one tsc` across all workspaces:

| Before | After | 
| --- | --- |
| [1m27s](https://github.com/paularmstrong/onerepo/actions/runs/4345466037/jobs/7590257407) | [47s](https://github.com/paularmstrong/onerepo/actions/runs/4348637980/jobs/7597441160) |