### PR TITLE
feat(package-manager): run and batch using npm exec-like methods

### DIFF
--- a/.changeset/chilled-zebras-serve.md
+++ b/.changeset/chilled-zebras-serve.md
@@ -1,0 +1,8 @@
+---
+'@onerepo/core': minor
+'@onerepo/graph': minor
+'@onerepo/package-manager': minor
+'onerepo': minor
+---
+
+Added `packageManager.batch` for batching third party module bins, similar to `npm exec`.

--- a/.changeset/empty-wasps-jog.md
+++ b/.changeset/empty-wasps-jog.md
@@ -1,0 +1,7 @@
+---
+'@onerepo/package-manager': minor
+'onerepo': minor
+'@onerepo/graph': minor
+---
+
+Added `packageManager.run` for running third party module bins, similar to `npm exec`.

--- a/.changeset/nervous-goats-cheat.md
+++ b/.changeset/nervous-goats-cheat.md
@@ -1,0 +1,5 @@
+---
+'@onerepo/plugin-typescript': patch
+---
+
+Respect the `tsconfig` option when looking up workspaces to check.

--- a/.changeset/silent-pianos-double.md
+++ b/.changeset/silent-pianos-double.md
@@ -1,0 +1,8 @@
+---
+'@onerepo/plugin-eslint': patch
+'@onerepo/plugin-prettier': patch
+'@onerepo/plugin-typescript': patch
+'@onerepo/plugin-changesets': patch
+---
+
+Made running third-party executables more resilient to package manager exclusions.

--- a/docs/commands/start.ts
+++ b/docs/commands/start.ts
@@ -28,10 +28,10 @@ export const handler: Handler = async (argv, { graph }) => {
 		},
 	});
 
-	await run({
+	await graph.packageManager.run({
 		name: 'Run astro',
-		cmd: 'npx',
-		args: ['netlify', 'dev'],
+		cmd: 'netlify',
+		args: ['dev'],
 		opts: {
 			cwd: ws.location,
 			stdio: 'inherit',

--- a/docs/src/content/docs/custom-commands.md
+++ b/docs/src/content/docs/custom-commands.md
@@ -102,6 +102,8 @@ export const handler: Handler = async (argv, { logger }) => {
 
 oneRepo includes advanced child process spawning via the [`run`](/docs/core/api/#run) and [`batch`](/docs/core/api/#batch) functions. These async functions work like Node.js [`child_process.spawn`](https://nodejs.org/docs/latest-v18.x/api/child_process.html#child_processspawncommand-args-options), but are promise-based asynchronous functions that handle redirecting and buffering output as well as failure tracking for you. These should be used in favor of the direct Node.js builtins.
 
+If the command you're trying to run is installed by a third party node module through your package manager (NPM, Yarn, or pNPM), you are encouraged to use [`graph.packageManager.run`](/docs/core/api/#packagemanager) and [`graph.packageManager.batch`](/docs/core/api/#packagemanager) functions. These will determine the correct install path to the executable and avoid potential issues across package manager install locations.
+
 ### Run single processes
 
 ```ts

--- a/modules/core/src/core/install/commands/__tests__/install.test.ts
+++ b/modules/core/src/core/install/commands/__tests__/install.test.ts
@@ -8,7 +8,7 @@ import * as Tasks from '../install';
 jest.mock('@onerepo/subprocess');
 jest.mock('@onerepo/file');
 
-const { build, run } = getCommand(Tasks);
+const { build, graph, run } = getCommand(Tasks);
 
 describe('builder', () => {
 	test('defaults verbosity to show warnings', async () => {
@@ -91,6 +91,7 @@ describe('handler', () => {
 
 	test('runs husky install husky is found', async () => {
 		jest.spyOn(subprocess, 'run').mockResolvedValue(['', '']);
+		jest.spyOn(graph.packageManager, 'run').mockResolvedValue(['', '']);
 		jest.spyOn(subprocess, 'sudo').mockResolvedValue(['', '']);
 		jest.spyOn(child_process, 'execSync').mockImplementation(() => '');
 		jest.spyOn(file, 'writeSafe').mockResolvedValue();
@@ -99,16 +100,17 @@ describe('handler', () => {
 		jest.spyOn(file, 'exists').mockResolvedValue(true);
 		await expect(run('--name tacos')).resolves.toBeTruthy();
 
-		expect(subprocess.run).toHaveBeenCalledWith(
+		expect(graph.packageManager.run).toHaveBeenCalledWith(
 			expect.objectContaining({
-				cmd: 'npx',
-				args: ['husky', 'install'],
+				cmd: 'husky',
+				args: ['install'],
 			}),
 		);
 	});
 
 	test('does not run husky install husky is NOT found', async () => {
 		jest.spyOn(subprocess, 'run').mockResolvedValue(['', '']);
+		jest.spyOn(graph.packageManager, 'run').mockResolvedValue(['', '']);
 		jest.spyOn(subprocess, 'sudo').mockResolvedValue(['', '']);
 		jest.spyOn(child_process, 'execSync').mockImplementation(() => '');
 		jest.spyOn(file, 'writeSafe').mockResolvedValue();
@@ -117,10 +119,10 @@ describe('handler', () => {
 		jest.spyOn(file, 'exists').mockResolvedValue(false);
 		await expect(run('--name tacos')).resolves.toBeTruthy();
 
-		expect(subprocess.run).not.toHaveBeenCalledWith(
+		expect(graph.packageManager.run).not.toHaveBeenCalledWith(
 			expect.objectContaining({
-				cmd: 'npx',
-				args: ['husky', 'install'],
+				cmd: 'husky',
+				args: ['install'],
 			}),
 		);
 	});

--- a/modules/core/src/core/install/commands/install.ts
+++ b/modules/core/src/core/install/commands/install.ts
@@ -123,10 +123,10 @@ export const handler: Handler<Args> = async function handler(argv, { graph, logg
 	});
 
 	if (await file.exists(graph.root.resolve('.husky'))) {
-		await run({
+		await graph.packageManager.run({
 			name: 'Install git hooks',
-			cmd: 'npx',
-			args: ['husky', 'install'],
+			cmd: 'husky',
+			args: ['install'],
 		});
 	}
 };

--- a/modules/package-manager/src/methods.ts
+++ b/modules/package-manager/src/methods.ts
@@ -1,3 +1,5 @@
+import type { RunSpec } from '@onerepo/subprocess';
+
 /**
  * Implementation details for all package managers. This interface defines a subset of common methods typically needed when interacting with a monorepo and its dependency {@link graph.Graph | `graph.Graph`} & {@link graph.Workspace | `graph.Workspace`}s.
  *
@@ -19,10 +21,24 @@ export interface PackageManager {
 			dev?: boolean;
 		},
 	): Promise<void>;
+
+	/**
+	 * Batch commands from npm packages as a batch of subprocesses using the package manager. Alternative to batching with `npm exec` and compatible APIs.
+	 * @see {@link batch | `batch`} for general subprocess batching.
+	 */
+	batch(processes: Array<RunSpec>): Promise<Array<[string, string] | Error>>;
+
+	/**
+	 * Run a command from an npm package as a subprocess using the package manager. Alternative to `npm exec` and compatible APIs.
+	 * @see {@link batch | `batch`} for general subprocess running.
+	 */
+	run(opts: RunSpec): Promise<[string, string]>;
+
 	/**
 	 * Install current dependencies as listed in the package manager's lock file
 	 */
 	install(cwd?: string): Promise<string>;
+
 	/**
 	 * Check if the current user is logged in to the external registry
 	 */
@@ -36,11 +52,13 @@ export interface PackageManager {
 		 */
 		registry?: string;
 	}): Promise<boolean>;
+
 	/**
 	 * Filter workspaces to the set of those that are actually publishable. This will check both whether the package is not marked as "private" and if the current version is not in the external registry.
 	 * @param workspaces List of compatible {@link graph.Workspace | `graph.Workspace`} objects.
 	 */
 	publishable<T extends MinimalWorkspace>(workspaces: Array<T>): Promise<Array<T>>;
+
 	/**
 	 * Publish workspaces to the external registry
 	 */
@@ -68,6 +86,7 @@ export interface PackageManager {
 		 */
 		tag?: string;
 	}): Promise<void>;
+
 	/**
 	 * Remove one or more packages.
 	 * @param packages One or more packages, by name

--- a/modules/package-manager/src/npm.ts
+++ b/modules/package-manager/src/npm.ts
@@ -11,6 +11,16 @@ export const Npm = {
 		});
 	},
 
+	batch: async (processes) => {
+		return batch(
+			processes.map((proc) => ({
+				...proc,
+				cmd: 'npm',
+				args: ['exec', proc.cmd, ...(proc.args ?? [])],
+			})),
+		);
+	},
+
 	install: async (cwd?: string) => {
 		await run({
 			name: 'Install dependencies',
@@ -92,6 +102,14 @@ export const Npm = {
 			name: 'Remove packages',
 			cmd: 'npm',
 			args: ['uninstall', ...pkgs],
+		});
+	},
+
+	run: async (opts) => {
+		return await run({
+			...opts,
+			cmd: 'npm',
+			args: ['exec', opts.cmd, ...(opts.args ?? [])],
 		});
 	},
 } satisfies PackageManager;

--- a/modules/package-manager/src/pnpm.ts
+++ b/modules/package-manager/src/pnpm.ts
@@ -11,6 +11,16 @@ export const Pnpm = {
 		});
 	},
 
+	batch: async (processes) => {
+		return batch(
+			processes.map((proc) => ({
+				...proc,
+				cmd: 'pnpm',
+				args: ['exec', proc.cmd, ...(proc.args ?? [])],
+			})),
+		);
+	},
+
 	install: async (cwd?: string) => {
 		await run({
 			name: 'Install dependencies',
@@ -93,6 +103,14 @@ export const Pnpm = {
 			name: 'Remove packages',
 			cmd: 'pnpm',
 			args: ['remove', ...pkgs],
+		});
+	},
+
+	run: async (opts) => {
+		return await run({
+			...opts,
+			cmd: 'pnpm',
+			args: ['exec', opts.cmd, ...(opts.args ?? [])],
 		});
 	},
 } satisfies PackageManager;

--- a/modules/package-manager/src/yarn.ts
+++ b/modules/package-manager/src/yarn.ts
@@ -11,6 +11,16 @@ export const Yarn = {
 		});
 	},
 
+	batch: async (processes) => {
+		return batch(
+			processes.map((proc) => ({
+				...proc,
+				cmd: 'yarn',
+				args: ['exec', proc.cmd, ...(proc.args ?? [])],
+			})),
+		);
+	},
+
 	install: async (cwd?: string) => {
 		await run({
 			name: 'Install dependencies',
@@ -101,6 +111,14 @@ export const Yarn = {
 			name: 'Remove packages',
 			cmd: 'yarn',
 			args: ['remove', ...pkgs],
+		});
+	},
+
+	run: async (opts) => {
+		return await run({
+			...opts,
+			cmd: 'yarn',
+			args: ['exec', opts.cmd, ...(opts.args ?? [])],
 		});
 	},
 } satisfies PackageManager;

--- a/modules/subprocess/src/index.ts
+++ b/modules/subprocess/src/index.ts
@@ -98,6 +98,7 @@ export type RunSpec = {
  * @group Subprocess
  * @return A promise with an array of `[stdout, stderr]`, as captured from the command run.
  * @throws {@link SubprocessError | `SubprocessError`} if not `skipFailures` and the spawned process does not exit cleanly (with code `0`)
+ * @see {@link PackageManager.run | `PackageManager.run`} to safely run executables exposed from third party modules.
  */
 export async function run(options: RunSpec): Promise<[string, string]> {
 	return new Promise((resolve, reject) => {
@@ -320,6 +321,7 @@ export async function sudo(options: Omit<RunSpec, 'opts'> & { reason?: string })
  *
  * @group Subprocess
  * @throws {@link BatchError | `BatchError`} An object that includes a list of all of the {@link SubprocessError | `SubprocessError`}s thrown.
+ * @see {@link PackageManager.batch | `PackageManager.batch`} to safely batch executables exposed from third party modules.
  */
 export async function batch(processes: Array<RunSpec>): Promise<Array<[string, string] | Error>> {
 	const results: Array<[string, string] | Error> = [];

--- a/plugins/changesets/src/commands/__tests__/init.test.ts
+++ b/plugins/changesets/src/commands/__tests__/init.test.ts
@@ -1,21 +1,19 @@
 import path from 'node:path';
 import { getGraph } from '@onerepo/graph';
 import * as file from '@onerepo/file';
-import * as subprocess from '@onerepo/subprocess';
 import { getCommand } from '@onerepo/test-cli';
 import * as Init from '../init';
 
-jest.mock('@onerepo/subprocess');
 jest.mock('@onerepo/file', () => ({
 	__esModule: true,
 	...jest.requireActual('@onerepo/file'),
 }));
 
-const { run } = getCommand(Init);
+const { graph, run } = getCommand(Init);
 
 describe('handler', () => {
 	beforeEach(async () => {
-		jest.spyOn(subprocess, 'run').mockResolvedValue(['', '']);
+		jest.spyOn(graph.packageManager, 'run').mockResolvedValue(['', '']);
 	});
 
 	test('Initializes changeset', async () => {
@@ -23,15 +21,17 @@ describe('handler', () => {
 		jest.spyOn(file, 'exists').mockResolvedValue(false);
 		await run('', { graph });
 
-		expect(subprocess.run).toHaveBeenCalledWith(expect.objectContaining({ cmd: 'npx', args: ['changeset', 'init'] }));
+		expect(graph.packageManager.run).toHaveBeenCalledWith(
+			expect.objectContaining({ cmd: 'changeset', args: ['init'] }),
+		);
 	});
 
 	test('Does not re-initialize', async () => {
 		const graph = getGraph(path.join(__dirname, '__fixtures__', 'repo'));
 		await run('', { graph });
 
-		expect(subprocess.run).not.toHaveBeenCalledWith(
-			expect.objectContaining({ cmd: 'npx', args: ['changeset', 'init'] }),
+		expect(graph.packageManager.run).not.toHaveBeenCalledWith(
+			expect.objectContaining({ cmd: 'changeset', args: ['init'] }),
 		);
 	});
 });

--- a/plugins/changesets/src/commands/init.ts
+++ b/plugins/changesets/src/commands/init.ts
@@ -1,4 +1,3 @@
-import { run } from '@onerepo/subprocess';
 import { exists } from '@onerepo/file';
 import type { Builder, Handler } from '@onerepo/yargs';
 
@@ -18,9 +17,9 @@ export const handler: Handler = async (argv, { graph, logger }) => {
 	}
 	await step.end();
 
-	await run({
+	await graph.packageManager.run({
 		name: 'Initialized changesets',
-		cmd: 'npx',
-		args: ['changeset', 'init'],
+		cmd: 'changeset',
+		args: ['init'],
 	});
 };

--- a/plugins/eslint/src/commands/eslint.ts
+++ b/plugins/eslint/src/commands/eslint.ts
@@ -2,7 +2,6 @@ import path from 'node:path';
 import { minimatch } from 'minimatch';
 import { updateIndex } from '@onerepo/git';
 import { exists, lstat, read } from '@onerepo/file';
-import { run } from '@onerepo/subprocess';
 import { builders } from '@onerepo/builders';
 import type { Builder, Handler } from '@onerepo/yargs';
 
@@ -117,7 +116,7 @@ export const handler: Handler<Args> = async function handler(argv, { getFilepath
 		return;
 	}
 
-	const args = ['eslint', '--ext', extensions.join(','), pretty ? '--color' : '--no-color'];
+	const args = ['--ext', extensions.join(','), pretty ? '--color' : '--no-color'];
 	if (!(passthrough.includes('-f') || passthrough.includes('--format'))) {
 		args.push('--format', 'onerepo');
 	}
@@ -132,9 +131,9 @@ export const handler: Handler<Args> = async function handler(argv, { getFilepath
 	}
 
 	const runStep = logger.createStep('Lint files');
-	const [out, err] = await run({
+	const [out, err] = await graph.packageManager.run({
 		name: `Lint ${all ? '' : filteredPaths.join(', ').substring(0, 40)}…`,
-		cmd: 'npx',
+		cmd: 'eslint',
 		args: [...args, ...(all ? ['.'] : filteredPaths), ...passthrough],
 		opts: {
 			env: { ONEREPO_ESLINT_GITHUB_ANNOTATE: github ? 'true' : 'false' },

--- a/plugins/prettier/src/commands/prettier.ts
+++ b/plugins/prettier/src/commands/prettier.ts
@@ -3,7 +3,6 @@ import { minimatch } from 'minimatch';
 import * as core from '@actions/core';
 import { updateIndex } from '@onerepo/git';
 import { exists, lstat, read } from '@onerepo/file';
-import { run } from '@onerepo/subprocess';
 import { builders } from '@onerepo/builders';
 import type { Builder, Handler } from '@onerepo/yargs';
 
@@ -79,15 +78,10 @@ export const handler: Handler<Args> = async function handler(argv, { getFilepath
 
 	const runStep = logger.createStep('Format files');
 	try {
-		await run({
+		await graph.packageManager.run({
 			name: `Format files ${all ? '' : filteredPaths.join(', ').substring(0, 60)}…`,
-			cmd: 'npx',
-			args: [
-				'prettier',
-				'--ignore-unknown',
-				isDry || check ? '--list-different' : '--write',
-				...(all ? ['.'] : filteredPaths),
-			],
+			cmd: 'prettier',
+			args: ['--ignore-unknown', isDry || check ? '--list-different' : '--write', ...(all ? ['.'] : filteredPaths)],
 			step: runStep,
 		});
 	} catch (e) {
@@ -110,6 +104,7 @@ To resolve the issue, run Prettier formatting and commit the resulting changes:
 		await runStep.end();
 		return;
 	}
+	await runStep.end();
 
 	if (add && filteredPaths.length) {
 		await updateIndex(filteredPaths);

--- a/plugins/typescript/src/commands/__tests__/typescript.test.ts
+++ b/plugins/typescript/src/commands/__tests__/typescript.test.ts
@@ -1,37 +1,34 @@
-import * as subprocess from '@onerepo/subprocess';
 import { getCommand } from '@onerepo/test-cli';
 import * as command from '../typescript';
 
-const { run } = getCommand(command);
-
-jest.mock('@onerepo/subprocess');
+const { graph, run } = getCommand(command);
 
 describe('handler', () => {
 	test('includes --pretty', async () => {
-		jest.spyOn(subprocess, 'run').mockResolvedValue(['', '']);
-		jest.spyOn(subprocess, 'batch').mockResolvedValue([['', '']]);
+		jest.spyOn(graph.packageManager, 'run').mockResolvedValue(['', '']);
+		jest.spyOn(graph.packageManager, 'batch').mockResolvedValue([['', '']]);
 		await run('-a');
 
-		expect(subprocess.batch).toHaveBeenCalledWith(
+		expect(graph.packageManager.batch).toHaveBeenCalledWith(
 			expect.arrayContaining([
 				expect.objectContaining({
-					cmd: 'npx',
-					args: ['tsc', '-p', expect.stringMatching('tsconfig.json'), '--noEmit', '--pretty'],
+					cmd: 'tsc',
+					args: ['-p', expect.stringMatching('tsconfig.json'), '--noEmit', '--pretty'],
 				}),
 			]),
 		);
 	});
 
 	test('can turn off --pretty', async () => {
-		jest.spyOn(subprocess, 'run').mockResolvedValue(['', '']);
-		jest.spyOn(subprocess, 'batch').mockResolvedValue([['', '']]);
+		jest.spyOn(graph.packageManager, 'run').mockResolvedValue(['', '']);
+		jest.spyOn(graph.packageManager, 'batch').mockResolvedValue([['', '']]);
 		await run('-a --no-pretty');
 
-		expect(subprocess.batch).toHaveBeenCalledWith(
+		expect(graph.packageManager.batch).toHaveBeenCalledWith(
 			expect.arrayContaining([
 				expect.objectContaining({
-					cmd: 'npx',
-					args: ['tsc', '-p', expect.stringMatching('tsconfig.json'), '--noEmit', '--no-pretty'],
+					cmd: 'tsc',
+					args: ['-p', expect.stringMatching('tsconfig.json'), '--noEmit', '--no-pretty'],
 				}),
 			]),
 		);

--- a/plugins/vitest/src/commands/__tests__/vitest.test.ts
+++ b/plugins/vitest/src/commands/__tests__/vitest.test.ts
@@ -19,8 +19,8 @@ describe('handler', () => {
 
 		expect(subprocess.run).toHaveBeenCalledWith(
 			expect.objectContaining({
-				cmd: 'node_modules/.bin/vitest',
-				args: ['--config', './jest.config.ts', 'related', 'foo.js', 'bar/baz.js'],
+				cmd: 'node',
+				args: ['node_modules/.bin/vitest', '--config', './jest.config.ts', 'related', 'foo.js', 'bar/baz.js'],
 			}),
 		);
 	});
@@ -30,8 +30,8 @@ describe('handler', () => {
 
 		expect(subprocess.run).toHaveBeenCalledWith(
 			expect.objectContaining({
-				cmd: 'node_modules/.bin/vitest',
-				args: ['--config', './jest.config.ts', expect.stringMatching(/\/burritos$/)],
+				cmd: 'node',
+				args: ['node_modules/.bin/vitest', '--config', './jest.config.ts', expect.stringMatching(/\/burritos$/)],
 			}),
 		);
 	});
@@ -62,8 +62,8 @@ describe('handler', () => {
 
 		expect(subprocess.run).toHaveBeenCalledWith(
 			expect.objectContaining({
-				cmd: 'node_modules/.bin/vitest',
-				args: ['--config', './jest.config.ts', '-w', 'foo'],
+				cmd: 'node',
+				args: ['node_modules/.bin/vitest', '--config', './jest.config.ts', '-w', 'foo'],
 			}),
 		);
 	});

--- a/plugins/vitest/src/commands/vitest.ts
+++ b/plugins/vitest/src/commands/vitest.ts
@@ -64,9 +64,10 @@ export const handler: Handler<Args> = async function handler(argv, { getWorkspac
 
 	await run({
 		name: 'Run tests',
-		cmd: inspect ? 'node' : 'node_modules/.bin/vitest',
+		cmd: 'node',
 		args: [
-			...(inspect ? ['--inspect', '--inspect-brk', 'node_modules/.bin/vitest'] : []),
+			...(inspect ? ['--inspect', '--inspect-brk'] : []),
+			'node_modules/.bin/vitest',
 			'--config',
 			config,
 			...related.filter((filepath) => !filepath.endsWith('.json')),


### PR DESCRIPTION
Adds `packageManager.run` an `packageManager.batch` – helpers for running `npx`/`npm exec` like commands using the correct package manager an avoiding needing to look up the location of the installed `.bin/*` file(s)