### PR TITLE
fix(changsets): filter versioning dependencies to prod-only

### DIFF
--- a/.changeset/sharp-paws-switch.md
+++ b/.changeset/sharp-paws-switch.md
@@ -1,0 +1,11 @@
+---
+'@onerepo/graph': minor
+---
+
+Adds dependency and dependent filtering option with `DependencyType` enum.
+
+Example: grab only production dependent workspaces:
+
+```ts
+graph.dependents(myWorkspace, true, DependencyType.PROD);
+```

--- a/.changeset/yellow-bees-suffer.md
+++ b/.changeset/yellow-bees-suffer.md
@@ -1,0 +1,5 @@
+---
+'@onerepo/plugin-changesets': patch
+---
+
+When versioning packages, only production dependencies will be versioned, even if dev dependencies have changes. This should be safe because `devDependencies` are explicitly stripped out during publish.

--- a/modules/graph/src/__tests__/Graph.test.ts
+++ b/modules/graph/src/__tests__/Graph.test.ts
@@ -1,20 +1,15 @@
 import path from 'path';
 import { getRootPackageJson } from '..';
-import { Graph } from '../Graph';
+import { DependencyType, Graph } from '../Graph';
 
 describe('Graph', () => {
 	test('bucket', async () => {
 		const location = path.join(__dirname, '__fixtures__', 'repo');
 		const result = await getRootPackageJson(location);
 		const repo = new Graph(location, result.json, result.json.workspaces!, require);
-		expect(repo.dependencies('fixture-burritos').map(({ name }) => name)).toEqual(['fixture-lettuce']);
-		expect(repo.dependencies('fixture-lettuce')).toEqual([]);
-		expect(repo.dependencies().map(({ name }) => name)).toEqual([
-			'fixture-tacos',
-			'fixture-burritos',
-			'fixture-lettuce',
-			'fixture-root',
-		]);
+		expect(repo.dependencies('burritos').map(({ name }) => name)).toEqual(['lettuce']);
+		expect(repo.dependencies('lettuce')).toEqual([]);
+		expect(repo.dependencies().map(({ name }) => name)).toEqual(['tacos', 'burritos', 'lettuce', 'fixture-root']);
 	});
 
 	test('cannot reuse an alias', async () => {
@@ -24,5 +19,114 @@ describe('Graph', () => {
 		expect(() => new Graph(location, result.json, result.json.workspaces!, require)).toThrow(
 			new Error('Cannot add alias "leaf" for spinach because it is already used for lettuce.')
 		);
+	});
+
+	test('can get all dependencies', async () => {
+		const location = path.join(__dirname, '__fixtures__', 'repo');
+		const result = await getRootPackageJson(location);
+		const repo = new Graph(location, result.json, result.json.workspaces!, require);
+
+		expect(repo.dependencies()).toEqual([
+			expect.objectContaining({ name: 'tacos' }),
+			expect.objectContaining({ name: 'burritos' }),
+			expect.objectContaining({ name: 'lettuce' }),
+			expect.objectContaining({ name: 'fixture-root' }),
+		]);
+	});
+
+	test('can get isolated dependencies', async () => {
+		const location = path.join(__dirname, '__fixtures__', 'repo');
+		const result = await getRootPackageJson(location);
+		const repo = new Graph(location, result.json, result.json.workspaces!, require);
+
+		expect(repo.dependencies('tacos')).toEqual([expect.objectContaining({ name: 'lettuce' })]);
+	});
+
+	test('can get all dependents', async () => {
+		const location = path.join(__dirname, '__fixtures__', 'repo');
+		const result = await getRootPackageJson(location);
+		const repo = new Graph(location, result.json, result.json.workspaces!, require);
+
+		expect(repo.dependents()).toEqual([
+			expect.objectContaining({ name: 'lettuce' }),
+			expect.objectContaining({ name: 'tacos' }),
+			expect.objectContaining({ name: 'burritos' }),
+			expect.objectContaining({ name: 'fixture-root' }),
+		]);
+	});
+
+	test('can get isolated dependents', async () => {
+		const location = path.join(__dirname, '__fixtures__', 'repo');
+		const result = await getRootPackageJson(location);
+		const repo = new Graph(location, result.json, result.json.workspaces!, require);
+
+		expect(repo.dependents('lettuce')).toEqual([
+			expect.objectContaining({ name: 'tacos' }),
+			expect.objectContaining({ name: 'burritos' }),
+		]);
+	});
+
+	test('can get all prod dependencies', async () => {
+		const location = path.join(__dirname, '__fixtures__', 'repo');
+		const result = await getRootPackageJson(location);
+		const repo = new Graph(location, result.json, result.json.workspaces!, require);
+
+		expect(repo.dependencies(undefined, true, DependencyType.DEV).map((w) => w.name)).toEqual([
+			'tacos',
+			'lettuce',
+			'burritos',
+			'fixture-root',
+		]);
+	});
+
+	test('can get prod-only isolated dependencies', async () => {
+		const location = path.join(__dirname, '__fixtures__', 'repo');
+		const result = await getRootPackageJson(location);
+		const repo = new Graph(location, result.json, result.json.workspaces!, require);
+
+		expect(repo.dependencies('tacos', true, DependencyType.PROD).map((w) => w.name)).toEqual(['tacos']);
+		expect(repo.dependencies('burritos', true, DependencyType.PROD).map((w) => w.name)).toEqual([
+			'burritos',
+			'lettuce',
+		]);
+	});
+
+	test('can get prod-only isolated dependents', async () => {
+		const location = path.join(__dirname, '__fixtures__', 'repo');
+		const result = await getRootPackageJson(location);
+		const repo = new Graph(location, result.json, result.json.workspaces!, require);
+
+		expect(repo.dependents('lettuce', true, DependencyType.PROD).map((w) => w.name)).toEqual(['lettuce', 'burritos']);
+	});
+
+	test('can get all dev dependencies', async () => {
+		const location = path.join(__dirname, '__fixtures__', 'repo');
+		const result = await getRootPackageJson(location);
+		const repo = new Graph(location, result.json, result.json.workspaces!, require);
+
+		expect(repo.dependencies(undefined, true, DependencyType.DEV).map((w) => w.name)).toEqual([
+			'tacos',
+			'lettuce',
+			'burritos',
+			'fixture-root',
+		]);
+	});
+
+	test('can get dev-only isolated dependencies', async () => {
+		const location = path.join(__dirname, '__fixtures__', 'repo');
+		const result = await getRootPackageJson(location);
+		const repo = new Graph(location, result.json, result.json.workspaces!, require);
+
+		expect(repo.dependencies('burritos', true, DependencyType.DEV).map((w) => w.name)).toEqual(['burritos']);
+		expect(repo.dependencies('tacos', true, DependencyType.DEV).map((w) => w.name)).toEqual(['tacos', 'lettuce']);
+	});
+
+	test('can get dev-only isolated dependents', async () => {
+		const location = path.join(__dirname, '__fixtures__', 'repo');
+		const result = await getRootPackageJson(location);
+		const repo = new Graph(location, result.json, result.json.workspaces!, require);
+
+		expect(repo.dependents('burritos', true, DependencyType.DEV).map((w) => w.name)).toEqual(['burritos']);
+		expect(repo.dependents('lettuce', true, DependencyType.DEV).map((w) => w.name)).toEqual(['lettuce', 'tacos']);
 	});
 });

--- a/modules/graph/src/__tests__/__fixtures__/repo/modules/burritos/package.json
+++ b/modules/graph/src/__tests__/__fixtures__/repo/modules/burritos/package.json
@@ -1,7 +1,7 @@
 {
-	"name": "fixture-burritos",
+	"name": "burritos",
 	"version": "4.5.2",
 	"dependencies": {
-		"fixture-lettuce": "4.5.2"
+		"lettuce": "4.5.2"
 	}
 }

--- a/modules/graph/src/__tests__/__fixtures__/repo/modules/lettuce/package.json
+++ b/modules/graph/src/__tests__/__fixtures__/repo/modules/lettuce/package.json
@@ -1,4 +1,4 @@
 {
-	"name": "fixture-lettuce",
+	"name": "lettuce",
 	"version": "4.5.2"
 }

--- a/modules/graph/src/__tests__/__fixtures__/repo/modules/tacos/package.json
+++ b/modules/graph/src/__tests__/__fixtures__/repo/modules/tacos/package.json
@@ -1,7 +1,7 @@
 {
-	"name": "fixture-tacos",
+	"name": "tacos",
 	"version": "1.2.3",
-	"dependencies": {
-		"fixture-lettuce": "4.5.2"
+	"devDependencies": {
+		"lettuce": "4.5.2"
 	}
 }

--- a/plugins/changesets/README.md
+++ b/plugins/changesets/README.md
@@ -81,3 +81,9 @@ This causes issues when publishing shared modules for use outside of the monorep
 This plugin will trigger the [core `tasks`](https://onerepo.tools/docs/core/tasks/) `build` lifecycle for every workspace during pre-release and publish. There is no need to manually run a build before publishing.
 
 </aside>
+
+## Caveats
+
+- When publishing, `devDependencies` are explicitly stripped from the `package.json`. This is a safety mechanism to ensure that dependencies are not mis-identified.
+
+  To help prevent errors before publishing, it is recommended to include the [ESLint plugin](/docs/plugins/eslint/) with [eslint-plugin-import](https://github.com/import-js/eslint-plugin-import/blob/main/README.md) and the rule [`import/no-extraneous-dependencies`](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-extraneous-dependencies.md)

--- a/plugins/changesets/src/commands/__tests__/__fixtures__/repo/.changeset/guh-gaz-gop.md
+++ b/plugins/changesets/src/commands/__tests__/__fixtures__/repo/.changeset/guh-gaz-gop.md
@@ -1,0 +1,5 @@
+---
+tacos: minor
+---
+
+Minor bump in churros

--- a/plugins/changesets/src/commands/__tests__/__fixtures__/repo/modules/tacos/package.json
+++ b/plugins/changesets/src/commands/__tests__/__fixtures__/repo/modules/tacos/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "tacos",
 	"version": "0.2.0",
-	"dependencies": {
+	"devDependencies": {
 		"tortillas": "0.4.5"
 	}
 }

--- a/plugins/changesets/src/commands/__tests__/__fixtures__/repo/modules/tortas/package.json
+++ b/plugins/changesets/src/commands/__tests__/__fixtures__/repo/modules/tortas/package.json
@@ -1,0 +1,4 @@
+{
+	"name": "tortas",
+	"version": "0.2.0"
+}

--- a/plugins/changesets/src/commands/__tests__/prerelease.test.ts
+++ b/plugins/changesets/src/commands/__tests__/prerelease.test.ts
@@ -79,7 +79,7 @@ describe('handler', () => {
 		expect(subprocess.run).toHaveBeenCalledWith(
 			expect.objectContaining({
 				cmd: process.argv[1],
-				args: ['tasks', '-c', 'build', '--no-affected', '-w', 'burritos', 'churros', 'tacos', 'tortillas'],
+				args: ['tasks', '-c', 'build', '--no-affected', '-w', 'burritos', 'churros', 'tacos', 'tortas', 'tortillas'],
 			})
 		);
 
@@ -90,6 +90,7 @@ describe('handler', () => {
 					expect.objectContaining({ name: 'burritos', newVersion: '0.0.0-pre.123456' }),
 					expect.objectContaining({ name: 'churros', newVersion: '0.0.0-pre.123456' }),
 					expect.objectContaining({ name: 'tacos', newVersion: '0.0.0-pre.123456' }),
+					expect.objectContaining({ name: 'tortas', newVersion: '0.0.0-pre.123456' }),
 					expect.objectContaining({ name: 'tortillas', newVersion: '0.0.0-pre.123456' }),
 				],
 				preState: undefined,
@@ -106,6 +107,7 @@ describe('handler', () => {
 				expect.objectContaining({ name: 'burritos' }),
 				expect.objectContaining({ name: 'churros' }),
 				expect.objectContaining({ name: 'tacos' }),
+				expect.objectContaining({ name: 'tortas' }),
 				expect.objectContaining({ name: 'tortillas' }),
 			],
 		});

--- a/plugins/changesets/src/commands/__tests__/publish.test.ts
+++ b/plugins/changesets/src/commands/__tests__/publish.test.ts
@@ -95,7 +95,7 @@ describe('handler', () => {
 		expect(subprocess.run).toHaveBeenCalledWith(
 			expect.objectContaining({
 				cmd: process.argv[1],
-				args: ['tasks', '-c', 'build', '--no-affected', '-w', 'burritos', 'churros', 'tacos', 'tortillas'],
+				args: ['tasks', '-c', 'build', '--no-affected', '-w', 'burritos', 'churros', 'tacos', 'tortas', 'tortillas'],
 			})
 		);
 

--- a/plugins/changesets/src/commands/version.ts
+++ b/plugins/changesets/src/commands/version.ts
@@ -9,6 +9,7 @@ import type { Package, Packages } from '@manypkg/get-packages';
 import type { Builder, Handler } from '@onerepo/yargs';
 import type { LogStep } from '@onerepo/logger';
 import type { NewChangeset } from '@changesets/types';
+import { DependencyType } from '@onerepo/graph';
 
 // Changesets does not properly document its ESM exports in package.json, so this gets funky
 const assembleReleasePlan = (
@@ -102,7 +103,7 @@ export const handler: Handler<Argv> = async (argv, { graph, logger }) => {
 	}
 
 	const choiceDependencies = graph
-		.dependencies(choices, true)
+		.dependencies(choices, true, DependencyType.PROD)
 		.filter((ws) => !ws.private)
 		.map(({ name }) => name);
 


### PR DESCRIPTION
**Problem:** When running `change version`, all dependencies, even `devDependencies` are being versioned and published. This is unexpected and unnecessary because `devDependencies` are explicitly filtered out of the `package.json` files when publishing.

**Solution:**
1. Add prod & dev graphs to the internal `Graph`
2. Add the ability to filter `dependents`, `dependencies`, `affected` and `isolatedGraph`s to the `DependencyType`
3. Filter dependencies during `change version` using the aforementioned filter abilities
4. Add tests
5. Add documentation caveats

Fixes #239