### PR TITLE
fix(eslint-formatter): fix build

### DIFF
--- a/.changeset/flat-boxes-allow.md
+++ b/.changeset/flat-boxes-allow.md
@@ -1,0 +1,6 @@
+---
+'eslint-formatter-onerepo': patch
+'@onerepo/plugin-eslint': patch
+---
+
+Fixes an issue with the ESLint plugin that caused it to never error. Internally, this fixes the build/distribution of `eslint-formatter-onerepo` to build as commonjs instead of esm, since eslint cannot do esm.

--- a/commands/build.ts
+++ b/commands/build.ts
@@ -91,7 +91,7 @@ export const handler: Handler<Args> = async function handler(argv, { getWorkspac
 					'--packages=external',
 					`--outdir=${workspace.resolve('dist')}`,
 					'--platform=node',
-					'--format=esm',
+					`--format=${'type' in workspace.packageJson && workspace.packageJson.type === 'module' ? 'esm' : 'cjs'}`,
 				],
 			});
 


### PR DESCRIPTION
This is the rogue package that _must_ be built & published as commonjs, because ESLint only uses commonjs.

Fixes build to check for package.json "type" field and uses that