### PR TITLE
fix(core): sequential tasks at root need to be force-included

### DIFF
--- a/.changeset/sharp-shirts-eat.md
+++ b/.changeset/sharp-shirts-eat.md
@@ -1,0 +1,6 @@
+---
+'@onerepo/core': patch
+'onerepo': patch
+---
+
+Sequential tasks at the root level were not being forcefully included for all changes.

--- a/modules/core/src/core/tasks/commands/__tests__/__fixtures__/repo/onerepo.config.js
+++ b/modules/core/src/core/tasks/commands/__tests__/__fixtures__/repo/onerepo.config.js
@@ -4,4 +4,5 @@ module.exports = {
 	'post-commit': { serial: ['echo "post-commit"'] },
 	build: { serial: [{ match: '**/foo.json', cmd: 'build' }] },
 	deploy: { parallel: ['echo "deployroot"'] },
+	'pre-merge': { serial: [['$0 lint', '$0 format']] },
 };

--- a/modules/core/src/core/tasks/commands/tasks.ts
+++ b/modules/core/src/core/tasks/commands/tasks.ts
@@ -84,7 +84,8 @@ export const handler: Handler<Argv> = async (argv, { getWorkspaces, graph, logge
 	for (const workspace of graph.workspaces) {
 		logger.log(`Looking for tasks in ${workspace.name}`);
 
-		const force = (task: Task) => (typeof task === 'string' && workspace.isRoot) || workspaces.includes(workspace);
+		const force = (task: Task) =>
+			(workspace.isRoot && (typeof task === 'string' || Array.isArray(task))) || workspaces.includes(workspace);
 
 		const tasks = workspace.getTasks(lifecycle);
 		tasks.serial.forEach((task) => {


### PR DESCRIPTION
**Problem:**

Sequential tasks are not being included from the root workspace when non-root workspace changes are made.

**Solution:**

When determining `force` adding tasks from the root, ensure checking `Array.isArray`, not just if task is `string`