### PR TITLE
fix: prevent workspaces from using the same aliases

### DIFF
--- a/.changeset/olive-rings-carry.md
+++ b/.changeset/olive-rings-carry.md
@@ -1,0 +1,6 @@
+---
+'@onerepo/graph': patch
+'onerepo': patch
+---
+
+Prevent aliases from being reused across workspaces.

--- a/modules/graph/src/Graph.test.ts
+++ b/modules/graph/src/Graph.test.ts
@@ -16,4 +16,13 @@ describe('Graph', () => {
 			'fixture-root',
 		]);
 	});
+
+	test('cannot reuse an alias', async () => {
+		const location = path.join(__dirname, 'fixtures', 'reused-alias');
+		const result = await getRootPackageJson(location);
+
+		expect(() => new Graph(location, result.json, require)).toThrow(
+			new Error('Cannot add alias "leaf" for spinach because it is already used for lettuce.')
+		);
+	});
 });

--- a/modules/graph/src/Graph.ts
+++ b/modules/graph/src/Graph.ts
@@ -272,6 +272,13 @@ export class Graph {
 		const workspace = new Workspace(this.#rootLocation, location, packageJson, this.#require);
 		this.#byName.set(workspace.name, workspace);
 		workspace.aliases.forEach((alias) => {
+			if (this.#nameByAlias.has(alias)) {
+				throw new Error(
+					`Cannot add alias "${alias}" for ${workspace.name} because it is already used for ${this.#nameByAlias.get(
+						alias
+					)}.`
+				);
+			}
 			this.#nameByAlias.set(alias, workspace.name);
 		});
 		this.#nameByLocation.set(location, workspace.name);

--- a/modules/graph/src/fixtures/reused-alias/modules/lettuce/package.json
+++ b/modules/graph/src/fixtures/reused-alias/modules/lettuce/package.json
@@ -1,0 +1,7 @@
+{
+	"name": "lettuce",
+	"alias": [
+		"leaf"
+	],
+	"version": "4.5.2"
+}

--- a/modules/graph/src/fixtures/reused-alias/modules/spinach/package.json
+++ b/modules/graph/src/fixtures/reused-alias/modules/spinach/package.json
@@ -1,0 +1,10 @@
+{
+	"name": "spinach",
+	"alias": [
+		"leaf"
+	],
+	"version": "1.2.3",
+	"dependencies": {
+		"fixture-lettuce": "4.5.2"
+	}
+}

--- a/modules/graph/src/fixtures/reused-alias/package.json
+++ b/modules/graph/src/fixtures/reused-alias/package.json
@@ -1,0 +1,8 @@
+{
+	"name": "fixture-root",
+	"private": true,
+	"type": "module",
+	"workspaces": [
+		"modules/*"
+	]
+}


### PR DESCRIPTION
Fixes #147