### PR TITLE
refactor: make use of logger.info

### DIFF
--- a/.changeset/modern-sheep-attend.md
+++ b/.changeset/modern-sheep-attend.md
@@ -1,0 +1,5 @@
+---
+'@onerepo/plugin-changesets': patch
+---
+
+Important output information for prerelease and publish will be output as INFO instead of WARN logs

--- a/.changeset/orange-moose-greet.md
+++ b/.changeset/orange-moose-greet.md
@@ -1,0 +1,7 @@
+---
+'@onerepo/core': patch
+'@onerepo/logger': patch
+'onerepo': patch
+---
+
+Logger verbosity is now explicitly number `0` through `5`.

--- a/.changeset/pink-papayas-unite.md
+++ b/.changeset/pink-papayas-unite.md
@@ -1,0 +1,7 @@
+---
+'@onerepo/file': patch
+'@onerepo/subprocess': patch
+'onerepo': patch
+---
+
+DRY-RUN information will now be written as INFO lines instead of warnings.

--- a/docs/src/content/docs/custom-commands.md
+++ b/docs/src/content/docs/custom-commands.md
@@ -69,7 +69,9 @@ You can also generate Markdown documentation of the full CLI using the [docgen c
 At the core of oneRepo command output is the [`Logger`](/docs/core/api/#logger). This logger is responsible for tracking output and ensuring that all subprocess output is buffered and redirected appropriately for a better debugging experience.
 
 <aside>
+
 This logger should always be used instead of directly writing to `console.log` or `process.stdout` unless you explicitly know that your output should be piped to another process (e.g. you want to write JSON to `stdout`).
+
 </aside>
 
 The `logger` instance is primarily available in command handlers via the [`HandlerExtra`](/docs/core/api/#handlerextra). Logger verbosity is controlled via the global counter argument `--verbosity`, or `-v`.
@@ -78,6 +80,7 @@ The `logger` instance is primarily available in command handlers via the [`Handl
 export const handler: Handler = async (argv, { logger }) => {
 	// -v (1)
 	logger.error('This will output an error (and also set cause this run to exit with code 1)');
+	logger.info('This will output an important informative message.');
 	// -vv (2, default)
 	logger.warn('This will output a warning');
 	// -vvv (3)

--- a/modules/core/src/index.ts
+++ b/modules/core/src/index.ts
@@ -192,7 +192,7 @@ export async function setup(
 			});
 
 			// Silence the logger so that shutdown handlers do not write logs
-			const logger = getLogger({ verbosity: -1 });
+			const logger = getLogger({ verbosity: 0 });
 
 			const results = await shutdown(argv);
 

--- a/modules/file/src/index.ts
+++ b/modules/file/src/index.ts
@@ -54,7 +54,7 @@ export async function write(filename: string, contents: string, { step }: Option
 		await mkdirp(path.dirname(filename), { step });
 
 		if (isDryRun()) {
-			step.warn(`DRY RUN: Not writing to ${filename}`);
+			step.info(`DRY RUN: Not writing to ${filename}`);
 			return;
 		}
 
@@ -83,7 +83,7 @@ export async function copy(input: string, output: string, { step }: Options = {}
 		await mkdirp(path.dirname(output), { step });
 
 		if (isDryRun()) {
-			step.warn(`DRY RUN: Not copy to ${output}`);
+			step.info(`DRY RUN: Not copy to ${output}`);
 			return;
 		}
 
@@ -148,7 +148,7 @@ export async function read(filename: string, flag: OpenMode = 'r', { step }: Opt
 export async function mkdirp(pathname: string, { step }: Options = {}) {
 	return stepWrapper({ step, name: `Create path \`${pathname}\`` }, async (step) => {
 		if (isDryRun()) {
-			step.warn(`DRY RUN: Not creating directory ${pathname}`);
+			step.info(`DRY RUN: Not creating directory ${pathname}`);
 		}
 		step.debug(`Creating dir \`${pathname}\``);
 		await fs.mkdir(pathname, { recursive: true });
@@ -165,7 +165,7 @@ export async function mkdirp(pathname: string, { step }: Options = {}) {
 export async function remove(pathname: string, { step }: Options = {}) {
 	return stepWrapper({ step, name: `Removing path \`${pathname}\`` }, async (step) => {
 		if (isDryRun()) {
-			step.warn(`DRY RUN: Not removing ${pathname}`);
+			step.info(`DRY RUN: Not removing ${pathname}`);
 		}
 		step.debug(`Deleting \`${pathname}\``);
 		await fs.rm(pathname, { recursive: true, force: true });
@@ -257,7 +257,7 @@ export async function makeTempDir(prefix: string, { step }: Options = {}) {
 		const tempdir = path.join(tmpdir(), prefix);
 
 		if (isDryRun()) {
-			step.warn(`DRY RUN: Create temporary directory ${tempdir}`);
+			step.info(`DRY RUN: Create temporary directory ${tempdir}`);
 			return tempdir;
 		}
 
@@ -276,7 +276,7 @@ export async function makeTempDir(prefix: string, { step }: Options = {}) {
 export async function chmod(filename: string, mode: string | number, { step }: Options = {}) {
 	return stepWrapper({ step, name: `chmod ${filename}` }, async (step) => {
 		if (isDryRun()) {
-			step.warn(`DRY RUN: chmod ${filename} ${mode}`);
+			step.info(`DRY RUN: chmod ${filename} ${mode}`);
 			return;
 		}
 

--- a/modules/logger/src/LogStep.ts
+++ b/modules/logger/src/LogStep.ts
@@ -195,7 +195,7 @@ export class LogStep {
 	}
 
 	/**
-	 * Log an informative message. Should be used when trying to convey information with a user.
+	 * Log an informative message. Should be used when trying to convey information with a user that is important enough to always be returned.
 	 *
 	 * @group Logging
 	 * @param contents Any value that can be converted to a string for writing to `stderr`.
@@ -233,7 +233,7 @@ export class LogStep {
 	}
 
 	/**
-	 * Log general information.
+	 * General logging information. Useful for light informative debugging. Recommended to use sparingly.
 	 *
 	 * @group Logging
 	 * @param contents Any value that can be converted to a string for writing to `stderr`.

--- a/modules/logger/src/Logger.ts
+++ b/modules/logger/src/Logger.ts
@@ -5,20 +5,22 @@ import { LogStep } from './LogStep';
 
 type LogUpdate = typeof logUpdate;
 
-interface LoggerOptions {
+/**
+ * | Value  | What           | Description                                      |
+ * | ------ | -------------- | ------------------------------------------------ |
+ * | `<= 0` | Silent         | No output will be read or written.               |
+ * | `>= 1` | Error, Info    |                                                  |
+ * | `>= 2` | Warnings       |                                                  |
+ * | `>= 3` | Log            |                                                  |
+ * | `>= 4` | Debug          | `logger.debug()` will be included                |
+ * | `>= 5` | Timing         | Extra performance timing metrics will be written |
+ * @group Logger
+ */
+export interface LoggerOptions {
 	/**
 	 * Verbosity ranges from 0 to 5
-	 *
-	 * | Value  | What     | Description                                      |
-	 * | ------ | -------- | ------------------------------------------------ |
-	 * | `<= 0` | Silent   | No output will be read or written.               |
-	 * | `>= 1` | Error    |                                                  |
-	 * | `>= 2` | Warnings |                                                  |
-	 * | `>= 3` | Log      |                                                  |
-	 * | `>= 4` | Debug    | `logger.debug()` will be included                |
-	 * | `>= 5` | Timing   | Extra performance timing metrics will be written |
 	 */
-	verbosity: number;
+	verbosity: 0 | 1 | 2 | 3 | 4 | 5;
 	/**
 	 * Advanced – override the writable stream in order to pipe logs elsewhere. Mostly used for dependency injection for `@onerepo/test-cli`.
 	 */
@@ -184,10 +186,11 @@ export class Logger {
 	}
 
 	/**
-	 * Log an error. This will cause the root logger to include an error and fail a command. This is a pass-through for the main step’s {@link LogStep#log | `log()`} method.
+	 * General logging information. Useful for light informative debugging. Recommended to use sparingly.
 	 *
 	 * @group Logging
 	 * @param contents Any value that can be converted to a string for writing to `stderr`.
+	 * @see {@link LogStep#log | `log()`} This is a pass-through for the main step’s {@link LogStep#log | `log()`} method.
 	 */
 	log(contents: unknown) {
 		this.#logger.log(contents);
@@ -195,51 +198,55 @@ export class Logger {
 
 	/**
 	 * Should be used to convey information or instructions through the log, will log when verbositu >= 1
-	 * This is a pass-through for the main step’s {@link LogStep#info | `info()`} method.
 	 *
 	 * @group Logging
 	 * @param contents Any value that can be converted to a string for writing to `stderr`.
+	 * @see {@link LogStep#info | `info()`} This is a pass-through for the main step’s {@link LogStep#info | `info()`} method.
 	 */
 	info(contents: unknown) {
 		this.#logger.info(contents);
 	}
 
 	/**
-	 * Log a warning. Does not have any effect on the command run, but will be called out. This is a pass-through for the main step’s {@link LogStep#error | `error()`} method.
+	 * Log an error. This will cause the root logger to include an error and fail a command.
 	 *
 	 * @group Logging
 	 * @param contents Any value that can be converted to a string for writing to `stderr`.
+	 * @see {@link LogStep#error | `error()`} This is a pass-through for the main step’s {@link LogStep#error | `error()`} method.
 	 */
 	error(contents: unknown) {
 		this.#logger.error(contents);
 	}
 
 	/**
-	 * Log general information. This is a pass-through for the main step’s {@link LogStep#warn | `warn()`} method.
+	 * Log a warning. Does not have any effect on the command run, but will be called out.
 	 *
 	 * @group Logging
 	 * @param contents Any value that can be converted to a string for writing to `stderr`.
+	 * @see {@link LogStep#warn | `warn()`} This is a pass-through for the main step’s {@link LogStep#warn | `warn()`} method.
 	 */
 	warn(contents: unknown) {
 		this.#logger.warn(contents);
 	}
 
 	/**
-	 * Extra debug logging when verbosity greater than or equal to 4. This is a pass-through for the main step’s {@link LogStep#debug | `debug()`} method.
+	 * Extra debug logging when verbosity greater than or equal to 4.
 	 *
 	 * @group Logging
 	 * @param contents Any value that can be converted to a string for writing to `stderr`.
+	 * @see {@link LogStep#debug | `debug()`} This is a pass-through for the main step’s {@link LogStep#debug | `debug()`} method.
 	 */
 	debug(contents: unknown) {
 		this.#logger.debug(contents);
 	}
 
 	/**
-	 * Log timing information between two [Node.js performance mark names](https://nodejs.org/dist/latest-v18.x/docs/api/perf_hooks.html#performancemarkname-options). This is a pass-through for the main step’s {@link LogStep#timing | `timing()`} method.
+	 * Log timing information between two [Node.js performance mark names](https://nodejs.org/dist/latest-v18.x/docs/api/perf_hooks.html#performancemarkname-options).
 	 *
 	 * @group Logging
 	 * @param start A `PerformanceMark` entry name
 	 * @param end A `PerformanceMark` entry name
+	 * @see {@link LogStep#timing | `timing()`} This is a pass-through for the main step’s {@link LogStep#timing | `timing()`} method.
 	 */
 	timing(start: string, end: string) {
 		this.#logger.timing(start, end);

--- a/modules/subprocess/src/index.ts
+++ b/modules/subprocess/src/index.ts
@@ -121,7 +121,7 @@ export async function run(options: RunSpec): Promise<[string, string]> {
 		let err = '';
 
 		if (!runDry && process.env.ONE_REPO_DRY_RUN === 'true') {
-			step.log(
+			step.info(
 				`DRY-RUN command:
 		${JSON.stringify(withoutLogger, null, 2)}\n`,
 			);
@@ -254,7 +254,7 @@ export async function sudo(options: Omit<RunSpec, 'opts'> & { reason?: string })
 	const commandString = `${options.cmd} ${(options.args || []).join(' ')}`;
 
 	if (!runDry && process.env.ONE_REPO_DRY_RUN === 'true') {
-		step.log(
+		step.info(
 			`DRY-RUN command:
     sudo ${commandString}\n`,
 		);

--- a/plugins/changesets/src/commands/prerelease.ts
+++ b/plugins/changesets/src/commands/prerelease.ts
@@ -123,7 +123,7 @@ Commit or stash your changes to continue.`);
 			},
 		]);
 
-		logger.warn(choices);
+		logger.info(choices);
 
 		if (!choices.includes('_ALL_')) {
 			workspaces = graph.dependencies(choices, true).filter((ws) => !ws.private);
@@ -162,7 +162,7 @@ Commit or stash your changes to continue.`);
 	});
 	const newVersion = `0.0.0-pre.${sha}`;
 
-	versionStep.warn(newVersion);
+	versionStep.info(`The following version will be used for all published workspaces: ${newVersion}`);
 	await versionStep.end();
 
 	const releases: ReleasePlan['releases'] = workspaces.map((ws) => ({

--- a/plugins/changesets/src/commands/publish.ts
+++ b/plugins/changesets/src/commands/publish.ts
@@ -80,7 +80,7 @@ export const handler: Handler<Args> = async (argv, { graph, logger }) => {
 		return;
 	}
 
-	infoStep.warn(`Publishing:\n${publishable.map((ws) => `  - ${ws.name}`).join('\n')}`);
+	infoStep.info(`Publishing:\n${publishable.map((ws) => `  - ${ws.name}`).join('\n')}`);
 	await infoStep.end();
 
 	if (!skipAuth) {


### PR DESCRIPTION
**Problem:**

We now have a handy `logger.info` method for presenting important information that users probably need.

**Solution:**

Make use of it where it makes sense. Update documentation.