### PR TITLE
refactor(core): remove implied pre- and post- lifecycles

### DIFF
--- a/.changeset/new-chicken-wink.md
+++ b/.changeset/new-chicken-wink.md
@@ -1,0 +1,5 @@
+---
+'@onerepo/core': minor
+---
+
+Removed implicit `pre-` and `post-` lifecycles for all non-prefixed lifecycles. No longer with running `--lifecycle=commit` auto run `pre-commit`, `commit`, and `post-commit` sequentially. If this behavior is still needed, change your task configurations to use the [sequential tasks](https://onerepo.tools/docs/core/tasks/#sequential-tasks) format.

--- a/commands/__tests__/__fixtures__/build/modules/burritos/package.json
+++ b/commands/__tests__/__fixtures__/build/modules/burritos/package.json
@@ -1,5 +1,6 @@
 {
 	"name": "burritos",
 	"main": "./src/index.ts",
+	"type": "module",
 	"version": "4.5.2"
 }

--- a/commands/__tests__/__fixtures__/build/modules/churros/package.json
+++ b/commands/__tests__/__fixtures__/build/modules/churros/package.json
@@ -1,5 +1,6 @@
 {
 	"name": "churros",
 	"main": "./src/index.ts",
+	"type": "module",
 	"version": "1.2.3"
 }

--- a/commands/__tests__/__fixtures__/build/modules/tacos/package.json
+++ b/commands/__tests__/__fixtures__/build/modules/tacos/package.json
@@ -1,5 +1,6 @@
 {
 	"name": "tacos",
 	"main": "./src/index.ts",
+	"type": "module",
 	"version": "1.2.3"
 }

--- a/commands/__tests__/build.test.ts
+++ b/commands/__tests__/build.test.ts
@@ -63,6 +63,17 @@ describe('handler', () => {
 						'--format=esm',
 					],
 				}),
+				expect.objectContaining({
+					cmd: 'esbuild',
+					args: [
+						expect.stringMatching(/build\/modules\/tacos\/src\/index\.ts$/),
+						'--bundle',
+						'--packages=external',
+						expect.stringMatching(/build\/modules\/tacos\/dist$/),
+						'--platform=node',
+						'--format=esm',
+					],
+				}),
 			]),
 		);
 	});

--- a/modules/core/src/core/tasks/README.md
+++ b/modules/core/src/core/tasks/README.md
@@ -135,7 +135,7 @@ setup({
 }).then(({ run }) => run());
 ```
 
-Now, in any of your `onerepo.config.js` files, you will have the ability to run tasks for `tacos`, `burritos`, and any variant of those with `pre-` or `post-` prefixes.
+Now, in any of your `onerepo.config.js` files, you will have the ability to run tasks for `tacos` and `burritos`.
 
 ```sh
 one tasks -c pre-tacos

--- a/modules/core/src/core/tasks/commands/__tests__/__fixtures__/repo/onerepo.config.js
+++ b/modules/core/src/core/tasks/commands/__tests__/__fixtures__/repo/onerepo.config.js
@@ -1,7 +1,6 @@
 /** @type import('onerepo').graph.TaskConfig */
 module.exports = {
 	'pre-commit': { parallel: ['$0 lint', '$0 tsc'] },
-	commit: { serial: ['echo "commit"'] },
 	'post-commit': { serial: ['echo "post-commit"'] },
 	build: { serial: [{ match: '**/foo.json', cmd: 'build' }] },
 	deploy: { parallel: ['echo "deployroot"'] },

--- a/modules/core/src/core/tasks/commands/__tests__/tasks.test.ts
+++ b/modules/core/src/core/tasks/commands/__tests__/tasks.test.ts
@@ -14,12 +14,12 @@ describe('builder', () => {
 	});
 
 	test('succeeds with --lifecycle', async () => {
-		await expect(build('--lifecycle commit')).resolves.toMatchObject({ lifecycle: 'commit' });
-		await expect(build('--lifecycle pre-build')).resolves.toMatchObject({ lifecycle: 'pre-build' });
+		await expect(build('--lifecycle pre-commit')).resolves.toMatchObject({ lifecycle: 'pre-commit' });
+		await expect(build('--lifecycle build')).resolves.toMatchObject({ lifecycle: 'build' });
 	});
 
 	test('-c is an alias for --lifecycle', async () => {
-		await expect(build('-c pre-build')).resolves.toMatchObject({ lifecycle: 'pre-build' });
+		await expect(build('-c build')).resolves.toMatchObject({ lifecycle: 'build' });
 	});
 
 	test('includes other options', async () => {
@@ -46,7 +46,7 @@ describe('handler', () => {
 		out = '';
 	});
 
-	test('lists tasks for pre- prefix only', async () => {
+	test('lists tasks for the given lifecycle', async () => {
 		jest.spyOn(git, 'getModifiedFiles').mockResolvedValue(['modules/burritos/src/index.ts']);
 		const graph = getGraph(path.join(__dirname, '__fixtures__', 'repo'));
 
@@ -57,29 +57,6 @@ describe('handler', () => {
 				[expect.objectContaining({ cmd: expect.stringMatching(/test-runner$/), args: ['tsc', '-vv'] })],
 			],
 			serial: [],
-		});
-	});
-
-	test('lists tasks for all pre-, normal, and post-', async () => {
-		jest.spyOn(git, 'getModifiedFiles').mockResolvedValue(['modules/burritos/src/index.ts']);
-		const graph = getGraph(path.join(__dirname, '__fixtures__', 'repo'));
-
-		await run('--lifecycle commit --list', { graph });
-		expect(JSON.parse(out)).toEqual({
-			parallel: [
-				[expect.objectContaining({ cmd: expect.stringMatching(/test-runner$/), args: ['lint', '-vv'] })],
-				[expect.objectContaining({ cmd: expect.stringMatching(/test-runner$/), args: ['tsc', '-vv'] })],
-			],
-			serial: [
-				[expect.objectContaining({ cmd: 'echo', args: ['"commit"'] })],
-				[
-					expect.objectContaining({
-						cmd: 'echo',
-						args: ['"post-commit"'],
-						opts: { cwd: '.' },
-					}),
-				],
-			],
 		});
 	});
 
@@ -107,7 +84,7 @@ describe('handler', () => {
 		jest.spyOn(git, 'getModifiedFiles').mockResolvedValue(['modules/tacos/src/index.ts']);
 		const graph = getGraph(path.join(__dirname, '__fixtures__', 'repo'));
 
-		await run('-c commit --list --ignore "modules/tacos/**/*"', { graph });
+		await run('-c pre-commit --list --ignore "modules/tacos/**/*"', { graph });
 
 		expect(JSON.parse(out)).toEqual({ parallel: [], serial: [] });
 	});

--- a/modules/graph/src/Workspace.ts
+++ b/modules/graph/src/Workspace.ts
@@ -274,20 +274,17 @@ export type Tasks = {
 /**
  * @group Tasks
  */
-export type StandardLifecycles = 'commit' | 'checkout' | 'merge' | 'build' | 'deploy' | 'publish';
-
-/**
- * Adds `pre-` and `post-` prefixes to any literal {@link Lifecycle | `Lifecycle`}
- * @group Tasks
- */
-export type MakeLifecycles<T extends string> = `pre-${T}` | T | `post-${T}`;
-
-/**
- * @group Tasks
- */
-export type Lifecycle = MakeLifecycles<StandardLifecycles>;
+export type Lifecycle =
+	| 'pre-commit'
+	| 'post-commit'
+	| 'post-checkout'
+	| 'pre-merge'
+	| 'post-merge'
+	| 'build'
+	| 'deploy'
+	| 'publish';
 
 /**
  * @group Tasks
  */
-export type TaskConfig<L extends string = never> = Partial<Record<Lifecycle | MakeLifecycles<L>, Tasks>>;
+export type TaskConfig<L extends string = never> = Partial<Record<Lifecycle | L, Tasks>>;


### PR DESCRIPTION
**Problem:** Since the inclusion of true sequential tasks, the auto `pre-` and `post-` prefixing for task lifecycles has been unnecessary and generally discouraged. There are no strong arguments for being able to run explicit `pre-` and `post-` lifecycles separately, when they are also automatically run with the non-prefixed (eg `pre-commit`, `commit`, `post-commit` would be run automatically for `--lifecycle=commit`). This was also poorly documented and difficult to explain.

**Solution:** Drop the code for this entirely. Reduce the included lifecycles.