### PR TITLE
fix(core): require core path config options be relative to the root

### DIFF
--- a/.changeset/weak-dancers-chew.md
+++ b/.changeset/weak-dancers-chew.md
@@ -1,0 +1,6 @@
+---
+'@onerepo/core': patch
+'onerepo': patch
+---
+
+Ensures path configuration options for core commands `docgen`, `generate`, and `graph` are relative to the repository root to ensure correct resolution across git worktrees.

--- a/bin/one.cjs
+++ b/bin/one.cjs
@@ -22,14 +22,12 @@ setup(
 		core: {
 			docgen: {
 				outWorkspace: 'root',
-				outFile: 'docs/usage/cli.md',
+				outFile: './docs/usage/cli.md',
 				format: 'markdown',
 				safeWrite: true,
 			},
-			generate: {
-				templatesDir: path.join(__dirname, '..', 'config', 'templates'),
-			},
-			graph: { customSchema: path.join(__dirname, '..', 'config', 'graph-schema.ts') },
+			generate: { templatesDir: './config/templates' },
+			graph: { customSchema: './config/graph-schema.ts' },
 			tasks: {
 				ignore: ['**/README.md', '**/CHANGELOG.md', '.changeset/**'],
 			},

--- a/modules/core/src/core/docgen/index.ts
+++ b/modules/core/src/core/docgen/index.ts
@@ -1,3 +1,4 @@
+import path from 'node:path';
 import { updateIndex } from '@onerepo/git';
 import { write, writeSafe } from '@onerepo/file';
 import type { Argv as Yargv } from 'yargs';
@@ -47,126 +48,132 @@ interface Args {
 	command?: string;
 }
 
-export const docgen = (opts: Options = {}, fn: (c: Config, y: Yargv) => Promise<App>, config: Config): Plugin => ({
-	yargs: (yargs, visitor) => {
-		const handler: Handler<Args> = async function handler(argv, { graph, logger }) {
-			const {
-				add,
-				format,
-				'heading-level': headingLevel,
-				'out-file': outFile,
-				'out-workspace': wsName,
-				'safe-write': safeWrite,
-				command,
-			} = argv;
+export const docgen = (opts: Options = {}, fn: (c: Config, y: Yargv) => Promise<App>, config: Config): Plugin => {
+	if (typeof opts.outFile === 'string' && (!opts.outFile || path.isAbsolute(opts.outFile))) {
+		throw new Error('Invalid path specified for `core.docgen.outFile`. Path must be relative, eg, "./docs/usage.md"');
+	}
 
-			let outPath = outFile;
-			if (wsName && outFile) {
-				const workspace = graph.getByName(wsName);
-				if (!workspace) {
-					throw new Error(`No workspace by name "${wsName}"`);
+	return {
+		yargs: (yargs, visitor) => {
+			const handler: Handler<Args> = async function handler(argv, { graph, logger }) {
+				const {
+					add,
+					format,
+					'heading-level': headingLevel,
+					'out-file': outFile,
+					'out-workspace': wsName,
+					'safe-write': safeWrite,
+					command,
+				} = argv;
+
+				let outPath = outFile;
+				if (wsName && outFile) {
+					const workspace = graph.getByName(wsName);
+					if (!workspace) {
+						throw new Error(`No workspace by name "${wsName}"`);
+					}
+					outPath = workspace.resolve(outFile);
 				}
-				outPath = workspace.resolve(outFile);
-			}
 
-			const docsYargs = new Yargs();
-			await fn(
-				config,
-				// @ts-ignore
-				docsYargs,
-			);
-			docsYargs._rootPath = config.root as string;
-			docsYargs._commandDirectory = (config.subcommandDir as string) ?? 'commands';
-			const docs = docsYargs._serialize();
+				const docsYargs = new Yargs();
+				await fn(
+					config,
+					// @ts-ignore
+					docsYargs,
+				);
+				docsYargs._rootPath = config.root as string;
+				docsYargs._commandDirectory = (config.subcommandDir as string) ?? 'commands';
+				const docs = docsYargs._serialize();
 
-			let outputDocs: Docs | undefined = docs;
-			if (command) {
-				if (command in docs.commands) {
-					outputDocs = docs.commands[command];
+				let outputDocs: Docs | undefined = docs;
+				if (command) {
+					if (command in docs.commands) {
+						outputDocs = docs.commands[command];
+					} else {
+						outputDocs = Object.values(docs.commands).find((cmd) => cmd.aliases?.includes(command));
+					}
+				}
+
+				if (!outputDocs) {
+					logger.error(`Could not find command "${command}" in CLI`);
+					return;
+				}
+
+				const output = format === 'markdown' ? `${toMarkdown(outputDocs, headingLevel)}` : JSON.stringify(outputDocs);
+
+				if (outPath) {
+					if (safeWrite) {
+						await writeSafe(outPath, output, { sentinel: `auto-generated-from-cli${command ? `-${command}` : ''}` });
+					} else {
+						await write(outPath, output);
+					}
+					if (add) {
+						await updateIndex(outPath);
+					}
 				} else {
-					outputDocs = Object.values(docs.commands).find((cmd) => cmd.aliases?.includes(command));
-				}
-			}
-
-			if (!outputDocs) {
-				logger.error(`Could not find command "${command}" in CLI`);
-				return;
-			}
-
-			const output = format === 'markdown' ? `${toMarkdown(outputDocs, headingLevel)}` : JSON.stringify(outputDocs);
-
-			if (outPath) {
-				if (safeWrite) {
-					await writeSafe(outPath, output, { sentinel: `auto-generated-from-cli${command ? `-${command}` : ''}` });
-				} else {
-					await write(outPath, output);
-				}
-				if (add) {
-					await updateIndex(outPath);
-				}
-			} else {
-				await new Promise<void>((resolve) => {
-					process.stdout.write(output, () => {
-						resolve();
+					await new Promise<void>((resolve) => {
+						process.stdout.write(output, () => {
+							resolve();
+						});
 					});
-				});
-			}
-		};
+				}
+			};
 
-		const command = opts.name ?? 'docgen';
-		const description = `Generate documentation for the \`${config.name}\` cli.`;
-		const { handler: wrappedHandler } = visitor({ command, description, handler });
+			const command = opts.name ?? 'docgen';
+			const description = `Generate documentation for the \`${config.name}\` cli.`;
+			const { handler: wrappedHandler } = visitor({ command, description, handler });
 
-		return yargs.command(
-			command,
-			description,
-			(yargs) =>
-				yargs
-					.usage(`$0 ${Array.isArray(command) ? command[0] : command} [options]`)
-					.epilogue(
-						'Help documentation should always be easy to find. This command will help automate the creation of docs for this command-line interface. If you are reading this somewhere that is not your terminal, there is a very good chance that this command was already run for you!',
-					)
-					.epilogue(
-						'Add this command to your one Repo tasks on pre-commit to ensure that your documentation is always up-to-date.',
-					)
-					.option('add', {
-						type: 'boolean',
-						description: 'Add the output file to the git stage',
-						default: false,
-					})
-					.option('out-file', {
-						type: 'string',
-						description: 'File to write output to. If not provided, stdout will be used',
-						default: 'outFile' in opts ? opts.outFile : undefined,
-					})
-					.option('out-workspace', {
-						type: 'string',
-						description: 'Workspace name to write the --out-file to',
-						default: 'outWorkspace' in opts ? opts.outWorkspace : undefined,
-					})
-					.option('format', {
-						type: 'string',
-						choices: ['markdown', 'json'],
-						default: opts.format ?? 'markdown',
-						description: 'Output format for documentation',
-					} as const)
-					.option('heading-level', {
-						type: 'number',
-						min: 1,
-						max: 5,
-						description: 'Heading level to start at for Markdown output',
-					})
-					.option('safe-write', {
-						type: 'boolean',
-						description: 'Write documentation to a portion of the file with start and end sentinels.',
-						default: opts.safeWrite ?? false,
-					})
-					.option('command', {
-						type: 'string',
-						hidden: true,
-						description: 'Start at the given command, skip the root and any others',
-					}),
-			wrappedHandler,
-		);
-	},
-});
+			return yargs.command(
+				command,
+				description,
+				(yargs) =>
+					yargs
+						.usage(`$0 ${Array.isArray(command) ? command[0] : command} [options]`)
+						.epilogue(
+							'Help documentation should always be easy to find. This command will help automate the creation of docs for this command-line interface. If you are reading this somewhere that is not your terminal, there is a very good chance that this command was already run for you!',
+						)
+						.epilogue(
+							'Add this command to your one Repo tasks on pre-commit to ensure that your documentation is always up-to-date.',
+						)
+						.option('add', {
+							type: 'boolean',
+							description: 'Add the output file to the git stage',
+							default: false,
+						})
+						.option('out-file', {
+							type: 'string',
+							description: 'File to write output to. If not provided, stdout will be used',
+							default: 'outFile' in opts ? opts.outFile : undefined,
+						})
+						.option('out-workspace', {
+							type: 'string',
+							description: 'Workspace name to write the --out-file to',
+							default: 'outWorkspace' in opts ? opts.outWorkspace : undefined,
+						})
+						.option('format', {
+							type: 'string',
+							choices: ['markdown', 'json'],
+							default: opts.format ?? 'markdown',
+							description: 'Output format for documentation',
+						} as const)
+						.option('heading-level', {
+							type: 'number',
+							min: 1,
+							max: 5,
+							description: 'Heading level to start at for Markdown output',
+						})
+						.option('safe-write', {
+							type: 'boolean',
+							description: 'Write documentation to a portion of the file with start and end sentinels.',
+							default: opts.safeWrite ?? false,
+						})
+						.option('command', {
+							type: 'string',
+							hidden: true,
+							description: 'Start at the given command, skip the root and any others',
+						}),
+				wrappedHandler,
+			);
+		},
+	};
+};

--- a/modules/core/src/core/generate/index.ts
+++ b/modules/core/src/core/generate/index.ts
@@ -19,6 +19,13 @@ export type Options = {
 };
 
 export function generate(opts: Options = { templatesDir: './config/templates' }): Plugin {
+	if (path.isAbsolute(opts.templatesDir)) {
+		throw new Error(
+			'Invalid path specified for `core.generate.templatesDir`. Path must be relative to the repository root, like "./config/templates"',
+		);
+	}
+	const resolvedDir = path.resolve(process.env.ONE_REPO_ROOT!, opts.templatesDir ?? '');
+
 	return {
 		yargs: (yargs, visitor) => {
 			const { command, description, builder, handler } = visitor(cmd);
@@ -30,11 +37,11 @@ export function generate(opts: Options = { templatesDir: './config/templates' })
 				(yargs) => {
 					const y = builder(yargs)
 						.usage(`$0 ${Array.isArray(name) ? name[0] : name} [options]`)
-						.default('templates-dir', opts.templatesDir ?? '')
+						.default('templates-dir', resolvedDir)
 						.epilogue(
 							`To create new templates add a new folder to ${path.relative(
-								process.cwd(),
-								opts.templatesDir,
+								process.env.ONE_REPO_ROOT!,
+								resolvedDir,
 							)} and create a \`.onegen.cjs\` configuration file. Follow the instructions online for more: https://onerepo.tools/docs/plugins/generate/`,
 						);
 


### PR DESCRIPTION
**Problem:**

When using worktrees, files are not generated in the worktree, but the repo root instead.

**Solution:**

Also relates to graph customSchema & potentially docgen outFile – allowing these paths to be absolute will result in the the original repo root paths be used and not be resolved from the worktree.

This updates the setup and configuration requirements to fix this issue, throwing an error if configured incorrectly using absolute paths.

Fixes #448 