### PR TITLE
feat(core): enable functional schema validation

### DIFF
--- a/.changeset/rude-eggs-breathe.md
+++ b/.changeset/rude-eggs-breathe.md
@@ -1,0 +1,27 @@
+---
+'@onerepo/builders': patch
+'@onerepo/core': patch
+'@onerepo/create': patch
+'create-onerepo': patch
+'eslint-formatter-onerepo': patch
+'@onerepo/file': patch
+'@onerepo/git': patch
+'@onerepo/graph': patch
+'@onerepo/logger': patch
+'onerepo': patch
+'@onerepo/package-manager': patch
+'@onerepo/subprocess': patch
+'@onerepo/test-cli': patch
+'@onerepo/yargs': patch
+'@onerepo/plugin-changesets': patch
+'@onerepo/plugin-eslint': patch
+'@onerepo/plugin-jest': patch
+'@onerepo/plugin-prettier': patch
+'@onerepo/plugin-typescript': patch
+'@onerepo/plugin-vitest': patch
+'@onerepo/docs': patch
+'@onerepo/github-action': patch
+'@onerepo/root': patch
+---
+
+Adds `repository.directory` to `package.json` so CHANGELOGs are picked up properly by npm, renovate, etc.

--- a/.changeset/wicked-eggs-taste.md
+++ b/.changeset/wicked-eggs-taste.md
@@ -1,0 +1,29 @@
+---
+'@onerepo/core': minor
+---
+
+Allows custom schema validators for `graph verify` to be functions that return JSONSchema.
+
+As a function, the schema accepts two arguments, `workspace` and `graph`:
+
+```ts
+import type { graph } from 'onerepo';
+
+export default {
+	'**': {
+		'package.json': (workspace: graph.Workspace, graph: graph.Graph) => ({
+			type: 'object',
+			properties: {
+				repository: {
+					type: 'object',
+					properties: {
+						directory: { type: 'string', const: graph.root.relative(workspace.location) },
+					},
+					required: ['directory'],
+				},
+			},
+			required: ['repository'],
+		}),
+	},
+};
+```

--- a/config/graph-schema.ts
+++ b/config/graph-schema.ts
@@ -1,4 +1,5 @@
 import type { GraphSchemaValidators } from '@onerepo/core';
+import type { graph } from 'onerepo';
 
 export default {
 	'internal/*': {
@@ -82,7 +83,7 @@ export default {
 			},
 			required: ['extends', 'include', 'compilerOptions'],
 		},
-		'package.json': {
+		'package.json': (workspace: graph.Workspace, graph: graph.Graph) => ({
 			type: 'object',
 			properties: {
 				files: {
@@ -138,8 +139,14 @@ export default {
 							const: 'git://github.com/paularmstrong/onerepo.git',
 							errorMessage: '"repository.url" must be "git://github.com/paularmstrong/onerepo.git".',
 						},
+						directory: { type: 'string', const: graph.root.relative(workspace.location) },
 					},
-					required: ['type', 'url'],
+					required: ['type', 'url', 'directory'],
+					errorMessage: {
+						required: {
+							directory: `repository.directory equal "${graph.root.relative(workspace.location)}"`,
+						},
+					},
 				},
 				license: {
 					type: 'string',
@@ -159,7 +166,7 @@ export default {
 				},
 			},
 			required: ['files', 'publishConfig', 'homepage', 'repository', 'license', 'engines'],
-		},
+		}),
 		'jest.config.js': {
 			type: 'object',
 			properties: {

--- a/modules/builders/package.json
+++ b/modules/builders/package.json
@@ -4,7 +4,8 @@
 	"license": "MIT",
 	"repository": {
 		"type": "git",
-		"url": "git://github.com/paularmstrong/onerepo.git"
+		"url": "git://github.com/paularmstrong/onerepo.git",
+		"directory": "modules/builders"
 	},
 	"homepage": "https://onerepo.tools",
 	"type": "module",

--- a/modules/core/package.json
+++ b/modules/core/package.json
@@ -4,7 +4,8 @@
 	"license": "MIT",
 	"repository": {
 		"type": "git",
-		"url": "git://github.com/paularmstrong/onerepo.git"
+		"url": "git://github.com/paularmstrong/onerepo.git",
+		"directory": "modules/core"
 	},
 	"homepage": "https://onerepo.tools",
 	"type": "module",

--- a/modules/core/src/core/graph/README.md
+++ b/modules/core/src/core/graph/README.md
@@ -98,6 +98,32 @@ export default {
 } satisfies GraphSchemaValidators;
 ```
 
+### Functional schema
+
+There are cases where more information about a workspace is needed for the schema to be complete. For this, the schema may also be a function that accepts two arguments, `workspace` and `graph`:
+
+```ts
+import type { graph, GraphSchemaValidators } from 'onerepo';
+
+export default {
+	'**': {
+		'package.json': (workspace: graph.Workspace, graph: graph.Graph) => ({
+			type: 'object',
+			properties: {
+				repository: {
+					type: 'object',
+					properties: {
+						directory: { type: 'string', const: graph.root.relative(workspace.location) },
+					},
+					required: ['directory'],
+				},
+			},
+			required: ['repository'],
+		}),
+	},
+} satisfies GraphSchemaValidators;
+```
+
 ### Base schema
 
 oneRepo provides a base schema with some defaults for private & public `package.json` files. If the provided schema are not to your liking, you can override with the location glob `'**'`:

--- a/modules/core/src/core/graph/commands/__tests__/__fixtures__/functional-schema.ts
+++ b/modules/core/src/core/graph/commands/__tests__/__fixtures__/functional-schema.ts
@@ -1,0 +1,19 @@
+import type { graph, GraphSchemaValidators } from 'onerepo';
+
+export default {
+	'**': {
+		'package.json': (workspace: graph.Workspace, graph: graph.Graph) => ({
+			type: 'object',
+			properties: {
+				repository: {
+					type: 'object',
+					properties: {
+						directory: { type: 'string', const: graph.root.relative(workspace.location) },
+					},
+					required: ['directory'],
+				},
+			},
+			required: ['repository'],
+		}),
+	},
+} satisfies GraphSchemaValidators;

--- a/modules/core/src/core/graph/commands/__tests__/__fixtures__/repo/apps/menu/package.json
+++ b/modules/core/src/core/graph/commands/__tests__/__fixtures__/repo/apps/menu/package.json
@@ -4,5 +4,8 @@
 	"main": "./src/index.ts",
 	"dependencies": {
 		"fixture-tacos": "workspace:^"
+	},
+	"repository": {
+		"directory": "apps/menu"
 	}
 }

--- a/modules/core/src/core/graph/commands/__tests__/__fixtures__/repo/modules/burritos/package.json
+++ b/modules/core/src/core/graph/commands/__tests__/__fixtures__/repo/modules/burritos/package.json
@@ -1,5 +1,8 @@
 {
 	"name": "fixture-burritos",
 	"version": "4.5.2",
-	"main": "./src/index.ts"
+	"main": "./src/index.ts",
+	"repository": {
+		"directory": "modules/burritos"
+	}
 }

--- a/modules/core/src/core/graph/commands/__tests__/__fixtures__/repo/modules/tacos/package.json
+++ b/modules/core/src/core/graph/commands/__tests__/__fixtures__/repo/modules/tacos/package.json
@@ -1,5 +1,8 @@
 {
 	"name": "fixture-tacos",
 	"version": "1.2.3",
-	"main": "./src/index.ts"
+	"main": "./src/index.ts",
+	"repository": {
+		"directory": "modules/tacos"
+	}
 }

--- a/modules/core/src/core/graph/commands/__tests__/__fixtures__/repo/package.json
+++ b/modules/core/src/core/graph/commands/__tests__/__fixtures__/repo/package.json
@@ -2,6 +2,9 @@
 	"name": "fixture-root",
 	"private": true,
 	"type": "commonjs",
+	"repository": {
+		"directory": ""
+	},
 	"workspaces": [
 		"apps/*",
 		"modules/*"

--- a/modules/core/src/core/graph/commands/__tests__/verify.test.ts
+++ b/modules/core/src/core/graph/commands/__tests__/verify.test.ts
@@ -38,4 +38,17 @@ describe('verify', () => {
 		const schema = require.resolve('./__fixtures__/yaml-schema.ts');
 		await expect(run(`--custom-schema ${schema}`, { graph })).rejects.toEqual(new Error('must be equal to constant'));
 	});
+
+	test('can validate with functions', async () => {
+		const schema = require.resolve('./__fixtures__/functional-schema.ts');
+		const goodGraph = getGraph(path.join(__dirname, '__fixtures__', 'repo'));
+
+		await expect(run(`--custom-schema ${schema}`, { graph: goodGraph })).resolves.toBeUndefined();
+
+		const badGraph = getGraph(path.join(__dirname, '__fixtures__', 'bad-repo'));
+
+		await expect(run(`--custom-schema ${schema}`, { graph: badGraph })).rejects.toEqual(
+			new Error("must have required property 'repository'")
+		);
+	});
 });

--- a/modules/create-scoped/package.json
+++ b/modules/create-scoped/package.json
@@ -4,7 +4,8 @@
 	"license": "MIT",
 	"repository": {
 		"type": "git",
-		"url": "git://github.com/paularmstrong/onerepo.git"
+		"url": "git://github.com/paularmstrong/onerepo.git",
+		"directory": "modules/create-scoped"
 	},
 	"homepage": "https://onerepo.tools",
 	"type": "module",

--- a/modules/create/package.json
+++ b/modules/create/package.json
@@ -4,7 +4,8 @@
 	"license": "MIT",
 	"repository": {
 		"type": "git",
-		"url": "git://github.com/paularmstrong/onerepo.git"
+		"url": "git://github.com/paularmstrong/onerepo.git",
+		"directory": "modules/create"
 	},
 	"homepage": "https://onerepo.tools",
 	"type": "module",

--- a/modules/eslint-formatter/package.json
+++ b/modules/eslint-formatter/package.json
@@ -4,7 +4,8 @@
 	"license": "MIT",
 	"repository": {
 		"type": "git",
-		"url": "git://github.com/paularmstrong/onerepo.git"
+		"url": "git://github.com/paularmstrong/onerepo.git",
+		"directory": "modules/eslint-formatter"
 	},
 	"homepage": "https://onerepo.tools",
 	"type": "commonjs",

--- a/modules/file/package.json
+++ b/modules/file/package.json
@@ -4,7 +4,8 @@
 	"license": "MIT",
 	"repository": {
 		"type": "git",
-		"url": "git://github.com/paularmstrong/onerepo.git"
+		"url": "git://github.com/paularmstrong/onerepo.git",
+		"directory": "modules/file"
 	},
 	"homepage": "https://onerepo.tools",
 	"type": "module",

--- a/modules/git/package.json
+++ b/modules/git/package.json
@@ -4,7 +4,8 @@
 	"license": "MIT",
 	"repository": {
 		"type": "git",
-		"url": "git://github.com/paularmstrong/onerepo.git"
+		"url": "git://github.com/paularmstrong/onerepo.git",
+		"directory": "modules/git"
 	},
 	"homepage": "https://onerepo.tools",
 	"type": "module",

--- a/modules/github-action/package.json
+++ b/modules/github-action/package.json
@@ -4,7 +4,8 @@
 	"license": "MIT",
 	"repository": {
 		"type": "git",
-		"url": "git://github.com/paularmstrong/onerepo.git"
+		"url": "git://github.com/paularmstrong/onerepo.git",
+		"directory": "modules/github-action"
 	},
 	"homepage": "https://onerepo.tools",
 	"type": "module",

--- a/modules/graph/package.json
+++ b/modules/graph/package.json
@@ -4,7 +4,8 @@
 	"license": "MIT",
 	"repository": {
 		"type": "git",
-		"url": "git://github.com/paularmstrong/onerepo.git"
+		"url": "git://github.com/paularmstrong/onerepo.git",
+		"directory": "modules/graph"
 	},
 	"homepage": "https://onerepo.tools",
 	"type": "module",

--- a/modules/logger/package.json
+++ b/modules/logger/package.json
@@ -4,7 +4,8 @@
 	"license": "MIT",
 	"repository": {
 		"type": "git",
-		"url": "git://github.com/paularmstrong/onerepo.git"
+		"url": "git://github.com/paularmstrong/onerepo.git",
+		"directory": "modules/logger"
 	},
 	"homepage": "https://onerepo.tools",
 	"type": "module",

--- a/modules/onerepo/package.json
+++ b/modules/onerepo/package.json
@@ -4,7 +4,8 @@
 	"license": "MIT",
 	"repository": {
 		"type": "git",
-		"url": "git://github.com/paularmstrong/onerepo.git"
+		"url": "git://github.com/paularmstrong/onerepo.git",
+		"directory": "modules/onerepo"
 	},
 	"homepage": "https://onerepo.tools",
 	"type": "module",

--- a/modules/package-manager/package.json
+++ b/modules/package-manager/package.json
@@ -7,7 +7,8 @@
 	"license": "MIT",
 	"repository": {
 		"type": "git",
-		"url": "git://github.com/paularmstrong/onerepo.git"
+		"url": "git://github.com/paularmstrong/onerepo.git",
+		"directory": "modules/package-manager"
 	},
 	"homepage": "https://onerepo.tools",
 	"type": "module",

--- a/modules/subprocess/package.json
+++ b/modules/subprocess/package.json
@@ -4,7 +4,8 @@
 	"license": "MIT",
 	"repository": {
 		"type": "git",
-		"url": "git://github.com/paularmstrong/onerepo.git"
+		"url": "git://github.com/paularmstrong/onerepo.git",
+		"directory": "modules/subprocess"
 	},
 	"homepage": "https://onerepo.tools",
 	"type": "module",

--- a/modules/test-cli/package.json
+++ b/modules/test-cli/package.json
@@ -4,7 +4,8 @@
 	"license": "MIT",
 	"repository": {
 		"type": "git",
-		"url": "git://github.com/paularmstrong/onerepo.git"
+		"url": "git://github.com/paularmstrong/onerepo.git",
+		"directory": "modules/test-cli"
 	},
 	"homepage": "https://onerepo.tools",
 	"type": "module",

--- a/modules/yargs/package.json
+++ b/modules/yargs/package.json
@@ -4,7 +4,8 @@
 	"license": "MIT",
 	"repository": {
 		"type": "git",
-		"url": "git://github.com/paularmstrong/onerepo.git"
+		"url": "git://github.com/paularmstrong/onerepo.git",
+		"directory": "modules/yargs"
 	},
 	"homepage": "https://onerepo.tools",
 	"type": "module",

--- a/plugins/changesets/package.json
+++ b/plugins/changesets/package.json
@@ -6,7 +6,8 @@
 	"license": "MIT",
 	"repository": {
 		"type": "git",
-		"url": "git://github.com/paularmstrong/onerepo.git"
+		"url": "git://github.com/paularmstrong/onerepo.git",
+		"directory": "plugins/changesets"
 	},
 	"homepage": "https://onerepo.tools/docs/plugins/changesets/",
 	"type": "module",

--- a/plugins/eslint/package.json
+++ b/plugins/eslint/package.json
@@ -6,7 +6,8 @@
 	"license": "MIT",
 	"repository": {
 		"type": "git",
-		"url": "git://github.com/paularmstrong/onerepo.git"
+		"url": "git://github.com/paularmstrong/onerepo.git",
+		"directory": "plugins/eslint"
 	},
 	"homepage": "https://onerepo.tools/docs/plugins/eslint/",
 	"type": "module",

--- a/plugins/jest/package.json
+++ b/plugins/jest/package.json
@@ -6,7 +6,8 @@
 	"license": "MIT",
 	"repository": {
 		"type": "git",
-		"url": "git://github.com/paularmstrong/onerepo.git"
+		"url": "git://github.com/paularmstrong/onerepo.git",
+		"directory": "plugins/jest"
 	},
 	"homepage": "https://onerepo.tools/docs/plugins/vitest/",
 	"type": "module",

--- a/plugins/prettier/package.json
+++ b/plugins/prettier/package.json
@@ -6,7 +6,8 @@
 	"license": "MIT",
 	"repository": {
 		"type": "git",
-		"url": "git://github.com/paularmstrong/onerepo.git"
+		"url": "git://github.com/paularmstrong/onerepo.git",
+		"directory": "plugins/prettier"
 	},
 	"homepage": "https://onerepo.tools/docs/plugins/prettier/",
 	"type": "module",

--- a/plugins/typescript/package.json
+++ b/plugins/typescript/package.json
@@ -6,7 +6,8 @@
 	"license": "MIT",
 	"repository": {
 		"type": "git",
-		"url": "git://github.com/paularmstrong/onerepo.git"
+		"url": "git://github.com/paularmstrong/onerepo.git",
+		"directory": "plugins/typescript"
 	},
 	"homepage": "https://onerepo.tools/docs/plugins/typescript",
 	"type": "module",

--- a/plugins/vitest/package.json
+++ b/plugins/vitest/package.json
@@ -6,7 +6,8 @@
 	"license": "MIT",
 	"repository": {
 		"type": "git",
-		"url": "git://github.com/paularmstrong/onerepo.git"
+		"url": "git://github.com/paularmstrong/onerepo.git",
+		"directory": "plugins/vitest"
 	},
 	"homepage": "https://onerepo.tools/docs/plugins/vitest/",
 	"type": "module",


### PR DESCRIPTION
**Problem:** Some schema need to determine values based on workspace & graph information. For example, in a monorepo, it's necessary to have the `package.json` key `repository.directory` set as the relative directory so that NPM, Renovate, and others pick up CHANGELOGs and link to things correctly.

**Solution:** Enable `one graph verify` custom schema to be functions that receive the workspace and graph.