### PR TITLE
fix(core): graph verify to check dev and peer dependencies

### DIFF
--- a/.changeset/lovely-seas-smile.md
+++ b/.changeset/lovely-seas-smile.md
@@ -1,0 +1,6 @@
+---
+'@onerepo/core': patch
+'onerepo': patch
+---
+
+Ensures that `devDependencies` and `peerDependencies` are checked for semantic version intersections when running `graph verify`.

--- a/internal/eslint-plugin/src/index.cjs
+++ b/internal/eslint-plugin/src/index.cjs
@@ -2,7 +2,6 @@
 module.exports = {
 	configs: {
 		base: {
-			// parser: '@typescript-eslint/parser',
 			parserOptions: {
 				ecmaVersion: 'latest',
 				sourceType: 'module',

--- a/modules/core/src/core/graph/commands/__tests__/__fixtures__/bad-repo-dev/apps/menu/package.json
+++ b/modules/core/src/core/graph/commands/__tests__/__fixtures__/bad-repo-dev/apps/menu/package.json
@@ -1,0 +1,9 @@
+{
+	"name": "menu",
+	"private": true,
+	"main": "./src/index.ts",
+	"dependencies": {
+		"fixture-tacos": "workspace:^",
+		"tortillas": "1.2.1"
+	}
+}

--- a/modules/core/src/core/graph/commands/__tests__/__fixtures__/bad-repo-dev/modules/burritos/package.json
+++ b/modules/core/src/core/graph/commands/__tests__/__fixtures__/bad-repo-dev/modules/burritos/package.json
@@ -1,0 +1,5 @@
+{
+	"name": "fixture-burritos",
+	"version": "4.5.2",
+	"main": "./src/index.ts"
+}

--- a/modules/core/src/core/graph/commands/__tests__/__fixtures__/bad-repo-dev/modules/tacos/package.json
+++ b/modules/core/src/core/graph/commands/__tests__/__fixtures__/bad-repo-dev/modules/tacos/package.json
@@ -1,0 +1,8 @@
+{
+	"name": "fixture-tacos",
+	"version": "1.2.3",
+	"main": "./src/index.ts",
+	"devDependencies": {
+		"tortillas": "^1.4.5"
+	}
+}

--- a/modules/core/src/core/graph/commands/__tests__/__fixtures__/bad-repo-dev/package.json
+++ b/modules/core/src/core/graph/commands/__tests__/__fixtures__/bad-repo-dev/package.json
@@ -1,0 +1,9 @@
+{
+	"name": "fixture-root",
+	"private": true,
+	"type": "commonjs",
+	"workspaces": [
+		"apps/*",
+		"modules/*"
+	]
+}

--- a/modules/core/src/core/graph/commands/__tests__/verify.test.ts
+++ b/modules/core/src/core/graph/commands/__tests__/verify.test.ts
@@ -12,8 +12,11 @@ describe('verify', () => {
 	});
 
 	test('can verify the graph dependencies', async () => {
-		const graph = getGraph(path.join(__dirname, '__fixtures__', 'bad-repo'));
-		await expect(run('--dependencies loose', { graph })).rejects.toBeUndefined();
+		const graphProd = getGraph(path.join(__dirname, '__fixtures__', 'bad-repo'));
+		await expect(run('--dependencies loose', { graph: graphProd })).rejects.toBeUndefined();
+
+		const graphDev = getGraph(path.join(__dirname, '__fixtures__', 'bad-repo-dev'));
+		await expect(run('--dependencies loose', { graph: graphDev })).rejects.toBeUndefined();
 	});
 
 	test('can verify cjson (eg tsconfigs)', async () => {

--- a/modules/graph/src/Graph.ts
+++ b/modules/graph/src/Graph.ts
@@ -306,17 +306,23 @@ export class Graph {
 		for (const [dependency, version] of Object.entries(dependencies)) {
 			if (this.#byName.has(dependency)) {
 				if (!version.startsWith('workspace:') && version !== this.#byName.get(dependency)!.version) {
-					throw new Error(`${dependent} does not use source version of ${dependency}`);
+					// While it is not _recommended_ to use non-source versions, it is still possible and allowed – edges just won't be created here.
+					// `graph verify` will throw an error here, unless dependency verification is turned off.
+					continue;
 				}
 
 				this.#graph.addEdge(dependent, dependency, weight);
 				if (this.#graph.hasCycle()) {
-					throw new Error(`Cycle found between ${dependent} and ${dependency}`);
+					throw new Error(
+						`Cyclical dependencies are not allowed. Please correct the cycle between ${dependent} and ${dependency}`
+					);
 				}
 
 				this.#inverted.addEdge(dependency, dependent, weight);
 				if (this.#inverted.hasCycle()) {
-					throw new Error(`Cycle found between ${dependent} and ${dependency}`);
+					throw new Error(
+						`Cyclical dependencies are not allowed. Please correct the cycle between ${dependent} and ${dependency}`
+					);
 				}
 			}
 		}

--- a/modules/yargs/package.json
+++ b/modules/yargs/package.json
@@ -26,7 +26,8 @@
 	},
 	"devDependencies": {
 		"@internal/test-config": "workspace:^",
-		"@internal/tsconfig": "workspace:^"
+		"@internal/tsconfig": "workspace:^",
+		"@types/yargs": "^17"
 	},
 	"engines": {
 		"node": ">= 16.0.0 < 17 > 18.0.0 < 19"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3070,6 +3070,7 @@ __metadata:
     "@onerepo/builders": 0.1.1
     "@onerepo/logger": 0.1.1
     "@onerepo/subprocess": 0.2.1
+    "@types/yargs": ^17
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
**Problem:** Errors were not being thrown when running `graph verify` and `dev` and `peer` dependencies were mismatched.

**Solution:** Ensure we include dev and peer dependencies in verification checks. Makes errors logged clearer to indicate _which_ workspace caught the error.