### PR TITLE
feat(builders): limit getFilepaths with a threshold

### DIFF
--- a/.changeset/swift-suns-tell.md
+++ b/.changeset/swift-suns-tell.md
@@ -1,0 +1,7 @@
+---
+'@onerepo/builders': minor
+'onerepo': minor
+'@onerepo/yargs': minor
+---
+
+Using `getFilepaths` and `getters.getFilepaths` to return the list of affected filepaths now has a threshold. When the threshold is reached, the relative workspace locations for the affected files will be returned instead. This threshold can be configured via the getter options: `{ affectedThreshold: number }`.

--- a/modules/builders/src/__tests__/getters.test.ts
+++ b/modules/builders/src/__tests__/getters.test.ts
@@ -50,6 +50,24 @@ describe('filepaths', () => {
 		const pathAffected = await filepaths(graph, { all: true, affected: true });
 		expect(pathAffected).toEqual(['.']);
 	});
+
+	test('returns workspace locations if threshold is hit', async () => {
+		jest
+			.spyOn(git, 'getModifiedFiles')
+			.mockResolvedValue(['modules/burritos/package.json', 'modules/burritos/bar', 'modules/burritos/baz']);
+
+		const paths = await filepaths(graph, { affected: true }, { affectedThreshold: 2 });
+		expect(paths).toEqual(['modules/burritos']);
+	});
+
+	test('if threshold is zero, returns all files', async () => {
+		jest
+			.spyOn(git, 'getModifiedFiles')
+			.mockResolvedValue(['modules/burritos/foo', 'modules/burritos/bar', 'modules/burritos/baz']);
+
+		const paths = await filepaths(graph, { affected: true }, { affectedThreshold: 0 });
+		expect(paths).toEqual(['modules/burritos/foo', 'modules/burritos/bar', 'modules/burritos/baz']);
+	});
 });
 
 describe('workspaces', () => {

--- a/modules/subprocess/src/index.ts
+++ b/modules/subprocess/src/index.ts
@@ -74,7 +74,7 @@ export type RunSpec = {
  * 	name: 'Run dry',
  * 	cmd: 'echo',
  * 	args: ['"hello"'],
- * 	skipFaiolures: true,
+ * 	skipFailures: true,
  * });
  *
  * logger.error(stderr);

--- a/modules/yargs/src/yargs.ts
+++ b/modules/yargs/src/yargs.ts
@@ -235,10 +235,17 @@ export type Argv<CommandArgv = object> = Arguments<CommandArgv & DefaultArgv>;
  *
  * @group Command type aliases
  *
- * @example
+ * @example All extras are available as the second argument on your {@link Handler | `Handler`}
  * ```ts
  * export const handler: Handler = (argv, { getAffected, getFilepaths, getWorkspace, logger }) => {
  * 	logger.warn('Nothing to do!');
+ * };
+ * ```
+ *
+ * @example Overriding the affected threshold in `getFilepaths`
+ * ```ts
+ * export const handler: Handler = (argv, { getFilepaths }) => {
+ * 	const filepaths = await getFilepaths({ affectedThreshold: 0 });
  * };
  * ```
  */
@@ -253,8 +260,11 @@ export interface HandlerExtra {
 	 * Get the affected filepaths based on the current inputs and state of the repository. Respects manual inputs provided by {@link builders.withFiles | `builders.withFiles`} if provided.
 	 *
 	 * This is a wrapped implementation of {@link getters.filepaths | `getters.filepaths`} that does not require the `graph` and `argv` arguments.
+	 *
+	 * **Note:** that when used with `--affected`, there is a default limit of 100 files before this will switch to returning affected workspace paths. Use `affectedThreshold: 0` to disable the limit.
+	 *
 	 */
-	getFilepaths: (opts?: getters.GetterOptions) => Promise<Array<string>>;
+	getFilepaths: (opts?: getters.FileGetterOptions) => Promise<Array<string>>;
 	/**
 	 * Get the affected workspaces based on the current inputs and the state of the repository.
 	 * This function differs from `getAffected` in that it respects all input arguments provided by


### PR DESCRIPTION
**Problem:** When running `one eslint` by default on changes with many affected files, some obscure and unexplainable errors will be thrown.

Likely due to the number of files hitting a system limit of the number of characters a subprocess can receive as arguments, eslint gets confused with partial/broken paths and will error out.

**Solution:** Have `getFilepaths` include an `affectedThreshold`. Starting with an arbitrary number of 100 files and will consider tuning that as necessary in the future.