### PR TITLE
feat(eslint): add github annotations

### DIFF
--- a/.changeset/gentle-knives-report.md
+++ b/.changeset/gentle-knives-report.md
@@ -1,0 +1,15 @@
+---
+'@onerepo/subprocess': patch
+---
+
+Ensures current environment variables are passed through to subprocesses (normally the default) when passing in extra custom environment variables.
+
+```ts
+await run({
+	// ...
+	opts: {
+		// The following will be merged with `...process.env`
+		env: { MY_ENV_VAR: 'true' },
+	},
+});
+```

--- a/.changeset/modern-squids-tell.md
+++ b/.changeset/modern-squids-tell.md
@@ -1,0 +1,5 @@
+---
+'@onerepo/plugin-eslint': minor
+---
+
+Adds GitHub formatting to ESLint default formatting output. Use `--no-github-annotate` to disable or configure via the plugin’s main config option `githubAnnotate: false`

--- a/.changeset/ninety-balloons-cry.md
+++ b/.changeset/ninety-balloons-cry.md
@@ -1,0 +1,5 @@
+---
+'@onerepo/plugin-prettier': patch
+---
+
+Fix config key: `annotateGithub` ➡️ `githubAnnotate`

--- a/modules/eslint-formatter/package.json
+++ b/modules/eslint-formatter/package.json
@@ -1,0 +1,36 @@
+{
+	"name": "eslint-formatter-onerepo",
+	"version": "0.0.0",
+	"license": "MIT",
+	"repository": {
+		"type": "git",
+		"url": "git://github.com/paularmstrong/onerepo.git"
+	},
+	"homepage": "https://onerepo.tools",
+	"type": "commonjs",
+	"main": "./src/index.js",
+	"publishConfig": {
+		"access": "public",
+		"main": "./dist/index.js",
+		"typings": "./dist/src/index.d.ts"
+	},
+	"files": [
+		"./dist/**/*",
+		"./README.md",
+		"./CHANGELOG.md"
+	],
+	"dependencies": {
+		"@actions/core": "^1.10.0"
+	},
+	"devDependencies": {
+		"@internal/test-config": "workspace:^",
+		"@internal/tsconfig": "workspace:^",
+		"eslint": "^8.38.0"
+	},
+	"peerDependencies": {
+		"eslint": "^8"
+	},
+	"engines": {
+		"node": "^18.0.0"
+	}
+}

--- a/modules/eslint-formatter/src/index.js
+++ b/modules/eslint-formatter/src/index.js
@@ -1,0 +1,30 @@
+const gh = require('@actions/core');
+const { ESLint } = require('eslint');
+
+/**
+ * @type {import('eslint').ESLint.Formatter}
+ */
+const formatter = {
+	format: async function (results, context) {
+		const eslint = new ESLint();
+		const { format } = await eslint.loadFormatter('stylish');
+
+		if (process.env.GITHUB_RUN_ID && process.env.ONEREPO_ESLINT_GITHUB_ANNOTATE === 'true') {
+			results.forEach((file) => {
+				file.messages.forEach((msg) => {
+					const data = { file: file.filePath, startLine: msg.line, startColumn: msg.column };
+					const message = `${msg.message} (${msg.ruleId})`;
+					if (msg.severity === 2) {
+						gh.error(message, data);
+					} else if (msg.severity === 1) {
+						gh.warning(message, data);
+					}
+				});
+			});
+		}
+
+		return format(results, context);
+	},
+};
+
+module.exports = formatter.format;

--- a/modules/eslint-formatter/tsconfig.build.json
+++ b/modules/eslint-formatter/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"outDir": "./dist/",
+		"composite": true
+	},
+	"include": ["./src"],
+	"exclude": ["./**/*.test.ts", "./**/__tests__/*"]
+}

--- a/modules/eslint-formatter/tsconfig.json
+++ b/modules/eslint-formatter/tsconfig.json
@@ -1,0 +1,8 @@
+{
+	"extends": "@internal/tsconfig/base.json",
+	"compilerOptions": {
+		"outDir": "./dist/",
+		"composite": true
+	},
+	"include": ["./src"]
+}

--- a/modules/subprocess/src/index.ts
+++ b/modules/subprocess/src/index.ts
@@ -199,6 +199,7 @@ export function start(options: Omit<RunSpec, 'runDry' | 'name'>): ChildProcess {
 		cwd: process.env.ONE_REPO_ROOT ?? process.cwd(),
 		stdio: ['inherit', 'pipe', 'pipe'],
 		...opts,
+		env: { ...process.env, ...opts.env },
 	});
 
 	if (!subprocess) {

--- a/plugins/eslint/package.json
+++ b/plugins/eslint/package.json
@@ -27,6 +27,7 @@
 		"@onerepo/git": "0.2.2",
 		"@onerepo/logger": "0.2.1",
 		"@onerepo/subprocess": "0.3.1",
+		"eslint-formatter-onerepo": "0.0.0",
 		"minimatch": "^9.0.0"
 	},
 	"devDependencies": {

--- a/plugins/eslint/src/index.ts
+++ b/plugins/eslint/src/index.ts
@@ -27,6 +27,10 @@ export type Options = {
 	 * Control the ESLint setting default to suppress warnings and only report errors.
 	 */
 	quiet?: boolean;
+	/**
+	 * When `true` or unset and run in GitHub Actions, any files failing format checks will be annotated with an error in the GitHub user interface.
+	 */
+	githubAnnotate?: boolean;
 };
 
 /**
@@ -53,7 +57,9 @@ export function eslint(opts: Options = {}): Plugin {
 				opts.name ?? command,
 				description,
 				(yargs) => {
-					const y = builder(yargs).usage(`$0 ${Array.isArray(name) ? name[0] : name} [options]`);
+					const y = builder(yargs)
+						.usage(`$0 ${Array.isArray(name) ? name[0] : name} [options]`)
+						.default('github-annotate', opts.githubAnnotate ?? true);
 					if (opts.extensions) {
 						y.default('extensions', opts.extensions);
 					}

--- a/plugins/prettier/src/commands/prettier.ts
+++ b/plugins/prettier/src/commands/prettier.ts
@@ -15,6 +15,7 @@ export const description = 'Format files with prettier';
 type Args = {
 	add?: boolean;
 	check?: boolean;
+	'github-annotate': boolean;
 } & builders.WithAllInputs;
 
 export const builder: Builder<Args> = (yargs) =>
@@ -42,7 +43,7 @@ export const builder: Builder<Args> = (yargs) =>
 		});
 
 export const handler: Handler<Args> = async function handler(argv, { getFilepaths, graph }) {
-	const { add, all, check, 'dry-run': isDry, $0: cmd, _: positionals } = argv;
+	const { add, all, check, 'dry-run': isDry, 'github-annotate': github, $0: cmd, _: positionals } = argv;
 
 	const filteredPaths = [];
 	if (!all) {
@@ -101,7 +102,7 @@ To resolve the issue, run Prettier formatting and commit the resulting changes:
   $ ${cmd} ${positionals[0]}
 	`);
 
-		if (process.env.GITHUB_RUN_ID) {
+		if (process.env.GITHUB_RUN_ID && github) {
 			const msg = `This file needs formatting. Fix by running \`${cmd} ${positionals[0]}\``;
 			files.forEach((file) => core.error(msg, { file }));
 		}

--- a/plugins/prettier/src/index.ts
+++ b/plugins/prettier/src/index.ts
@@ -22,7 +22,7 @@ export type Options = {
 	/**
 	 * When `true` or unset and run in GitHub Actions, any files failing format checks will be annotated with an error in the GitHub user interface.
 	 */
-	annotateGithub?: boolean;
+	githubAnnotate?: boolean;
 };
 
 /**
@@ -51,7 +51,7 @@ export function prettier(opts: Options = {}): Plugin {
 				(yargs) =>
 					builder(yargs)
 						.usage(`$0 ${Array.isArray(name) ? name[0] : name} [options]`)
-						.default('github-annotate', opts.annotateGithub ?? true),
+						.default('github-annotate', opts.githubAnnotate ?? true),
 				handler
 			);
 		},

--- a/yarn.lock
+++ b/yarn.lock
@@ -2983,6 +2983,7 @@ __metadata:
     "@types/eslint": ^8.37.0
     esbuild-register: ^3.4.2
     eslint: ^8.38.0
+    eslint-formatter-onerepo: 0.0.0
     minimatch: ^9.0.0
     onerepo: "workspace:^"
     typescript: ^5.0.4
@@ -7372,6 +7373,19 @@ __metadata:
   checksum: 5aa6b2966fafe0545e4e77936300cc94ad57cfe4dc4ebff9950492eaba83eef634503f12d7e3cbd644ecc1bab388ad0e92b06fd32222c9281a75d1cf02ec6cef
   languageName: node
   linkType: hard
+
+"eslint-formatter-onerepo@0.0.0, eslint-formatter-onerepo@workspace:modules/eslint-formatter":
+  version: 0.0.0-use.local
+  resolution: "eslint-formatter-onerepo@workspace:modules/eslint-formatter"
+  dependencies:
+    "@actions/core": ^1.10.0
+    "@internal/test-config": "workspace:^"
+    "@internal/tsconfig": "workspace:^"
+    eslint: ^8.38.0
+  peerDependencies:
+    eslint: ^8
+  languageName: unknown
+  linkType: soft
 
 "eslint-import-resolver-node@npm:^0.3.7":
   version: 0.3.7


### PR DESCRIPTION
**Problem:** Reading GH action logs is hard, even with our nice output. Figuring out eslint errors could be easier.

**Solution:** Add file annotations via a custom formatter

<img width="969" alt="Screenshot 2023-06-28 at 16 02 07" src="https://github.com/paularmstrong/onerepo/assets/33297/11b2d4bc-e03b-4960-967b-d451ff3a0813">
