### PR TITLE
fix(file): fix default export for prettier 2 in format

### DIFF
--- a/.changeset/unlucky-seahorses-confess.md
+++ b/.changeset/unlucky-seahorses-confess.md
@@ -1,0 +1,6 @@
+---
+'@onerepo/file': patch
+'onerepo': patch
+---
+
+Fixed file `write`, `writeSafe`, and `format` when using prettier@2 in which prettier formatting would not be run at all.

--- a/modules/file/src/index.ts
+++ b/modules/file/src/index.ts
@@ -223,6 +223,9 @@ async function format(filename: string, contents: string, { step }: Options = {}
 		let prettier;
 		try {
 			prettier = await import('prettier');
+			if ('default' in prettier) {
+				prettier = prettier.default;
+			}
 		} catch (e) {
 			return contents;
 		}


### PR DESCRIPTION
**Problem:**

When using Prettier v2, file formatting was broken due to support for Prettier v3, which was rewritten to use ESM exports instead of CJS `defaults`.

**Solution:**

if `default` in the prettier import, use that, otherwise continue to use the v3 api