### PR TITLE
fix(package-manager): recover from json parsing in publishable check

### DIFF
--- a/.changeset/early-pandas-push.md
+++ b/.changeset/early-pandas-push.md
@@ -1,0 +1,7 @@
+---
+'onerepo': patch
+'@onerepo/package-manager': patch
+'@onerepo/plugin-changesets': patch
+---
+
+Attempt to recover from JSON parsing issues when determining publishable modules.

--- a/modules/package-manager/src/__tests__/npm.test.ts
+++ b/modules/package-manager/src/__tests__/npm.test.ts
@@ -212,6 +212,32 @@ describe('NPM', () => {
 
 			expect(publishable).toEqual([{ name: 'burritos', version: '4.5.6' }]);
 		});
+
+		test('does not fail for unparseable json', async () => {
+			jest.spyOn(subprocess, 'batch').mockImplementation((calls) => {
+				return Promise.resolve(
+					calls.map(({ args }) => {
+						const versions: Array<string> = [];
+						if (args?.includes('tacos')) {
+							return ['', ''];
+						} else if (args?.includes('burritos')) {
+							return ['LOL', ''];
+						}
+
+						return [JSON.stringify({ name: args![2]!, versions }), ''];
+					}) as Array<[string, string]>,
+				);
+			});
+			const publishable = await manager.publishable([
+				{ name: 'tacos', version: '1.2.5' },
+				{ name: 'burritos', version: '4.5.6' },
+			]);
+
+			expect(publishable).toEqual([
+				{ name: 'tacos', version: '1.2.5' },
+				{ name: 'burritos', version: '4.5.6' },
+			]);
+		});
 	});
 
 	describe('remove', () => {

--- a/modules/package-manager/src/__tests__/pnpm.test.ts
+++ b/modules/package-manager/src/__tests__/pnpm.test.ts
@@ -212,6 +212,32 @@ describe('PNPm', () => {
 
 			expect(publishable).toEqual([{ name: 'burritos', version: '4.5.6' }]);
 		});
+
+		test('does not fail for unparseable json', async () => {
+			jest.spyOn(subprocess, 'batch').mockImplementation((calls) => {
+				return Promise.resolve(
+					calls.map(({ args }) => {
+						const versions: Array<string> = [];
+						if (args?.includes('tacos')) {
+							return ['', ''];
+						} else if (args?.includes('burritos')) {
+							return ['LOL', ''];
+						}
+
+						return [JSON.stringify({ name: args![2]!, versions }), ''];
+					}) as Array<[string, string]>,
+				);
+			});
+			const publishable = await manager.publishable([
+				{ name: 'tacos', version: '1.2.5' },
+				{ name: 'burritos', version: '4.5.6' },
+			]);
+
+			expect(publishable).toEqual([
+				{ name: 'tacos', version: '1.2.5' },
+				{ name: 'burritos', version: '4.5.6' },
+			]);
+		});
 	});
 
 	describe('remove', () => {

--- a/modules/package-manager/src/npm.ts
+++ b/modules/package-manager/src/npm.ts
@@ -72,10 +72,14 @@ export const Npm = {
 			if (res instanceof Error || res[1]) {
 				continue;
 			}
-			const { name, versions } = JSON.parse(res[0]);
-			const ws = workspaces.find((ws) => ws.name === name);
-			if (ws && ws.version && versions.includes(ws.version)) {
-				publishable.delete(ws);
+			try {
+				const { name, versions } = JSON.parse(res[0]);
+				const ws = workspaces.find((ws) => ws.name === name);
+				if (ws && ws.version && versions.includes(ws.version)) {
+					publishable.delete(ws);
+				}
+			} catch (e) {
+				// no catch
 			}
 		}
 

--- a/modules/package-manager/src/pnpm.ts
+++ b/modules/package-manager/src/pnpm.ts
@@ -73,10 +73,14 @@ export const Pnpm = {
 			if (res instanceof Error || res[1]) {
 				continue;
 			}
-			const { name, versions } = JSON.parse(res[0]);
-			const ws = workspaces.find((ws) => ws.name === name);
-			if (ws && ws.version && versions.includes(ws.version)) {
-				publishable.delete(ws);
+			try {
+				const { name, versions } = JSON.parse(res[0]);
+				const ws = workspaces.find((ws) => ws.name === name);
+				if (ws && ws.version && versions.includes(ws.version)) {
+					publishable.delete(ws);
+				}
+			} catch (e) {
+				// no catch
 			}
 		}
 

--- a/modules/package-manager/src/yarn.ts
+++ b/modules/package-manager/src/yarn.ts
@@ -48,15 +48,15 @@ export const Yarn = {
 			await run({
 				name: 'Publish',
 				cmd: 'yarn',
-				args: ['npm', 'publish', ...options],
-				opts: cwd ? { cwd: cwd } : {},
+				args: ['npm', 'publish', '--tolerate-republish', ...options],
+				opts: cwd ? { cwd } : {},
 			});
 		} else {
 			await batch(
 				workspaces.map((ws) => ({
 					name: `Publish ${ws.name}`,
 					cmd: 'yarn',
-					args: ['npm', 'publish', ...options],
+					args: ['npm', 'publish', '--tolerate-republish', ...options],
 					opts: { cwd: ws.location },
 				})),
 			);
@@ -81,10 +81,14 @@ export const Yarn = {
 			if (res instanceof Error || res[1] || res[0].includes('\n')) {
 				continue;
 			}
-			const { name, versions } = JSON.parse(res[0]);
-			const ws = workspaces.find((ws) => ws.name === name);
-			if (ws && ws.version && versions.includes(ws.version)) {
-				publishable.delete(ws);
+			try {
+				const { name, versions } = JSON.parse(res[0]);
+				const ws = workspaces.find((ws) => ws.name === name);
+				if (ws && ws.version && versions.includes(ws.version)) {
+					publishable.delete(ws);
+				}
+			} catch (e) {
+				// no catch
 			}
 		}
 


### PR DESCRIPTION
**Problem:** Seeing reports of some registries (nexus in particular) responding with no output when getting package info (npm info/yarn npm info) to determine publishable modules.

**Solution:** Assume this means the package might need publishing. NOTE: this is not really correct to assume, but the only other options would be to continue requesting info until it comes back clean, which is not exactly great either.