### PR TITLE
fix(core): graph verify more clearly indicates file errors

### DIFF
--- a/.changeset/eight-lies-dress.md
+++ b/.changeset/eight-lies-dress.md
@@ -1,0 +1,6 @@
+---
+'@onerepo/core': patch
+'onerepo': patch
+---
+
+Error output from `graph verify` against schema will more clearly explain which file(s) include which error(s).

--- a/config/graph-schema.ts
+++ b/config/graph-schema.ts
@@ -132,19 +132,19 @@ export default {
 				repository: {
 					type: 'object',
 					properties: {
-						type: { type: 'string', pattern: '^git$', errorMessage: '`repository.type` must be `git`' },
+						type: { type: 'string', const: 'git', errorMessage: '"repository.type" must be "git"' },
 						url: {
 							type: 'string',
-							pattern: 'git://github.com/paularmstrong/onerepo.git',
-							errorMessage: 'Use the correct repository URL.',
+							const: 'git://github.com/paularmstrong/onerepo.git',
+							errorMessage: '"repository.url" must be "git://github.com/paularmstrong/onerepo.git".',
 						},
 					},
 					required: ['type', 'url'],
 				},
 				license: {
 					type: 'string',
-					pattern: '^MIT$',
-					errorMessage: 'License MUST be `MIT`',
+					const: 'MIT',
+					errorMessage: 'License MUST be "MIT"',
 				},
 				engines: {
 					type: 'object',

--- a/modules/core/src/core/graph/commands/__tests__/__fixtures__/bad-repo/apps/menu/package.json
+++ b/modules/core/src/core/graph/commands/__tests__/__fixtures__/bad-repo/apps/menu/package.json
@@ -1,0 +1,9 @@
+{
+	"name": "menu",
+	"private": true,
+	"main": "./src/index.ts",
+	"dependencies": {
+		"fixture-tacos": "workspace:^",
+		"tortillas": "1.2.1"
+	}
+}

--- a/modules/core/src/core/graph/commands/__tests__/__fixtures__/bad-repo/modules/burritos/package.json
+++ b/modules/core/src/core/graph/commands/__tests__/__fixtures__/bad-repo/modules/burritos/package.json
@@ -1,0 +1,5 @@
+{
+	"name": "fixture-burritos",
+	"version": "4.5.2",
+	"main": "./src/index.ts"
+}

--- a/modules/core/src/core/graph/commands/__tests__/__fixtures__/bad-repo/modules/tacos/package.json
+++ b/modules/core/src/core/graph/commands/__tests__/__fixtures__/bad-repo/modules/tacos/package.json
@@ -1,0 +1,8 @@
+{
+	"name": "fixture-tacos",
+	"version": "1.2.3",
+	"main": "./src/index.ts",
+	"dependencies": {
+		"tortillas": "^1.4.5"
+	}
+}

--- a/modules/core/src/core/graph/commands/__tests__/__fixtures__/bad-repo/package.json
+++ b/modules/core/src/core/graph/commands/__tests__/__fixtures__/bad-repo/package.json
@@ -1,0 +1,9 @@
+{
+	"name": "fixture-root",
+	"private": true,
+	"type": "commonjs",
+	"workspaces": [
+		"apps/*",
+		"modules/*"
+	]
+}

--- a/modules/core/src/core/graph/commands/__tests__/verify.test.ts
+++ b/modules/core/src/core/graph/commands/__tests__/verify.test.ts
@@ -6,9 +6,14 @@ import { getCommand } from '@onerepo/test-cli';
 const { run } = getCommand(Verify);
 
 describe('verify', () => {
-	test('can verify the graph', async () => {
-		const graph = getGraph(path.join(__dirname, '__fixtures__', 'repo'));
-		await expect(run('', { graph })).resolves.toBeUndefined();
+	test('can turn off graph dependency verification', async () => {
+		const graph = getGraph(path.join(__dirname, '__fixtures__', 'bad-repo'));
+		await expect(run('--dependencies off', { graph })).resolves.toBeUndefined();
+	});
+
+	test('can verify the graph dependencies', async () => {
+		const graph = getGraph(path.join(__dirname, '__fixtures__', 'bad-repo'));
+		await expect(run('--dependencies loose', { graph })).rejects.toBeUndefined();
 	});
 
 	test('can verify cjson (eg tsconfigs)', async () => {

--- a/modules/core/src/core/graph/index.ts
+++ b/modules/core/src/core/graph/index.ts
@@ -8,6 +8,7 @@ import * as Verify from './commands/verify';
 export type Options = {
 	name?: string | Array<string>;
 	customSchema?: string;
+	dependencies?: 'loose' | 'off';
 };
 
 export function graph(opts: Options = {}): Plugin {
@@ -23,12 +24,23 @@ export function graph(opts: Options = {}): Plugin {
 					const y = yargs
 						.usage(`$0 ${Array.isArray(name) ? name[0] : name} <command>`)
 						.command(show.command, show.description, show.builder, show.handler)
-						.command(verify.command, verify.description, verify.builder, verify.handler)
+						.command(
+							verify.command,
+							verify.description,
+							(yargs) => {
+								const y = verify.builder(yargs);
+								if (opts.customSchema) {
+									y.default('custom-schema', opts.customSchema);
+								}
+								if (opts.dependencies) {
+									y.default('dependencies', opts.dependencies);
+								}
+								return y;
+							},
+							verify.handler
+						)
 						.demandCommand(1);
 
-					if (opts.customSchema) {
-						y.default('custom-schema', opts.customSchema);
-					}
 					return y;
 				},
 				noop


### PR DESCRIPTION
**Problem:** The output of the `graph verify` command is not clear for what file is throwing each error

**Solution:** Make it clearer.