### PR TITLE
feat(prettier): clearer output on prettier errors

### DIFF
--- a/.changeset/tough-ducks-cheer.md
+++ b/.changeset/tough-ducks-cheer.md
@@ -1,0 +1,5 @@
+---
+'@onerepo/plugin-prettier': minor
+---
+
+Adds better formatting and context for prettier formatting errors when run with `--check`. Also includes GitHub annotations when run in GH Actions.

--- a/plugins/prettier/package.json
+++ b/plugins/prettier/package.json
@@ -22,6 +22,7 @@
 		"./CHANGELOG.md"
 	],
 	"dependencies": {
+		"@actions/core": "^1.10.0",
 		"@onerepo/builders": "0.2.2",
 		"@onerepo/file": "0.3.1",
 		"@onerepo/git": "0.2.2",

--- a/plugins/prettier/src/index.ts
+++ b/plugins/prettier/src/index.ts
@@ -15,7 +15,14 @@ import * as cmd from './commands/prettier';
  * ```
  */
 export type Options = {
+	/**
+	 * The name of the prettier command. You might change this to `'format'` or `['format', 'prettier']` to keep things more familiar for most developers.
+	 */
 	name?: string | Array<string>;
+	/**
+	 * When `true` or unset and run in GitHub Actions, any files failing format checks will be annotated with an error in the GitHub user interface.
+	 */
+	annotateGithub?: boolean;
 };
 
 /**
@@ -41,7 +48,10 @@ export function prettier(opts: Options = {}): Plugin {
 			return yargs.command(
 				name,
 				description,
-				(yargs) => builder(yargs).usage(`$0 ${Array.isArray(name) ? name[0] : name} [options]`),
+				(yargs) =>
+					builder(yargs)
+						.usage(`$0 ${Array.isArray(name) ? name[0] : name} [options]`)
+						.default('github-annotate', opts.annotateGithub ?? true),
 				handler
 			);
 		},

--- a/yarn.lock
+++ b/yarn.lock
@@ -3016,6 +3016,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@onerepo/plugin-prettier@workspace:plugins/prettier"
   dependencies:
+    "@actions/core": ^1.10.0
     "@internal/test-config": "workspace:^"
     "@internal/tsconfig": "workspace:^"
     "@onerepo/builders": 0.2.2


### PR DESCRIPTION
**Problem:** When prettier fails (with `--check`), just the list of files that fail formatting are listed with no other context.

**Solution:**
1. Add a clear error message with instructions on how to fix
2. In GitHub actions, annotate the files and include instructions on how to fix