### PR TITLE
fix(package-manager): publishable check to resist errors

### DIFF
--- a/.changeset/shiny-pets-run.md
+++ b/.changeset/shiny-pets-run.md
@@ -1,0 +1,6 @@
+---
+'@onerepo/package-manager': patch
+'@onerepo/plugin-changesets': patch
+---
+
+More accurately determines the list of publishable workspaces.

--- a/modules/package-manager/src/__tests__/npm.test.ts
+++ b/modules/package-manager/src/__tests__/npm.test.ts
@@ -195,7 +195,7 @@ describe('NPM', () => {
 					calls.map(({ args }) => {
 						const versions: Array<string> = [];
 						if (args?.includes('tacos')) {
-							versions.push('1.2.3', '1.2.4');
+							versions.push('1.2.3', '1.2.5');
 						} else if (args?.includes('burritos')) {
 							return new Error('i do not know');
 						}
@@ -210,7 +210,7 @@ describe('NPM', () => {
 				{ name: 'burritos', version: '4.5.6' },
 			]);
 
-			expect(publishable).toEqual([{ name: 'tacos', version: '1.2.5' }]);
+			expect(publishable).toEqual([{ name: 'burritos', version: '4.5.6' }]);
 		});
 	});
 

--- a/modules/package-manager/src/__tests__/pnpm.test.ts
+++ b/modules/package-manager/src/__tests__/pnpm.test.ts
@@ -195,7 +195,7 @@ describe('NPM', () => {
 					calls.map(({ args }) => {
 						const versions: Array<string> = [];
 						if (args?.includes('tacos')) {
-							versions.push('1.2.3', '1.2.4');
+							versions.push('1.2.3', '1.2.5');
 						} else if (args?.includes('burritos')) {
 							return new Error('i do not know');
 						}
@@ -210,7 +210,7 @@ describe('NPM', () => {
 				{ name: 'burritos', version: '4.5.6' },
 			]);
 
-			expect(publishable).toEqual([{ name: 'tacos', version: '1.2.5' }]);
+			expect(publishable).toEqual([{ name: 'burritos', version: '4.5.6' }]);
 		});
 	});
 

--- a/modules/package-manager/src/__tests__/yarn.test.ts
+++ b/modules/package-manager/src/__tests__/yarn.test.ts
@@ -160,17 +160,21 @@ describe('NPM', () => {
 
 	describe('publishable', () => {
 		test('filters workspaces by the ones with a version not in the registry', async () => {
-			jest.spyOn(subprocess, 'run').mockRejectedValue(new Error('foo'));
+			jest.spyOn(subprocess, 'run').mockRejectedValue([
+				`{"name":"tacos","versions":["1.2.5"]}
+{"type":"error","name":35,"displayName":"YN0035","indent":"","data":"The remote server failed to provide the requested resource"}
+{"type":"error","name":35,"displayName":"YN0035","indent":"","data":"Response Code\\u001b[39m: \\u001b]8;;https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404\\u0007\\u001b[38;2;255;215;0m404\\u001b[39m (Not Found)\\u001b]8;;\\u0007"}
+{"type":"error","name":35,"displayName":"YN0035","indent":"","data":"  \\u001b[38;2;135;175;255mRequest Method\\u001b[39m: GET"}
+{"type":"error","name":35,"displayName":"YN0035","indent":"","data":"  \\u001b[38;2;135;175;255mRequest URL\\u001b[39m: \\u001b[38;2;215;95;215mhttps://registry.yarnpkg.com/burritos\\u001b[39m"}`,
+				'',
+			]);
 
 			const publishable = await manager.publishable([
 				{ name: 'tacos', version: '1.2.5' },
 				{ name: 'burritos', version: '4.5.6' },
 			]);
 
-			expect(publishable).toEqual([
-				{ name: 'tacos', version: '1.2.5' },
-				{ name: 'burritos', version: '4.5.6' },
-			]);
+			expect(publishable).toEqual([{ name: 'burritos', version: '4.5.6' }]);
 		});
 	});
 

--- a/modules/package-manager/src/npm.ts
+++ b/modules/package-manager/src/npm.ts
@@ -56,6 +56,8 @@ export const Npm = {
 	publishable: async <T extends MinimalWorkspace>(workspaces: Array<T>) => {
 		const filtered = workspaces.filter((ws) => !ws.private && ws.version);
 
+		const publishable = new Set<T>(filtered);
+
 		const responses = await batch(
 			filtered.map(({ name }) => ({
 				name: `Get ${name} versions`,
@@ -65,16 +67,14 @@ export const Npm = {
 			}))
 		);
 
-		const publishable = new Set<T>();
-
 		for (const res of responses) {
 			if (res instanceof Error || res[1]) {
 				continue;
 			}
 			const { name, versions } = JSON.parse(res[0]);
 			const ws = workspaces.find((ws) => ws.name === name);
-			if (ws && ws.version && !versions.includes(ws.version)) {
-				publishable.add(ws);
+			if (ws && ws.version && versions.includes(ws.version)) {
+				publishable.delete(ws);
 			}
 		}
 

--- a/modules/package-manager/src/pnpm.ts
+++ b/modules/package-manager/src/pnpm.ts
@@ -56,6 +56,7 @@ export const Pnpm = {
 
 	publishable: async <T extends MinimalWorkspace>(workspaces: Array<T>) => {
 		const filtered = workspaces.filter((ws) => !ws.private && ws.version);
+		const publishable = new Set<T>(filtered);
 
 		const responses = await batch(
 			filtered.map(({ name }) => ({
@@ -66,16 +67,14 @@ export const Pnpm = {
 			}))
 		);
 
-		const publishable = new Set<T>();
-
 		for (const res of responses) {
 			if (res instanceof Error || res[1]) {
 				continue;
 			}
 			const { name, versions } = JSON.parse(res[0]);
 			const ws = workspaces.find((ws) => ws.name === name);
-			if (ws && ws.version && !versions.includes(ws.version)) {
-				publishable.add(ws);
+			if (ws && ws.version && versions.includes(ws.version)) {
+				publishable.delete(ws);
 			}
 		}
 


### PR DESCRIPTION
This should more accurately determine what needs to be published by selecting all workspaces, then removing those that have been published, instead of building up a set individually from the responses.