### PR TITLE
fix(eslint): fail when eslint reports stderr

### DIFF
--- a/.changeset/thin-panthers-destroy.md
+++ b/.changeset/thin-panthers-destroy.md
@@ -1,0 +1,5 @@
+---
+'@onerepo/plugin-eslint': patch
+---
+
+Properly fails eslint in the event of eslint having configuration or internal problems.

--- a/plugins/eslint/src/commands/__tests__/eslint.test.ts
+++ b/plugins/eslint/src/commands/__tests__/eslint.test.ts
@@ -298,4 +298,10 @@ something
 		expect(process.stdout.write).toHaveBeenCalledWith('::error burritos\n::warning tacos');
 		expect(process.stdout.write).toHaveBeenCalledWith('\n');
 	});
+
+	test('if eslint returns with any stderr, the command will fail', async () => {
+		jest.spyOn(subprocess, 'run').mockResolvedValue(['', 'oh no!']);
+
+		await expect(run('-a')).rejects.toMatch('oh no!');
+	});
 });

--- a/plugins/eslint/src/commands/eslint.ts
+++ b/plugins/eslint/src/commands/eslint.ts
@@ -132,7 +132,7 @@ export const handler: Handler<Args> = async function handler(argv, { getFilepath
 	}
 
 	const runStep = logger.createStep('Lint files');
-	const [out] = await run({
+	const [out, err] = await run({
 		name: `Lint ${all ? '' : filteredPaths.join(', ').substring(0, 40)}…`,
 		cmd: 'npx',
 		args: [...args, ...(all ? ['.'] : filteredPaths), ...passthrough],
@@ -153,6 +153,12 @@ export const handler: Handler<Args> = async function handler(argv, { getFilepath
 
 		runStep.error(out.replace(/^::.*$/gm, ''));
 	}
+
+	// If eslint has an internal or config problem, it logs to stderr, not stdout
+	if (err) {
+		runStep.error(err);
+	}
+
 	await runStep.end();
 
 	if (add && filteredPaths.length) {


### PR DESCRIPTION
**Problem:** If an eslint configuration has a problem (eg, missing referenced plugin), eslint will respond with no stdout, but some stderr.

**Solution:** Ensure that's watched for, caught, and reported as an error.