### PR TITLE
refactor(logger): allow dependency-injection of writable to logger

### DIFF
--- a/.changeset/mighty-pots-smash.md
+++ b/.changeset/mighty-pots-smash.md
@@ -1,0 +1,7 @@
+---
+'@onerepo/core': patch
+'@onerepo/plugin-changesets': patch
+'@onerepo/plugin-prettier': patch
+---
+
+Adjustments for using `logger` from the `HandlerExtras`. Commands no longer throw or return incorrectly when there are errors.

--- a/.changeset/nervous-ties-matter.md
+++ b/.changeset/nervous-ties-matter.md
@@ -1,0 +1,5 @@
+---
+'@onerepo/test-cli': minor
+---
+
+Running command handlers in tests will return the logger output to avoid the need to spy on `process.stderr`.

--- a/.changeset/smooth-hats-shop.md
+++ b/.changeset/smooth-hats-shop.md
@@ -1,0 +1,5 @@
+---
+'@onerepo/test-cli': minor
+---
+
+Failing command handlers due to `logger.error` or `logStep.error` calls will now properly reject the handler with the full log output string.

--- a/.changeset/sour-walls-remember.md
+++ b/.changeset/sour-walls-remember.md
@@ -1,0 +1,6 @@
+---
+'@onerepo/core': patch
+'@onerepo/logger': patch
+---
+
+Clarified usage of `logger` should be restricted to only the one that is given in `HandlerExtra`

--- a/.changeset/weak-students-stare.md
+++ b/.changeset/weak-students-stare.md
@@ -1,0 +1,5 @@
+---
+'@onerepo/logger': minor
+---
+
+Allows passing in a custom stream to override writing to `process.stderr`. Mostly useful for dependency injection during testing.

--- a/modules/core/src/core/graph/commands/__tests__/verify.test.ts
+++ b/modules/core/src/core/graph/commands/__tests__/verify.test.ts
@@ -8,47 +8,51 @@ const { run } = getCommand(Verify);
 describe('verify', () => {
 	test('can turn off graph dependency verification', async () => {
 		const graph = getGraph(path.join(__dirname, '__fixtures__', 'bad-repo'));
-		await expect(run('--dependencies off', { graph })).resolves.toBeUndefined();
+		await expect(run('--dependencies off', { graph })).resolves.toBeTruthy();
 	});
 
 	test('can verify the graph dependencies', async () => {
 		const graphProd = getGraph(path.join(__dirname, '__fixtures__', 'bad-repo'));
-		await expect(run('--dependencies loose', { graph: graphProd })).rejects.toBeUndefined();
+		await expect(run('--dependencies loose', { graph: graphProd })).rejects.toMatch(
+			'Version mismatches found in "menu"'
+		);
 
 		const graphDev = getGraph(path.join(__dirname, '__fixtures__', 'bad-repo-dev'));
-		await expect(run('--dependencies loose', { graph: graphDev })).rejects.toBeUndefined();
+		await expect(run('--dependencies loose', { graph: graphDev })).rejects.toMatch(
+			'Version mismatches found in "menu"'
+		);
 	});
 
 	test('can verify cjson (eg tsconfigs)', async () => {
 		const graph = getGraph(path.join(__dirname, '__fixtures__', 'repo'));
 		const schema = require.resolve('./__fixtures__/tsconfig-schema.ts');
-		await expect(run(`--custom-schema ${schema}`, { graph })).rejects.toEqual(new Error('must be equal to constant'));
+		await expect(run(`--custom-schema ${schema}`, { graph })).rejects.toMatch('must be equal to constant');
 	});
 
 	test('can verify js (eg jest.config, etc)', async () => {
 		const graph = getGraph(path.join(__dirname, '__fixtures__', 'repo'));
 		const schema = require.resolve('./__fixtures__/js-schema.ts');
-		await expect(run(`--custom-schema ${schema}`, { graph })).rejects.toEqual(
-			new Error("must have required property 'displayName'")
+		await expect(run(`--custom-schema ${schema}`, { graph })).rejects.toMatch(
+			"must have required property 'displayName'"
 		);
 	});
 
 	test('can verify yaml files', async () => {
 		const graph = getGraph(path.join(__dirname, '__fixtures__', 'repo'));
 		const schema = require.resolve('./__fixtures__/yaml-schema.ts');
-		await expect(run(`--custom-schema ${schema}`, { graph })).rejects.toEqual(new Error('must be equal to constant'));
+		await expect(run(`--custom-schema ${schema}`, { graph })).rejects.toMatch('must be equal to constant');
 	});
 
 	test('can validate with functions', async () => {
 		const schema = require.resolve('./__fixtures__/functional-schema.ts');
 		const goodGraph = getGraph(path.join(__dirname, '__fixtures__', 'repo'));
 
-		await expect(run(`--custom-schema ${schema}`, { graph: goodGraph })).resolves.toBeUndefined();
+		await expect(run(`--custom-schema ${schema}`, { graph: goodGraph })).resolves.toBeTruthy();
 
 		const badGraph = getGraph(path.join(__dirname, '__fixtures__', 'bad-repo'));
 
-		await expect(run(`--custom-schema ${schema}`, { graph: badGraph })).rejects.toEqual(
-			new Error("must have required property 'repository'")
+		await expect(run(`--custom-schema ${schema}`, { graph: badGraph })).rejects.toMatch(
+			"must have required property 'repository'"
 		);
 	});
 });

--- a/modules/core/src/core/graph/commands/verify.ts
+++ b/modules/core/src/core/graph/commands/verify.ts
@@ -108,6 +108,7 @@ export const handler: Handler<Argv> = async function handler(argv, { graph, logg
 	// const availableSchema = Object.keys(ajv.schemas).filter((key) => key.includes(splitChar));
 
 	for (const workspace of graph.workspaces) {
+		const schemaStep = logger.createStep(`Validating ${workspace.name}`);
 		const relativePath = graph.root.relative(workspace.location);
 
 		// Build a map so the log output is nicer if there are multiple schema for the same file
@@ -127,7 +128,6 @@ export const handler: Handler<Argv> = async function handler(argv, { graph, logg
 			}
 		}
 
-		const schemaStep = logger.createStep(`Validating ${workspace.name}`);
 		for (const [file, fileSchema] of Object.entries(map)) {
 			for (const schemaKey of fileSchema) {
 				schemaStep.debug(`Using schema for "${schemaKey}"`);
@@ -149,13 +149,6 @@ export const handler: Handler<Argv> = async function handler(argv, { graph, logg
 				if (!valid) {
 					schemaStep.error(`Errors in ${workspace.resolve(file)}:`);
 					ajv.errors?.forEach((err) => {
-						if (err.keyword === 'if') {
-							return;
-						}
-						if (process.env.NODE_ENV === 'test') {
-							throw new Error(err.message);
-						}
-
 						schemaStep.error(`  ↳ ${err.message}`);
 					});
 				}

--- a/modules/core/src/core/install/commands/__tests__/install.test.ts
+++ b/modules/core/src/core/install/commands/__tests__/install.test.ts
@@ -34,7 +34,9 @@ describe('handler', () => {
 		jest.spyOn(file, 'writeSafe').mockResolvedValue();
 		jest.spyOn(file, 'read').mockResolvedValue('asdfkujhasdfkljh');
 
-		await expect(run('--name tacos')).rejects.toBeUndefined();
+		await expect(run('--name tacos')).rejects.toMatch(
+			'Refusing to install with name `tacos` because it already exists'
+		);
 		expect(subprocess.run).toHaveBeenCalledWith(expect.objectContaining({ cmd: 'which', args: ['tacos'] }));
 	});
 
@@ -46,7 +48,7 @@ describe('handler', () => {
 		jest.spyOn(file, 'read').mockResolvedValue('onerepo-test-runner');
 		jest.spyOn(os, 'platform').mockReturnValue('darwin');
 
-		await expect(run('--name tacos')).resolves.toBeUndefined();
+		await expect(run('--name tacos')).resolves.toBeTruthy();
 
 		expect(subprocess.sudo).toHaveBeenCalledWith(
 			expect.objectContaining({
@@ -70,7 +72,7 @@ describe('handler', () => {
 		jest.spyOn(file, 'read').mockResolvedValue('asdfasdf');
 		jest.spyOn(os, 'platform').mockReturnValue('darwin');
 
-		await expect(run('--name tacos --force')).resolves.toBeUndefined();
+		await expect(run('--name tacos --force')).resolves.toBeTruthy();
 		expect(subprocess.run).not.toHaveBeenCalledWith(expect.objectContaining({ cmd: 'which', args: ['tacos'] }));
 
 		expect(subprocess.sudo).toHaveBeenCalledWith(
@@ -95,7 +97,7 @@ describe('handler', () => {
 		jest.spyOn(file, 'read').mockResolvedValue(process.argv[1]);
 
 		jest.spyOn(file, 'exists').mockResolvedValue(true);
-		await expect(run('--name tacos')).resolves.toBeUndefined();
+		await expect(run('--name tacos')).resolves.toBeTruthy();
 
 		expect(subprocess.run).toHaveBeenCalledWith(
 			expect.objectContaining({
@@ -113,7 +115,7 @@ describe('handler', () => {
 		jest.spyOn(file, 'read').mockResolvedValue(process.argv[1]);
 
 		jest.spyOn(file, 'exists').mockResolvedValue(false);
-		await expect(run('--name tacos')).resolves.toBeUndefined();
+		await expect(run('--name tacos')).resolves.toBeTruthy();
 
 		expect(subprocess.run).not.toHaveBeenCalledWith(
 			expect.objectContaining({

--- a/modules/core/src/core/install/commands/install.ts
+++ b/modules/core/src/core/install/commands/install.ts
@@ -63,7 +63,7 @@ export const builder: Builder<Args> = (yargs) =>
 			'As an added bonus, tab-completions will be added to your .zshrc or .bash_profile (depending on your current shell).'
 		);
 
-export const handler: Handler<Args> = async function handler(argv, { graph }) {
+export const handler: Handler<Args> = async function handler(argv, { graph, logger }) {
 	const { force, location, name } = argv;
 
 	if (!force) {

--- a/modules/core/src/core/tasks/commands/__tests__/tasks.test.ts
+++ b/modules/core/src/core/tasks/commands/__tests__/tasks.test.ts
@@ -53,8 +53,8 @@ describe('handler', () => {
 		await run('--lifecycle pre-commit --list', { graph });
 		expect(JSON.parse(out)).toEqual({
 			parallel: [
-				[expect.objectContaining({ cmd: expect.stringMatching(/test-runner$/), args: ['lint'] })],
-				[expect.objectContaining({ cmd: expect.stringMatching(/test-runner$/), args: ['tsc'] })],
+				[expect.objectContaining({ cmd: expect.stringMatching(/test-runner$/), args: ['lint', '-vvvv'] })],
+				[expect.objectContaining({ cmd: expect.stringMatching(/test-runner$/), args: ['tsc', '-vvvv'] })],
 			],
 			serial: [],
 		});
@@ -67,8 +67,8 @@ describe('handler', () => {
 		await run('--lifecycle commit --list', { graph });
 		expect(JSON.parse(out)).toEqual({
 			parallel: [
-				[expect.objectContaining({ cmd: expect.stringMatching(/test-runner$/), args: ['lint'] })],
-				[expect.objectContaining({ cmd: expect.stringMatching(/test-runner$/), args: ['tsc'] })],
+				[expect.objectContaining({ cmd: expect.stringMatching(/test-runner$/), args: ['lint', '-vvvv'] })],
+				[expect.objectContaining({ cmd: expect.stringMatching(/test-runner$/), args: ['tsc', '-vvvv'] })],
 			],
 			serial: [
 				[expect.objectContaining({ cmd: 'echo', args: ['"commit"'] })],

--- a/modules/logger/src/index.ts
+++ b/modules/logger/src/index.ts
@@ -7,12 +7,6 @@ export * from './LogStep';
 /**
  * This logger is a singleton instance for use across all of oneRepo and its commands.
  *
- * Available as a root import:
- *
- * ```ts
- * import { logger } from 'onerepo';
- * ```
- *
  * Available as extras on Handler functions:
  *
  * ```ts

--- a/plugins/changesets/src/commands/__tests__/add.test.ts
+++ b/plugins/changesets/src/commands/__tests__/add.test.ts
@@ -49,7 +49,7 @@ describe('handler', () => {
 			chosen: [],
 		});
 
-		await expect(run('', { graph })).rejects.toBeUndefined();
+		await expect(run('', { graph })).rejects.toMatch('No workspaces were chosen');
 
 		expect(changesetWrite.default).not.toHaveBeenCalled();
 		expect(git.updateIndex).not.toHaveBeenCalled();
@@ -60,7 +60,7 @@ describe('handler', () => {
 			chosen: ['burritos'],
 		});
 
-		await expect(run('', { graph })).rejects.toBeUndefined();
+		await expect(run('', { graph })).rejects.toMatch('No semantic version type chosen');
 
 		expect(changesetWrite.default).not.toHaveBeenCalled();
 		expect(git.updateIndex).not.toHaveBeenCalled();

--- a/plugins/changesets/src/commands/__tests__/prerelease.test.ts
+++ b/plugins/changesets/src/commands/__tests__/prerelease.test.ts
@@ -40,7 +40,7 @@ describe('handler', () => {
 
 	test('does nothing if git working tree is dirty', async () => {
 		jest.spyOn(git, 'isClean').mockResolvedValue(false);
-		await expect(run('', { graph })).rejects.toBeUndefined();
+		await expect(run('', { graph })).rejects.toMatch('Working directory must be unmodified to ensure safe pre-publis');
 
 		expect(inquirer.prompt).not.toHaveBeenCalled();
 		expect(subprocess.run).not.toHaveBeenCalledWith(expect.objectContaining({ name: 'Build workspaces' }));
@@ -60,7 +60,9 @@ describe('handler', () => {
 		jest.spyOn(inquirer, 'prompt').mockResolvedValue({ choices: ['_ALL_'] });
 		jest.spyOn(graph.packageManager, 'loggedIn').mockResolvedValue(false);
 		jest.spyOn(graph.packageManager, 'publish').mockResolvedValue(undefined);
-		await expect(run('', { graph })).rejects.toBeUndefined();
+		await expect(run('', { graph })).rejects.toMatch(
+			'You do not appear to have publish rights to the configured registry'
+		);
 		expect(graph.packageManager.loggedIn).toHaveBeenCalled();
 	});
 
@@ -79,7 +81,19 @@ describe('handler', () => {
 		expect(subprocess.run).toHaveBeenCalledWith(
 			expect.objectContaining({
 				cmd: process.argv[1],
-				args: ['tasks', '-c', 'build', '--no-affected', '-w', 'burritos', 'churros', 'tacos', 'tortas', 'tortillas'],
+				args: [
+					'tasks',
+					'-c',
+					'build',
+					'--no-affected',
+					'-w',
+					'burritos',
+					'churros',
+					'tacos',
+					'tortas',
+					'tortillas',
+					'-vv',
+				],
 			})
 		);
 
@@ -120,7 +134,7 @@ describe('handler', () => {
 		expect(subprocess.run).toHaveBeenCalledWith(
 			expect.objectContaining({
 				cmd: process.argv[1],
-				args: ['tasks', '-c', 'build', '--no-affected', '-w', 'burritos', 'tortillas'],
+				args: ['tasks', '-c', 'build', '--no-affected', '-w', 'burritos', 'tortillas', '-vv'],
 			})
 		);
 

--- a/plugins/changesets/src/commands/__tests__/version.test.ts
+++ b/plugins/changesets/src/commands/__tests__/version.test.ts
@@ -23,7 +23,9 @@ describe('handler', () => {
 
 	test('does nothing if git working tree is dirty', async () => {
 		jest.spyOn(git, 'isClean').mockResolvedValue(false);
-		await expect(run('', { graph })).rejects.toBeUndefined();
+		await expect(run('', { graph })).rejects.toMatch(
+			'Working directory must be unmodified to ensure correct versioning'
+		);
 
 		expect(inquirer.prompt).not.toHaveBeenCalled();
 		expect(applyReleasePlan.default).not.toHaveBeenCalled();

--- a/plugins/changesets/src/commands/publish.ts
+++ b/plugins/changesets/src/commands/publish.ts
@@ -107,8 +107,8 @@ export const handler: Handler<Args> = async (argv, { graph, logger }) => {
 				'--no-affected',
 				'-w',
 				...publishable.map((ws) => ws.name),
-				verbosity ? `-${'v'.repeat(verbosity)}` : '',
-			].filter(Boolean),
+				...(verbosity ? [`-${'v'.repeat(verbosity)}`] : []),
+			],
 			runDry: true,
 		});
 	}

--- a/plugins/eslint/src/commands/__tests__/eslint.test.ts
+++ b/plugins/eslint/src/commands/__tests__/eslint.test.ts
@@ -71,7 +71,7 @@ describe('handler', () => {
 			{ isDirectory: () => true }
 		);
 
-		await expect(run('-w burritos -w tacos')).resolves.toBeUndefined();
+		await expect(run('-w burritos -w tacos')).resolves.toBeTruthy();
 
 		expect(subprocess.run).toHaveBeenCalledWith(
 			expect.objectContaining({
@@ -99,7 +99,7 @@ describe('handler', () => {
 	test('does not fix in dry-run', async () => {
 		jest.spyOn(subprocess, 'run').mockResolvedValue(['', '']);
 
-		await expect(run('-a --dry-run')).resolves.toBeUndefined();
+		await expect(run('-a --dry-run')).resolves.toBeTruthy();
 
 		expect(subprocess.run).toHaveBeenCalledWith(
 			expect.objectContaining({
@@ -125,7 +125,7 @@ describe('handler', () => {
 	test('does not fix in no-cache', async () => {
 		jest.spyOn(subprocess, 'run').mockResolvedValue(['', '']);
 
-		await expect(run('-a --no-cache')).resolves.toBeUndefined();
+		await expect(run('-a --no-cache')).resolves.toBeTruthy();
 
 		expect(subprocess.run).toHaveBeenCalledWith(
 			expect.objectContaining({
@@ -141,7 +141,7 @@ describe('handler', () => {
 	test('filters unapproved extensions', async () => {
 		jest.spyOn(subprocess, 'run').mockResolvedValue(['', '']);
 
-		await expect(run('-f foo.xd -f bar.js')).resolves.toBeUndefined();
+		await expect(run('-f foo.xd -f bar.js')).resolves.toBeTruthy();
 
 		expect(subprocess.run).toHaveBeenCalledWith(
 			expect.objectContaining({
@@ -176,7 +176,7 @@ bar/**/*
 			// @ts-ignore mock
 			{ isDirectory: () => false }
 		);
-		await expect(run('-f foo.js -f bar/baz/bop.js')).resolves.toBeUndefined();
+		await expect(run('-f foo.js -f bar/baz/bop.js')).resolves.toBeTruthy();
 
 		expect(file.exists).toHaveBeenCalledWith(expect.stringMatching(/\.eslintignore$/), expect.any(Object));
 
@@ -206,7 +206,7 @@ bar/**/*
 		jest.spyOn(subprocess, 'run').mockResolvedValue(['', '']);
 		jest.spyOn(git, 'updateIndex').mockResolvedValue('');
 
-		await expect(run('-f foo.xd -f bar.js --add')).resolves.toBeUndefined();
+		await expect(run('-f foo.xd -f bar.js --add')).resolves.toBeTruthy();
 
 		expect(subprocess.run).toHaveBeenCalledWith(
 			expect.objectContaining({
@@ -293,7 +293,7 @@ something
 			'',
 		]);
 
-		await expect(run('-a')).rejects.toBeUndefined();
+		await expect(run('-a')).rejects.toMatch('something');
 
 		expect(process.stdout.write).toHaveBeenCalledWith('::error burritos\n::warning tacos');
 		expect(process.stdout.write).toHaveBeenCalledWith('\n');

--- a/plugins/prettier/src/commands/__tests__/prettier.test.ts
+++ b/plugins/prettier/src/commands/__tests__/prettier.test.ts
@@ -69,7 +69,7 @@ describe('handler', () => {
 			{ isDirectory: () => true }
 		);
 
-		await expect(run('-w burritos -w tacos')).resolves.toBeUndefined();
+		await expect(run('-w burritos -w tacos')).resolves.toBeTruthy();
 
 		expect(subprocess.run).toHaveBeenCalledWith(
 			expect.objectContaining({
@@ -82,7 +82,7 @@ describe('handler', () => {
 	test('does not write in dry-run', async () => {
 		jest.spyOn(subprocess, 'run').mockResolvedValue(['', '']);
 
-		await expect(run('-a --dry-run')).resolves.toBeUndefined();
+		await expect(run('-a --dry-run')).resolves.toBeTruthy();
 
 		expect(subprocess.run).toHaveBeenCalledWith(
 			expect.objectContaining({
@@ -103,7 +103,7 @@ bar/**/*
 			// @ts-ignore mock
 			{ isDirectory: () => false }
 		);
-		await expect(run('-f foo.js -f bar/baz/bop.js')).resolves.toBeUndefined();
+		await expect(run('-f foo.js -f bar/baz/bop.js')).resolves.toBeTruthy();
 
 		expect(file.exists).toHaveBeenCalledWith(expect.stringMatching(/\.prettierignore$/), expect.any(Object));
 
@@ -129,7 +129,7 @@ bar/**/*
 
 		jest.spyOn(git, 'updateIndex').mockResolvedValue('');
 
-		await expect(run('-f foo.xd -f bar.js --add')).resolves.toBeUndefined();
+		await expect(run('-f foo.xd -f bar.js --add')).resolves.toBeTruthy();
 
 		expect(subprocess.run).toHaveBeenCalledWith(
 			expect.objectContaining({
@@ -147,7 +147,9 @@ bar/**/*
 			throw new Error('foo.js\nbop.js\n');
 		});
 
-		await expect(run('-f foo.js -f bop.js -f bar.js')).rejects.toBeUndefined();
+		await expect(run('-f foo.js -f bop.js -f bar.js')).rejects.toMatch(
+			'The following files were not properly formatted'
+		);
 
 		expect(core.error).toHaveBeenCalledWith(expect.stringContaining('This file needs formatting'), { file: 'foo.js' });
 		expect(core.error).toHaveBeenCalledWith(expect.stringContaining('This file needs formatting'), { file: 'bop.js' });

--- a/plugins/prettier/src/commands/prettier.ts
+++ b/plugins/prettier/src/commands/prettier.ts
@@ -5,7 +5,6 @@ import { updateIndex } from '@onerepo/git';
 import { exists, lstat, read } from '@onerepo/file';
 import { run } from '@onerepo/subprocess';
 import { builders } from '@onerepo/builders';
-import { logger } from '@onerepo/logger';
 import type { Builder, Handler } from '@onerepo/yargs';
 
 export const command = 'prettier';
@@ -42,7 +41,7 @@ export const builder: Builder<Args> = (yargs) =>
 			}
 		});
 
-export const handler: Handler<Args> = async function handler(argv, { getFilepaths, graph }) {
+export const handler: Handler<Args> = async function handler(argv, { getFilepaths, graph, logger }) {
 	const { add, all, check, 'dry-run': isDry, 'github-annotate': github, $0: cmd, _: positionals } = argv;
 
 	const filteredPaths = [];
@@ -93,14 +92,14 @@ export const handler: Handler<Args> = async function handler(argv, { getFilepath
 		});
 	} catch (e) {
 		const files = (e instanceof Error ? e.message : `${e}`).trim().split('\n');
-		const err = new Error(`The following files were not properly formatted.
+		const err = `The following files were not properly formatted.
 
 ${files.map((f) => `  - ${f}`).join('\n')}
 
 To resolve the issue, run Prettier formatting and commit the resulting changes:
 
   $ ${cmd} ${positionals[0]}
-	`);
+	`;
 
 		if (process.env.GITHUB_RUN_ID && github) {
 			const msg = `This file needs formatting. Fix by running \`${cmd} ${positionals[0]}\``;


### PR DESCRIPTION
**Problem:** Getting logger output in tests (whether resolving or rejecting) is difficult because we rely on `process.stderr` to write logs.

**Solution:** Switch `Logger` and `LogStep` to use dependency injection for the stream to write to. Update `@onerepo/test-cli` to pass in a stream that captures the output and resolve/reject the output accordingly.