### PR TITLE
refactor(core): warn on unimplemented yargs methods

### DIFF
--- a/.changeset/poor-months-try.md
+++ b/.changeset/poor-months-try.md
@@ -1,0 +1,6 @@
+---
+'@onerepo/core': patch
+'onerepo': patch
+---
+
+Prevent hard-failures during `docgen` when yargs methods are encountered that are not implemented in documentation generation.

--- a/modules/core/src/core/docgen/index.ts
+++ b/modules/core/src/core/docgen/index.ts
@@ -75,7 +75,8 @@ export const docgen = (opts: Options = {}, fn: (c: Config, y: Yargv) => Promise<
 					outPath = workspace.resolve(outFile);
 				}
 
-				const docsYargs = new Yargs();
+				const parseStep = logger.createStep('Parse commands');
+				const docsYargs = new Yargs(parseStep);
 				await fn(
 					config,
 					// @ts-ignore
@@ -84,6 +85,7 @@ export const docgen = (opts: Options = {}, fn: (c: Config, y: Yargv) => Promise<
 				docsYargs._rootPath = config.root as string;
 				docsYargs._commandDirectory = (config.subcommandDir as string) ?? 'commands';
 				const docs = docsYargs._serialize();
+				await parseStep.end();
 
 				let outputDocs: Docs | undefined = docs;
 				if (command) {


### PR DESCRIPTION
**Problem:**
Some yargs methods are left unimplemented. This can cause `docgen` to fail.

**Solution:**
Instead of hard failing, log a warning and return the yargs instance so that the doc generation can continue on. This is accomplished by using a Proxy object in the constructor to automatically handle everything.