### PR TITLE
fix(logger): optimize stream buffer w/ max call stack

### DIFF
--- a/.changeset/chatty-ghosts-appear.md
+++ b/.changeset/chatty-ghosts-appear.md
@@ -1,0 +1,5 @@
+---
+'@onerepo/logger': patch
+---
+
+Prevents "maximum call stack exceeded" in logging when attempting to dim output through picocolors

--- a/modules/logger/src/__tests__/LogStep.test.ts
+++ b/modules/logger/src/__tests__/LogStep.test.ts
@@ -42,7 +42,7 @@ describe('LogStep', () => {
 		expect(out).toMatchInlineSnapshot(`
 		" ┌ tacos
 		 │ [36m[1mLOG[22m[39m hellooooo
-		 └ [32m✔ [39m[2m0ms[22m
+		 └ [32m✔[39m [2m0ms[22m
 		"
 	`);
 	});


### PR DESCRIPTION
**Problem:** When a subprocess has a lot of output drained at once, picocolors can wind up with a maximum call stack exceeded error:

```
> one lint -a
 ┌ Lint …
 └ ⠋
./node_modules/picocolors/picocolors.js:22
        let start = string.substring(0, index) + replace
                           ^

RangeError: Maximum call stack size exceeded
    at String.substring (<anonymous>)
    at replaceClose (./node_modules/picocolors/picocolors.js:22:21)
    at replaceClose (./node_modules/picocolors/picocolors.js:25:30)
    at replaceClose (./node_modules/picocolors/picocolors.js:25:30)
    at replaceClose (./node_modules/picocolors/picocolors.js:25:30)
    at replaceClose (./node_modules/picocolors/picocolors.js:25:30)
    at replaceClose (./node_modules/picocolors/picocolors.js:25:30)
    at replaceClose (./node_modules/picocolors/picocolors.js:25:30)
    at replaceClose (./node_modules/picocolors/picocolors.js:25:30)
    at replaceClose (./node_modules/picocolors/picocolors.js:25:30)
```

**Solution:**

Optimize the `LogStep#writeStream` method to first split and grab the last 3 lines before sending them off to picocolors for dimming. This reduces and limits the amount of work that picocolors will have to do.

Also moved some of the reused colored/styled strings to constants.