### PR TITLE
fix(file): apply substitutions in writeSafe as string literals

### DIFF
--- a/.changeset/odd-files-talk.md
+++ b/.changeset/odd-files-talk.md
@@ -1,0 +1,6 @@
+---
+'onerepo': patch
+'@onerepo/subprocess': patch
+---
+
+Subprocess `sudo` command will now respect `--dry-run` settings

--- a/.changeset/slimy-hornets-relate.md
+++ b/.changeset/slimy-hornets-relate.md
@@ -1,0 +1,6 @@
+---
+'@onerepo/core': patch
+'onerepo': patch
+---
+
+Running `install` multiple times will no longer break tab-completions.

--- a/.changeset/tasty-crabs-wave.md
+++ b/.changeset/tasty-crabs-wave.md
@@ -1,0 +1,6 @@
+---
+'@onerepo/file': patch
+'onerepo': patch
+---
+
+Does not apply regex substitues during `file.writeSafe` calls (will write out string literals for `$'`, `$\``, etc.)

--- a/modules/core/src/core/install/commands/install.ts
+++ b/modules/core/src/core/install/commands/install.ts
@@ -96,8 +96,6 @@ export const handler: Handler<Args> = async function handler(argv, { graph }) {
 
 	const installLocation = path.join(location!, name);
 
-	logger.warn(`Requesting sudo permissions in order to write to ${installLocation}. `);
-
 	await sudo({
 		name: 'Create executable',
 		cmd: 'echo',

--- a/modules/file/src/__tests__/index.test.ts
+++ b/modules/file/src/__tests__/index.test.ts
@@ -1,0 +1,116 @@
+import * as fsSync from 'node:fs';
+import * as fs from 'node:fs/promises';
+import * as file from '..';
+
+jest.mock('node:fs');
+jest.mock('node:fs/promises');
+jest.mock('..', () => ({
+	...jest.requireActual('..'),
+	__esModule: true,
+}));
+
+describe('file', () => {
+	describe('writeSafe', () => {
+		test('writes to file if it does not exist', async () => {
+			jest.spyOn(fsSync, 'existsSync').mockReturnValue(false);
+
+			await file.writeSafe('tacos.txt', 'add some contents');
+
+			expect(fs.readFile).not.toHaveBeenCalled();
+			expect(fs.writeFile).toHaveBeenCalledWith(
+				'tacos.txt',
+				`
+
+# start-onerepo-sentinel
+add some contents
+# end-onerepo-sentinel
+
+`
+			);
+		});
+
+		test('appends to a file contents when no sentinel is found', async () => {
+			jest.spyOn(fsSync, 'existsSync').mockReturnValue(true);
+			jest.spyOn(fs, 'readFile').mockResolvedValue('original contents');
+
+			await file.writeSafe('tacos.txt', 'add some contents');
+
+			expect(fs.writeFile).toHaveBeenCalledWith(
+				'tacos.txt',
+				`original contents
+
+# start-onerepo-sentinel
+add some contents
+# end-onerepo-sentinel
+
+`
+			);
+		});
+
+		test('replaces previous content', async () => {
+			jest.spyOn(fsSync, 'existsSync').mockReturnValue(true);
+			jest.spyOn(fs, 'readFile').mockResolvedValue(`original contents
+
+# start-onerepo-sentinel
+add some contents
+# end-onerepo-sentinel
+`);
+
+			await file.writeSafe('tacos.txt', 'this is new');
+
+			expect(fs.writeFile).toHaveBeenCalledWith(
+				'tacos.txt',
+				`original contents
+
+# start-onerepo-sentinel
+this is new
+# end-onerepo-sentinel
+`
+			);
+		});
+
+		test('escapes/avoids special substitutions', async () => {
+			jest.spyOn(fsSync, 'existsSync').mockReturnValue(true);
+			jest.spyOn(fs, 'readFile').mockResolvedValue(`original contents
+
+# start-onerepo-sentinel
+add some contents
+# end-onerepo-sentinel
+`);
+
+			await file.writeSafe('tacos.txt', "this is new $' $` $1 $$ $&");
+
+			expect(fs.writeFile).toHaveBeenCalledWith(
+				'tacos.txt',
+				`original contents
+
+# start-onerepo-sentinel
+this is new $' $\` $1 $$ $&
+# end-onerepo-sentinel
+`
+			);
+		});
+
+		test('can use a custom sentinel', async () => {
+			jest.spyOn(fsSync, 'existsSync').mockReturnValue(true);
+			jest.spyOn(fs, 'readFile').mockResolvedValue(`original contents
+
+# start-tacos
+add some contents
+# end-tacos
+`);
+
+			await file.writeSafe('tacos.txt', 'this is new', { sentinel: 'tacos' });
+
+			expect(fs.writeFile).toHaveBeenCalledWith(
+				'tacos.txt',
+				`original contents
+
+# start-tacos
+this is new
+# end-tacos
+`
+			);
+		});
+	});
+});

--- a/modules/file/src/index.ts
+++ b/modules/file/src/index.ts
@@ -212,7 +212,7 @@ export async function writeSafe(
 		const writeContent = `${start}\n${contents}\n${end}\n`;
 		const output =
 			matches && matches.length
-				? fileContents.replace(matches[1], writeContent)
+				? fileContents.replace(matches[1], () => writeContent)
 				: `${fileContents}\n\n${writeContent}\n`;
 
 		return await write(filename, output, { step });


### PR DESCRIPTION
**Problem:** Completions are breaking after running `one install` multiple times in a row

On first run:

```sh
_one_yargs_completions()
{
  local reply
  local si=$IFS
  IFS=$'
' reply=($(COMP_CWORD="$((CURRENT-1))" COMP_LINE="$BUFFER" COMP_POINT="$CURSOR" one --get-yargs-completions "${words[@]}"))
  IFS=$si
  _describe 'values' reply
}
```

On second run (see line 5)
```sh
_one_yargs_completions()
{
  local reply
  local si=$IFS
  IFS= # <- missing `$'` here!
' reply=($(COMP_CWORD="$((CURRENT-1))" COMP_LINE="$BUFFER" COMP_POINT="$CURSOR" one --get-yargs-completions "${words[@]}"))
  IFS=$si
  _describe 'values' reply
}
```

**Solution:** `file.writeSafe` using `replace` was not writing out string literals, so regex substitutions like `$'` were getting replaced and not written correctly. By passing a function to the second argument of `String.replace`, we can avoid default substitutions.