### PR TITLE
refactor: performance logging

### DIFF
--- a/.changeset/brave-bikes-buy.md
+++ b/.changeset/brave-bikes-buy.md
@@ -1,0 +1,6 @@
+---
+'@onerepo/logger': patch
+'onerepo': patch
+---
+
+Fixed a regression that prevented the default logger from writing out any logs until after all steps were completed.

--- a/.changeset/purple-tomatoes-travel.md
+++ b/.changeset/purple-tomatoes-travel.md
@@ -1,0 +1,8 @@
+---
+'@onerepo/core': minor
+'@onerepo/logger': minor
+'onerepo': minor
+'@onerepo/subprocess': minor
+---
+
+Overhauled performance logging. All marks are pairs that start with `onerepo_start_` and `onerepo_end_`. By default, these will be converted into [Node.js performance measureme entries](https://nodejs.org/api/perf_hooks.html#class-performancemeasure) for use in your own telemetry implementation.

--- a/.changeset/silly-wasps-clap.md
+++ b/.changeset/silly-wasps-clap.md
@@ -1,0 +1,7 @@
+---
+'@onerepo/core': minor
+'onerepo': minor
+'@onerepo/yargs': minor
+---
+
+No longer re-throws errors thrown from handlers. If an error is encountered, the process will still exit with a code (`1`), but will not crash the process to ensure cleanup and post-handlers are completed properly.

--- a/bin/one.cjs
+++ b/bin/one.cjs
@@ -1,8 +1,7 @@
 #!/usr/bin/env node
 const path = require('node:path');
-const { performance } = require('node:perf_hooks');
+// const { performance } = require('node:perf_hooks');
 
-performance.mark('one_register');
 require('esbuild-register/dist/node').register({});
 
 const { setup } = require('onerepo');
@@ -42,4 +41,10 @@ setup(
 			typescript({ tsconfig: 'tsconfig.json' }),
 		],
 	}
-).then(({ run }) => run());
+)
+	.then(({ run }) => run())
+	.then(() => {
+		// Example do something with the performance measurements
+		// const measures = performance.getEntriesByType('measure');
+		// console.log(JSON.stringify(measures, null, 2));
+	});

--- a/commands/build.ts
+++ b/commands/build.ts
@@ -45,7 +45,7 @@ export const handler: Handler<Args> = async function handler(argv, { getWorkspac
 
 	for (const workspace of workspaces) {
 		if (workspace.private) {
-			logger.warn(`Not building \`${workspace.name}\` because it is private`);
+			buildableStep.warn(`Not building \`${workspace.name}\` because it is private`);
 			continue;
 		}
 
@@ -66,7 +66,7 @@ export const handler: Handler<Args> = async function handler(argv, { getWorkspac
 		const main = workspace.resolve(workspace.packageJson.main!);
 		addFile(main);
 
-		if (await file.exists(workspace.resolve('src/fixtures'))) {
+		if (await file.exists(workspace.resolve('src/fixtures'), { step: buildableStep })) {
 			postCopy.push(() => file.copy(workspace.resolve('src/fixtures'), workspace.resolve('dist/fixtures')));
 		}
 

--- a/docs/commands/typedoc.ts
+++ b/docs/commands/typedoc.ts
@@ -54,6 +54,7 @@ export const handler: Handler = async (argv, { graph, logger }) => {
 			.replace(/index\.md(#[^)]+)?/g, '$1')
 			.replace(/\.md(#[^)]+)?/g, '/$1')
 			.replace(/^#+ Source\n\n\[([^:]+):(\d+)\]/gm, `**Source:** [$1:$2]`)
+			.replace(/(?:<br(?: \/)?>)+\*\*(Default(?: Value)?)\*\*(?:<br(?: \/)?>)+/g, '<br /><br />**$1:** ')
 			.replace('[**onerepo**](/docs/core/api/)\n\n---\n\n', '');
 		out = `---
 title: "API: ${doc.replace('.md', '')}"

--- a/docs/src/components/Sidebar.astro
+++ b/docs/src/components/Sidebar.astro
@@ -15,7 +15,7 @@ const plugins = await getCollection('plugins');
 			docs.map((doc) => {
 				return (
 					<li>
-						<SidebarLink href={`/docs/${doc.slug}`}>{doc.data.title}</SidebarLink>
+						<SidebarLink href={`/docs/${doc.slug}/`}>{doc.data.title}</SidebarLink>
 					</li>
 				);
 			})
@@ -52,6 +52,7 @@ const plugins = await getCollection('plugins');
 			</ul>
 		</li>
 		<li><SidebarLink href="/docs/core/changelog/">Changelog</SidebarLink></li>
+		<li><SidebarLink href="/docs/telemetry/">Telemetry</SidebarLink></li>
 		<li><SidebarLink href="/docs/glossary/">Glossary</SidebarLink></li>
 		<li>
 			<SidebarLink href="/docs/contributing/">Contributing</SidebarLink>

--- a/docs/src/pages/docs/telemetry.md
+++ b/docs/src/pages/docs/telemetry.md
@@ -1,0 +1,97 @@
+---
+title: Telemetry
+layout: '../../layouts/Docs.astro'
+---
+
+# Telemetry
+
+First and foremost: oneRepo _does not_ and _will not_ send metrics, stats, or any other telemetry data anywhere.
+
+However, it _does_ use the [Node.js performance hooks](https://nodejs.org/api/perf_hooks.html) to automatically measure timing of log steps and subprocesses. While nothing is done with this information by default, your application can get measurement entries and decide what to do with that information later.
+
+```tsx title="bin/one.mjs" showLineNumbers {8-12}
+import { performance } from 'node:perf_hooks';
+import { writeFile } from 'node:fs/promises';
+import { setup } from 'onerepo';
+
+setup({})
+	.then(({ run }) => run())
+	.then(() => {
+		const measurements = performance.getEntriesByType('measure');
+		// write the measurements somewhere for reuse
+		await writeFile('/tmp/one/measurements.json', JSON.stringify(measures, null, 2));
+		// detach a subprocess for your reporter and the file
+		spawn('my-reporter', ['/tmp/one/measurements.json'], { detached, stdio: 'ignore' });
+	});
+```
+
+```json title="Sample measurements"
+[
+	{
+		"name": "Program",
+		"entryType": "measure",
+		"startTime": 53.776582956314,
+		"duration": 85.6957499980927,
+		"detail": {
+			"argv": {
+				"_": ["build"],
+				"workspaces": ["logger"],
+				"dry-run": false,
+				"verbosity": 2,
+				"silent": false,
+				"$0": "one"
+			},
+			"description": "The measure of time from the beginning of parsing program setup and CLI arguments through the end of the handler & any postHandler options."
+		}
+	},
+	{
+		"name": "Handler: build",
+		"entryType": "measure",
+		"startTime": 79.6299171447754,
+		"duration": 1188.8661658763885,
+		"detail": {
+			"argv": {
+				"_": ["build"],
+				"workspaces": ["logger"],
+				"dry-run": false,
+				"verbosity": 2,
+				"silent": false,
+				"$0": "one"
+			}
+		}
+	},
+	{
+		"name": "Pre-Handler",
+		"entryType": "measure",
+		"startTime": 79.73641705513,
+		"duration": 3.887083053588867,
+		"detail": {
+			"argv": {
+				"_": ["build"],
+				"workspaces": ["logger"],
+				"dry-run": false,
+				"verbosity": 2,
+				"silent": false,
+				"$0": "one"
+			}
+		}
+	},
+	{
+		"name": "Get workspaces from inputs",
+		"entryType": "measure",
+		"startTime": 83.8167080879211,
+		"duration": 0.40558385848999023,
+		"detail": {
+			"argv": {
+				"_": ["build"],
+				"workspaces": ["logger"],
+				"dry-run": false,
+				"verbosity": 2,
+				"silent": false,
+				"$0": "one"
+			}
+		}
+	}
+	// ...
+]
+```

--- a/modules/core/src/__tests__/performance.test.ts
+++ b/modules/core/src/__tests__/performance.test.ts
@@ -1,0 +1,81 @@
+import { performance } from 'node:perf_hooks';
+import { measure } from '../performance';
+
+describe('measure', () => {
+	beforeEach(() => {
+		performance.clearMarks();
+		performance.clearMeasures();
+	});
+
+	test('measures between onerepo_start_ and onerepo_end_', async () => {
+		performance.mark('onerepo_start_Tacos');
+		performance.mark('onerepo_end_Tacos');
+		measure({});
+
+		expect(performance.getEntriesByType('measure')).toEqual([
+			expect.objectContaining({
+				duration: expect.any(Number),
+				entryType: 'measure',
+				name: 'Tacos',
+				startTime: expect.any(Number),
+			}),
+		]);
+	});
+
+	test('merges details', async () => {
+		performance.mark('onerepo_start_Tacos', { detail: { foo: 'foo' } });
+		performance.mark('onerepo_end_Tacos', { detail: { bar: 'bar' } });
+		measure({});
+
+		expect(performance.getEntriesByType('measure')[0]).toHaveProperty('detail', { argv: {}, foo: 'foo', bar: 'bar' });
+	});
+
+	test('passes argv from measure into detail', async () => {
+		performance.mark('onerepo_start_Tacos', { detail: { foo: 'foo' } });
+		performance.mark('onerepo_end_Tacos', { detail: { bar: 'bar' } });
+		measure({ cmd: 'foo' });
+
+		expect(performance.getEntriesByType('measure')[0]).toHaveProperty('detail', {
+			argv: { cmd: 'foo' },
+			foo: 'foo',
+			bar: 'bar',
+		});
+	});
+
+	test('converts string detail into description', async () => {
+		performance.mark('onerepo_start_Tacos', { detail: 'from start' });
+		performance.mark('onerepo_end_Tacos', {});
+		measure({});
+
+		expect(performance.getEntriesByType('measure')[0]).toHaveProperty('detail', {
+			argv: {},
+			description: 'from start',
+		});
+	});
+
+	test('merges string details into description', async () => {
+		performance.mark('onerepo_start_Tacos', { detail: 'from start' });
+		performance.mark('onerepo_end_Tacos', { detail: 'from end' });
+		measure({});
+
+		expect(performance.getEntriesByType('measure')[0]).toHaveProperty('detail', {
+			argv: {},
+			description: 'from start from end',
+		});
+	});
+
+	test('ignores marks that are not onerepo_start_', async () => {
+		performance.mark('foo');
+		performance.mark('bar');
+		measure({});
+
+		expect(performance.getEntriesByType('measure')).toEqual([]);
+	});
+
+	test('does not create measure if no onerepo_end_ mark', async () => {
+		performance.mark('onerepo_start_Tacos');
+		measure({});
+
+		expect(performance.getEntriesByType('measure')).toEqual([]);
+	});
+});

--- a/modules/core/src/performance.ts
+++ b/modules/core/src/performance.ts
@@ -1,0 +1,34 @@
+import { performance } from 'node:perf_hooks';
+
+export function measure(argv: Record<string, unknown>) {
+	const entries = performance.getEntriesByType('mark');
+	entries.forEach((entry) => {
+		if (!entry.name.startsWith('onerepo_start_')) {
+			return;
+		}
+
+		const [end] = performance.getEntriesByName(entry.name.replace('_start_', '_end_'));
+		if (end) {
+			let detail: Record<string, unknown> = { argv };
+			if (typeof entry.detail === 'string') {
+				detail.description = entry.detail;
+			} else if (entry.detail) {
+				detail = { ...detail, ...entry.detail };
+			}
+			if (typeof end.detail === 'string') {
+				detail.description = `${detail.description ? `${detail.description} ` : ''}${end.detail}`;
+			} else if (end.detail) {
+				detail = { ...detail, ...end.detail };
+			}
+
+			performance.measure(entry.name.replace('onerepo_start_', ''), {
+				start: entry.startTime,
+				end: end.startTime,
+				detail,
+			});
+
+			performance.clearMarks(entry.name);
+			performance.clearMarks(end.name);
+		}
+	});
+}

--- a/modules/core/src/types.ts
+++ b/modules/core/src/types.ts
@@ -44,35 +44,47 @@ export type CoreConfig = {
 export type Config = {
 	/**
 	 * Core plugin configuration. These plugins will be added automatically unless the value specified is `false`
+	 * @default `{}`
 	 */
 	core?: CoreConfig;
-	/**
-	 * What's the default branch of your repo? Probably `main`, but it might be something else, so it's helpful to put that here so that we can determine changed files accurately.
-	 */
-	head?: string;
-	/**
-	 * When using subcommandDir, include a regular expression here to ignore files. By default, we will try to override *.(test|spec).* files and maybe some more. This will override the default.
-	 */
-	ignoreCommands?: RegExp;
 	/**
 	 * When you ask for `--help` at the root of the CLI, this description will be shown. It might even show up in documentation, so don't make it too funny…
 	 */
 	description?: string;
 	/**
+	 * What's the default branch of your repo? Probably `main`, but it might be something else, so it's helpful to put that here so that we can determine changed files accurately.
+	 * @default `'main'`
+	 */
+	head?: string;
+	/**
+	 * When using subcommandDir, include a regular expression here to ignore files.
+	 * @default `/(\/__\w+__\/|\.test\.|\.spec\.)/`
+	 */
+	ignoreCommands?: RegExp;
+	/**
+	 * Whether or not to measure performance marks. Adds minimal overhead. Disable if you’d prefer to make your own measurements.
+	 * @default `true`
+	 */
+	measurePerformance?: boolean;
+	/**
 	 * Give your CLI a unique name that's short and easy to remember.
 	 * If not provided, will default to `one`. That's great, but will cause conflicts if you try to use multiple monorepos that are both using oneRepo. But then again, what's the point of having multiple monorepos. Isn't that a bit besides the point?
+	 * @default `'one'`
 	 */
 	name?: string;
 	/**
-	 * Add shared commands. https://onerepo.tools/docs/plugins/
+	 * Add shared commands and extra handlers. See the [official plugin list](https://onerepo.tools/docs/plugins/) for more information.
+	 * @default `[]`
 	 */
 	plugins?: Array<Plugin>;
 	/**
 	 * Absolute path location to the root of the repository.
+	 * @default `process.cwd()`
 	 */
 	root?: string;
 	/**
 	 * A string to use as filepaths to subcommands. We'll look for commands in all workspaces using this string. If any are found, they'll be available from the CLI.
+	 * @default `'commands'`
 	 */
 	subcommandDir?: string | false;
 };

--- a/modules/logger/src/__tests__/LogStep.test.ts
+++ b/modules/logger/src/__tests__/LogStep.test.ts
@@ -63,6 +63,7 @@ describe('LogStep', () => {
 		[2, ['error', 'warn']],
 		[3, ['error', 'warn', 'log']],
 		[4, ['error', 'warn', 'log', 'debug']],
+		[5, ['error', 'warn', 'log', 'debug', 'timing']],
 	] as Array<[number, Array<keyof LogStep>]>)('verbosity = %d writes %j', async (verbosity, methods) => {
 		const onEnd = jest.fn(() => Promise.resolve());
 		const onError = jest.fn();
@@ -74,6 +75,7 @@ describe('LogStep', () => {
 			warn: ` │ ${pc.yellow(pc.bold('WRN'))} a warning`,
 			log: ` │ ${pc.cyan(pc.bold('LOG'))} a log`,
 			debug: ` │ ${pc.magenta(pc.bold('DBG'))} a debug`,
+			timing: ` │ ${pc.red('⏳')} foo → bar: 0ms`,
 		};
 
 		let out = '';
@@ -87,6 +89,9 @@ describe('LogStep', () => {
 		step.warn('a warning');
 		step.log('a log');
 		step.debug('a debug');
+		performance.mark('foo');
+		performance.mark('bar');
+		step.timing('foo', 'bar');
 
 		await step.end();
 		await step.flush();

--- a/modules/logger/src/__tests__/Logger.test.ts
+++ b/modules/logger/src/__tests__/Logger.test.ts
@@ -1,0 +1,101 @@
+import { PassThrough } from 'node:stream';
+import pc from 'picocolors';
+import { Logger } from '../Logger';
+
+async function waitStreamEnd(stream: PassThrough) {
+	return new Promise<void>((resolve) => {
+		stream.end(() => {
+			resolve();
+		});
+	});
+}
+describe('Logger', () => {
+	test.concurrent.each([
+		[0, []],
+		[1, ['error']],
+		[2, ['error', 'warn']],
+		[3, ['error', 'warn', 'log']],
+		[4, ['error', 'warn', 'log', 'debug']],
+		[5, ['error', 'warn', 'log', 'debug', 'timing']],
+	] as Array<[number, Array<keyof Logger>]>)('verbosity = %d writes %j', async (verbosity, methods) => {
+		const stream = new PassThrough();
+		let out = '';
+		stream.on('data', (chunk) => {
+			out += chunk.toString();
+		});
+
+		const logger = new Logger({ verbosity, stream });
+
+		const logs = {
+			error: `${pc.red(pc.bold('ERR'))} an error`,
+			warn: `${pc.yellow(pc.bold('WRN'))} a warning`,
+			// log: `${pc.cyan(pc.bold('LOG'))} a log`,
+			log: ' a log',
+			debug: `${pc.magenta(pc.bold('DBG'))} a debug`,
+			timing: `${pc.red('⏳')} foo → bar: 0ms`,
+		};
+
+		logger.error('an error');
+		logger.warn('a warning');
+		logger.log('a log');
+		logger.debug('a debug');
+		performance.mark('foo');
+		performance.mark('bar');
+		logger.timing('foo', 'bar');
+
+		await logger.end();
+		await waitStreamEnd(stream);
+
+		for (const [method, str] of Object.entries(logs)) {
+			// @ts-ignore
+			if (!methods.includes(method)) {
+				expect(out).not.toMatch(str);
+			} else {
+				expect(out).toMatch(str);
+			}
+		}
+	});
+
+	test('logs "completed" message', async () => {
+		const stream = new PassThrough();
+		let out = '';
+		stream.on('data', (chunk) => {
+			out += chunk.toString();
+		});
+
+		const logger = new Logger({ verbosity: 2, stream });
+
+		const step = logger.createStep('tacos');
+		await step.end();
+
+		await logger.end();
+		await waitStreamEnd(stream);
+
+		expect(out).toMatch(`${pc.dim(pc.bold('■'))} ${pc.green('✔')} Completed`);
+	});
+
+	test('writes logs if verbosity increased after construction', async () => {
+		const stream = new PassThrough();
+		let out = '';
+		stream.on('data', (chunk) => {
+			out += chunk.toString();
+		});
+
+		const logger = new Logger({ verbosity: 0, stream });
+		logger.verbosity = 2;
+
+		logger.warn('this is a warning');
+
+		const step = logger.createStep('tacos');
+		await step.end();
+
+		await logger.end();
+		await waitStreamEnd(stream);
+
+		expect(out).toEqual(` ${pc.yellow(pc.bold('WRN'))} this is a warning
+ ┌ tacos
+ └ ${pc.green('✔')} ${pc.dim('0ms')}
+ ${pc.dim(pc.bold('■'))} ${pc.green('✔')} Completed ${pc.dim('0ms')}
+`);
+	});
+});

--- a/modules/package-manager/src/methods.ts
+++ b/modules/package-manager/src/methods.ts
@@ -51,7 +51,7 @@ export interface PackageManager {
 		workspaces?: Array<T>;
 		/**
 		 * Set the registry access level for the package
-		 * @default 'public' inferred from workspaces publishConfig.access
+		 * @default inferred from workspaces `publishConfig.access` or `'public'`
 		 */
 		access?: 'restricted' | 'public';
 		/**


### PR DESCRIPTION
**Problem:** Performance marks and measurements are a little ad-hoc at the moment

**Solution:** Internally, only use marks with `onerepo_start_` and `onerepo_end_` prefixes. This allows creating measurements from start to end marks more reliably.

- Passes the parsed `argv` to every measurement
- Merges mark details