### PR TITLE
added logger success method

### DIFF
--- a/modules/logger/src/LogStep.ts
+++ b/modules/logger/src/LogStep.ts
@@ -20,6 +20,7 @@ const PREFIX_ERR = pc.red(pc.bold('ERR'));
 const PREFIX_WARN = pc.yellow(pc.bold('WRN'));
 const PREFIX_LOG = pc.cyan(pc.bold('LOG'));
 const PREFIX_DBG = pc.magenta(pc.bold('DBG'));
+const PREFIX_SUCC = pc.green(pc.bold('SUCC'));
 const PREFIX_END = pc.dim(pc.bold('■'));
 
 const noop = () => {};
@@ -184,6 +185,16 @@ export class LogStep {
 				resolve();
 			});
 		});
+	}
+
+	/**
+	 * Log a success message.
+	 *
+	 * @group Logging
+	 * @param contents Any value that can be converted to a string for writing to `stderr`.
+	 */
+	success(contents: unknown) {
+		this.#writeStream(this.#prefix(PREFIX_SUCC, stringify(contents)));
 	}
 
 	/**

--- a/modules/logger/src/Logger.ts
+++ b/modules/logger/src/Logger.ts
@@ -194,6 +194,16 @@ export class Logger {
 	}
 
 	/**
+	 * Log a success message, this will log regardless of log verbosity. This is a pass-through for the main step’s {@link LogStep#success | `success()`} method.
+	 *
+	 * @group Logging
+	 * @param contents Any value that can be converted to a string for writing to `stderr`.
+	 */
+	success(contents: unknown) {
+		this.#logger.success(contents);
+	}
+
+	/**
 	 * Log a warning. Does not have any effect on the command run, but will be called out. This is a pass-through for the main step’s {@link LogStep#error | `error()`} method.
 	 *
 	 * @group Logging

--- a/modules/logger/src/__tests__/LogStep.test.ts
+++ b/modules/logger/src/__tests__/LogStep.test.ts
@@ -59,11 +59,11 @@ describe('LogStep', () => {
 
 	test.concurrent.each([
 		[0, []],
-		[1, ['error']],
-		[2, ['error', 'warn']],
-		[3, ['error', 'warn', 'log']],
-		[4, ['error', 'warn', 'log', 'debug']],
-		[5, ['error', 'warn', 'log', 'debug', 'timing']],
+		[1, ['success', 'error']],
+		[2, ['success', 'error', 'warn']],
+		[3, ['success', 'error', 'warn', 'log']],
+		[4, ['success', 'error', 'warn', 'log', 'debug']],
+		[5, ['success', 'error', 'warn', 'log', 'debug', 'timing']],
 	] as Array<[number, Array<keyof LogStep>]>)('verbosity = %d writes %j', async (verbosity, methods) => {
 		const onEnd = jest.fn(() => Promise.resolve());
 		const onError = jest.fn();
@@ -71,6 +71,7 @@ describe('LogStep', () => {
 		const step = new LogStep('tacos', { onEnd, onError, verbosity, stream });
 
 		const logs = {
+			success: `${pc.green(pc.bold('SUCC'))} a success`,
 			error: ` │ ${pc.red(pc.bold('ERR'))} an error`,
 			warn: ` │ ${pc.yellow(pc.bold('WRN'))} a warning`,
 			log: ` │ ${pc.cyan(pc.bold('LOG'))} a log`,
@@ -85,6 +86,7 @@ describe('LogStep', () => {
 
 		step.activate();
 
+		step.success('a success');
 		step.error('an error');
 		step.warn('a warning');
 		step.log('a log');

--- a/modules/logger/src/__tests__/Logger.test.ts
+++ b/modules/logger/src/__tests__/Logger.test.ts
@@ -14,11 +14,11 @@ async function waitStreamEnd(stream: PassThrough) {
 describe('Logger', () => {
 	test.concurrent.each([
 		[0, []],
-		[1, ['error']],
-		[2, ['error', 'warn']],
-		[3, ['error', 'warn', 'log']],
-		[4, ['error', 'warn', 'log', 'debug']],
-		[5, ['error', 'warn', 'log', 'debug', 'timing']],
+		[1, ['success', 'error']],
+		[2, ['success', 'error', 'warn']],
+		[3, ['success', 'error', 'warn', 'log']],
+		[4, ['success', 'error', 'warn', 'log', 'debug']],
+		[5, ['success', 'error', 'warn', 'log', 'debug', 'timing']],
 	] as Array<[number, Array<keyof Logger>]>)('verbosity = %d writes %j', async (verbosity, methods) => {
 		const stream = new PassThrough();
 		let out = '';
@@ -29,6 +29,7 @@ describe('Logger', () => {
 		const logger = new Logger({ verbosity, stream });
 
 		const logs = {
+			success: `${pc.green(pc.bold('SUCC'))} a success`,
 			error: `${pc.red(pc.bold('ERR'))} an error`,
 			warn: `${pc.yellow(pc.bold('WRN'))} a warning`,
 			// log: `${pc.cyan(pc.bold('LOG'))} a log`,
@@ -37,6 +38,7 @@ describe('Logger', () => {
 			timing: `${pc.red('⏳')} foo → bar: 0ms`,
 		};
 
+		logger.success('a success');
 		logger.error('an error');
 		logger.warn('a warning');
 		logger.log('a log');


### PR DESCRIPTION
Related Story: https://app.shortcut.com/figure/story/257357/add-success-log-method-to-onerepo-logger

**Problem**
There is no way to convey a success message to developers through the fe cli. 

**Solution**
Add a `success` method to the Logger and LogStep that logs regardless of verbosity and has a green `SUCC` prefix.