### PR TITLE
fix(logger): ensure logger is created/destroyed properly

### DIFF
--- a/.changeset/wild-otters-shout.md
+++ b/.changeset/wild-otters-shout.md
@@ -1,0 +1,5 @@
+---
+'@onerepo/logger': patch
+---
+
+Ensures the logger closes all timers and file descriptors.

--- a/modules/core/src/core/install/commands/__tests__/install.test.ts
+++ b/modules/core/src/core/install/commands/__tests__/install.test.ts
@@ -72,7 +72,7 @@ describe('handler', () => {
 		jest.spyOn(file, 'read').mockResolvedValue('asdfasdf');
 		jest.spyOn(os, 'platform').mockReturnValue('darwin');
 
-		await expect(run('--name tacos --force')).resolves.toBeTruthy();
+		await expect(run('--name tacos --force')).resolves.toEqual('');
 		expect(subprocess.run).not.toHaveBeenCalledWith(expect.objectContaining({ cmd: 'which', args: ['tacos'] }));
 
 		expect(subprocess.sudo).toHaveBeenCalledWith(

--- a/modules/core/src/core/install/commands/install.ts
+++ b/modules/core/src/core/install/commands/install.ts
@@ -2,7 +2,7 @@ import path from 'node:path';
 import os from 'node:os';
 import { run, sudo } from '@onerepo/subprocess';
 import * as file from '@onerepo/file';
-import { logger } from '@onerepo/logger';
+import { getLogger } from '@onerepo/logger';
 import type { Builder, Handler } from '@onerepo/yargs';
 
 export const command = 'install';
@@ -33,6 +33,7 @@ export const builder: Builder<Args> = (yargs) =>
 				'Install location for the binary. Default location is chosen as default option for usr/bin dependent on the OS type.',
 		})
 		.middleware((argv) => {
+			const logger = getLogger();
 			const { shell } = os.userInfo();
 			if (!/\/(?:zsh|bash)$/.test(shell)) {
 				logger.warn(

--- a/modules/core/src/core/tasks/commands/__tests__/tasks.test.ts
+++ b/modules/core/src/core/tasks/commands/__tests__/tasks.test.ts
@@ -53,8 +53,8 @@ describe('handler', () => {
 		await run('--lifecycle pre-commit --list', { graph });
 		expect(JSON.parse(out)).toEqual({
 			parallel: [
-				[expect.objectContaining({ cmd: expect.stringMatching(/test-runner$/), args: ['lint', '-vvvv'] })],
-				[expect.objectContaining({ cmd: expect.stringMatching(/test-runner$/), args: ['tsc', '-vvvv'] })],
+				[expect.objectContaining({ cmd: expect.stringMatching(/test-runner$/), args: ['lint', '-vv'] })],
+				[expect.objectContaining({ cmd: expect.stringMatching(/test-runner$/), args: ['tsc', '-vv'] })],
 			],
 			serial: [],
 		});
@@ -67,8 +67,8 @@ describe('handler', () => {
 		await run('--lifecycle commit --list', { graph });
 		expect(JSON.parse(out)).toEqual({
 			parallel: [
-				[expect.objectContaining({ cmd: expect.stringMatching(/test-runner$/), args: ['lint', '-vvvv'] })],
-				[expect.objectContaining({ cmd: expect.stringMatching(/test-runner$/), args: ['tsc', '-vvvv'] })],
+				[expect.objectContaining({ cmd: expect.stringMatching(/test-runner$/), args: ['lint', '-vv'] })],
+				[expect.objectContaining({ cmd: expect.stringMatching(/test-runner$/), args: ['tsc', '-vv'] })],
 			],
 			serial: [
 				[expect.objectContaining({ cmd: 'echo', args: ['"commit"'] })],

--- a/modules/core/src/index.ts
+++ b/modules/core/src/index.ts
@@ -9,6 +9,7 @@ import { globSync } from 'glob';
 import { commandDirOptions, setupYargs } from '@onerepo/yargs';
 import createYargs from 'yargs/yargs';
 import { getGraph } from '@onerepo/graph';
+import { destroyLogger } from '@onerepo/logger';
 import type { RequireDirectoryOptions, Argv as Yargv } from 'yargs';
 import type { Argv, DefaultArgv, HandlerExtra, Yargs } from '@onerepo/yargs';
 import { workspaceBuilder } from './workspaces';
@@ -180,6 +181,7 @@ export async function setup(
 		yargs,
 		run: async () => {
 			const argv = await yargs.parse();
+			destroyLogger();
 			if (!measurePerformance) {
 				return;
 			}

--- a/modules/logger/src/LogStep.ts
+++ b/modules/logger/src/LogStep.ts
@@ -180,8 +180,7 @@ export class LogStep {
 		// End the buffer, helps with memory/gc
 		// But do it after immediate otherwise the buffer may not be done flushing to stream
 		return await new Promise<void>((resolve) => {
-			setImmediate(() => {
-				this.#buffer.end();
+			this.#buffer.end(() => {
 				resolve();
 			});
 		});

--- a/modules/logger/src/Logger.ts
+++ b/modules/logger/src/Logger.ts
@@ -247,13 +247,6 @@ export class Logger {
 		clearTimeout(this.#updaterTimeout);
 		await this.#logger.end();
 		await this.#logger.flush();
-
-		// Allows flushing to complete, probably
-		return new Promise<void>((resolve) => {
-			setImmediate(() => {
-				resolve();
-			});
-		});
 	}
 
 	#activate = (step: LogStep) => {

--- a/modules/logger/src/__tests__/Logger.test.ts
+++ b/modules/logger/src/__tests__/Logger.test.ts
@@ -4,8 +4,10 @@ import { Logger } from '../Logger';
 
 async function waitStreamEnd(stream: PassThrough) {
 	return new Promise<void>((resolve) => {
-		stream.end(() => {
-			resolve();
+		setImmediate(() => {
+			stream.end(() => {
+				resolve();
+			});
 		});
 	});
 }

--- a/modules/logger/src/index.ts
+++ b/modules/logger/src/index.ts
@@ -4,20 +4,52 @@ import type { LogStep } from './LogStep';
 export * from './Logger';
 export * from './LogStep';
 
+const loggerSym = Symbol.for('onerepo-logger');
+
 /**
- * This logger is a singleton instance for use across all of oneRepo and its commands.
+ * This gets the logger singleton for use across all of oneRepo and its commands.
  *
- * Available as extras on Handler functions:
+ * Available directly as {@link !HandlerExtra | `HandlerExtra`} on {@link !Handler | `Handler`} functions:
  *
  * ```ts
  * export const handler: Handler = (argv, { logger }) => {
  * 	logger.log('Hello!');
  * };
  * ```
- *
  * @group Logger
  */
-export const logger = new Logger({ verbosity: 0 });
+export function getLogger(opts: Partial<ConstructorParameters<typeof Logger>[0]> = {}): Logger {
+	// @ts-ignore
+	if (!global[loggerSym]) {
+		// @ts-ignore
+		global[loggerSym] = new Logger({ verbosity: 0, ...opts });
+	}
+
+	const logger = // @ts-ignore
+		global[loggerSym] as Logger;
+
+	if (opts.verbosity) {
+		logger.verbosity = opts.verbosity;
+	}
+	if (opts.stream) {
+		logger.stream = opts.stream;
+	}
+
+	return logger;
+}
+
+/**
+ * @internal
+ */
+export function destroyLogger() {
+	if (!(loggerSym in global)) {
+		return;
+	}
+	// @ts-ignore
+	global[loggerSym] = null;
+	// @ts-ignore
+	delete global[loggerSym];
+}
 
 /**
  * For cases where multiple processes need to be completed, but should be joined under a single {@link LogStep | `LogStep`} to avoid too much noisy output, this safely wraps an asynchronous function and handles step creation and completion, unless a `step` override is given.
@@ -42,7 +74,7 @@ export async function stepWrapper<T>(
 	fn: (step: LogStep) => Promise<T>
 ): Promise<T> {
 	const { name, step: inputStep } = options;
-	const step = inputStep ?? logger.createStep(name);
+	const step = inputStep ?? getLogger().createStep(name);
 
 	const out = await fn(step);
 

--- a/modules/subprocess/src/index.ts
+++ b/modules/subprocess/src/index.ts
@@ -3,8 +3,10 @@ import { exec, execSync, spawn } from 'node:child_process';
 import os from 'node:os';
 import { Transform } from 'node:stream';
 import type { ChildProcess, SpawnOptions } from 'node:child_process';
-import { logger } from '@onerepo/logger';
+import { getLogger } from '@onerepo/logger';
 import type { LogStep } from '@onerepo/logger';
+
+const logger = getLogger();
 
 /**
  * The core configuration for {@link run | `run`}, {@link start | `start`}, {@link sudo | `sudo`}, and {@link batch | `batch`} subprocessing.

--- a/modules/test-cli/src/index.ts
+++ b/modules/test-cli/src/index.ts
@@ -6,7 +6,7 @@ import parser from 'yargs-parser';
 import unparser from 'yargs-unparser';
 import { getters } from '@onerepo/builders';
 import { parserConfiguration, setupYargs } from '@onerepo/yargs';
-import { logger as rootLogger, Logger } from '@onerepo/logger';
+import { destroyLogger, getLogger } from '@onerepo/logger';
 import { getGraph } from '@onerepo/graph';
 import type { MiddlewareFunction } from 'yargs';
 import type { Argv, Builder, Handler, HandlerExtra } from '@onerepo/yargs';
@@ -90,9 +90,8 @@ export async function runHandler<R = Record<string, unknown>>(
 	stream.on('data', (chunk) => {
 		out += chunk.toString();
 	});
-	rootLogger.verbosity = 0;
-	rootLogger.stream = stream;
-	const logger = new Logger({ stream, verbosity: 4 });
+	destroyLogger();
+	const logger = getLogger({ verbosity: 0, stream });
 
 	const { graph = getGraph(path.join(dirname, 'fixtures', 'repo')) } = extras;
 	const argv = await runBuilder(builder, cmd);
@@ -118,10 +117,12 @@ export async function runHandler<R = Record<string, unknown>>(
 
 	await logger.end();
 
-	if (logger.hasError || rootLogger.hasError || error) {
+	if (logger.hasError || error) {
+		destroyLogger();
 		return Promise.reject(out || error);
 	}
 
+	destroyLogger();
 	return out;
 }
 

--- a/modules/yargs/src/middleware/environment.ts
+++ b/modules/yargs/src/middleware/environment.ts
@@ -1,9 +1,9 @@
-import { logger } from '@onerepo/logger';
+import { getLogger } from '@onerepo/logger';
 import type { Argv } from '@onerepo/yargs';
 
 export function setEnvironmentMiddleware(argv: Omit<Argv, '--'>) {
 	process.env.ONE_REPO_DRY_RUN = `${argv['dry-run']}`;
 	argv.verbosity = argv.silent ? 0 : argv.verbosity;
 	process.env.ONE_REPO_VERBOSITY = `${argv.verbosity}`;
-	logger.verbosity = argv.verbosity;
+	getLogger().verbosity = argv.verbosity;
 }

--- a/modules/yargs/src/middleware/sudo-check.ts
+++ b/modules/yargs/src/middleware/sudo-check.ts
@@ -1,4 +1,4 @@
-import { logger } from '@onerepo/logger';
+import { getLogger } from '@onerepo/logger';
 import type { Argv } from 'yargs';
 
 export const sudoCheckMiddleware = (yargs: Argv) =>
@@ -7,7 +7,7 @@ export const sudoCheckMiddleware = (yargs: Argv) =>
 			yargs.showHelp();
 			const msg =
 				'Do not run commands with `sudo`! If elevated permissions are required, commands will prompt you for your password only if and when necessary.';
-			logger.error(msg);
+			getLogger().error(msg);
 			yargs.exit(1, new Error(msg));
 		}
 	};

--- a/modules/yargs/src/yargs.ts
+++ b/modules/yargs/src/yargs.ts
@@ -1,5 +1,5 @@
 import { performance } from 'node:perf_hooks';
-import { logger } from '@onerepo/logger';
+import { getLogger } from '@onerepo/logger';
 import { BatchError, SubprocessError } from '@onerepo/subprocess';
 import { getters } from '@onerepo/builders';
 import type { Logger } from '@onerepo/logger';
@@ -98,6 +98,8 @@ export const commandDirOptions = ({
 			description,
 			...rest,
 			handler: async (argv: Arguments<DefaultArgv>) => {
+				const logger = getLogger();
+
 				performance.mark(`onerepo_start_Handler: ${command}`);
 				logger.debug(`Resolved CLI arguments:
 ${JSON.stringify(argv, null, 2)}`);
@@ -135,6 +137,7 @@ ${JSON.stringify(argv, null, 2)}`);
 						logger.error(err);
 					} else if (err && !(err instanceof SubprocessError)) {
 						logger.error(err);
+						throw err;
 					}
 
 					process.exitCode = 1;
@@ -149,11 +152,6 @@ ${JSON.stringify(argv, null, 2)}`);
 				logger.timing(`onerepo_start_Handler: ${command}`, `onerepo_end_Handler: ${command}`);
 
 				await logger.end();
-				await new Promise<void>((resolve) => {
-					setTimeout(() => {
-						resolve();
-					}, 1);
-				});
 
 				if (logger.hasError) {
 					process.exitCode = 1;


### PR DESCRIPTION
**Problem:** The logger was leaving behind open file descriptors, preventing node from exiting cleanly without explicitly calling `process.exit()`

**Solution:** This was on the list anyway… Removes the `logger` singleton in favor of a getter method, `getLogger()` that more strictly sets the singleton to the global object. On teardown, we explicitly call the internal method `destroyLogger()`