### PR TITLE
fix: escape spaces in onerepo cli installation path

### DIFF
--- a/modules/core/src/core/install/commands/__tests__/install.test.ts
+++ b/modules/core/src/core/install/commands/__tests__/install.test.ts
@@ -3,12 +3,12 @@ import os from 'node:os';
 import { getCommand } from '@onerepo/test-cli';
 import * as subprocess from '@onerepo/subprocess';
 import * as file from '@onerepo/file';
-import { builder, handler } from '../install';
+import * as Tasks from '../install';
 
 vi.mock('@onerepo/subprocess');
 vi.mock('@onerepo/file');
 
-const { build, graph, run } = getCommand({ builder, handler });
+const { build, graph, run } = getCommand(Tasks);
 
 describe('builder', () => {
 	test('defaults verbosity to show warnings', async () => {
@@ -42,13 +42,7 @@ describe('handler', () => {
 
 	test('escapes spaces in installation path', async () => {
 		const location = 'Dev Location';
-		const { run: overrideRun } = getCommand({
-			builder,
-			builderArgs: {
-				argv: ['tacos', location],
-			},
-			handler,
-		});
+
 		vi.spyOn(subprocess, 'run').mockResolvedValue(['/usr/local/bin/tacos', '']);
 		vi.spyOn(subprocess, 'sudo').mockResolvedValue(['', '']);
 		vi.spyOn(child_process, 'execSync').mockImplementation(() => '');
@@ -56,7 +50,7 @@ describe('handler', () => {
 		vi.spyOn(file, 'read').mockResolvedValue('Dev Location');
 		vi.spyOn(os, 'platform').mockReturnValue('darwin');
 
-		await expect(overrideRun('--name tacos')).resolves.toBeTruthy();
+		await expect(run('--name tacos', { builderExtras: { executable: location } })).resolves.toBeTruthy();
 
 		expect(subprocess.sudo).toHaveBeenCalledWith({
 			name: 'Create executable',

--- a/modules/core/src/core/install/commands/install.ts
+++ b/modules/core/src/core/install/commands/install.ts
@@ -100,7 +100,7 @@ export const handler: Handler<Args> = async function handler(argv, { graph, logg
 	await sudo({
 		name: 'Create executable',
 		cmd: 'echo',
-		args: [`"#!/bin/zsh\n\n${process.argv[1].replace(' ', '\\ ')} \\$@"`, '|', 'sudo', 'tee', installLocation],
+		args: [`"#!/bin/zsh\n\n${process.argv[1].replace(/ /g, '\\ ')} \\$@"`, '|', 'sudo', 'tee', installLocation],
 	});
 
 	await sudo({

--- a/modules/core/src/core/install/commands/install.ts
+++ b/modules/core/src/core/install/commands/install.ts
@@ -100,7 +100,7 @@ export const handler: Handler<Args> = async function handler(argv, { graph, logg
 	await sudo({
 		name: 'Create executable',
 		cmd: 'echo',
-		args: [`"#!/bin/zsh\n\n${process.argv[1]} \\$@"`, '|', 'sudo', 'tee', installLocation],
+		args: [`"#!/bin/zsh\n\n${process.argv[1].replace(' ', '\\ ')} \\$@"`, '|', 'sudo', 'tee', installLocation],
 	});
 
 	await sudo({

--- a/modules/test-cli/src/index.ts
+++ b/modules/test-cli/src/index.ts
@@ -30,8 +30,6 @@ export async function runBuilder<R = Record<string, unknown>>(
 		configuration: parserConfiguration,
 	});
 
-	process.env.ONE_REPO_VERBOSITY = '4';
-	process.env.ONE_REPO_HEAD_BRANCH = 'main';
 	process.env = {
 		...process.env,
 		ONE_REPO_VERBOSITY: '4',
@@ -39,7 +37,7 @@ export async function runBuilder<R = Record<string, unknown>>(
 		...(builderExtras?.env ?? {}),
 	};
 
-	process.argv = builderExtras?.argv ?? ['', 'onerepo-test-runner'];
+	process.argv[1] = builderExtras?.executable ?? 'onerepo-test-runner';
 
 	const spy = testRunner.spyOn(console, 'error').mockImplementation(() => {});
 
@@ -140,18 +138,16 @@ export async function runHandler<R = Record<string, unknown>>(
 export function getCommand<R = Record<string, unknown>>({
 	builder,
 	handler,
-	builderArgs = undefined,
 }: {
 	builder: Builder<R>;
 	handler: Handler<R>;
-	builderArgs?: BuilderExtras;
 }) {
 	const graph = getGraph(path.join(dirname, 'fixtures', 'repo'));
 	return {
-		build: async (cmd = '') => runBuilder<R>(builder, cmd, builderArgs),
+		build: async (cmd = '', extras?: BuilderExtras) => runBuilder<R>(builder, cmd, extras),
 		graph,
 		run: async (cmd = '', extras: Partial<Extras> = {}) =>
-			runHandler<R>({ builder, handler, extras: { graph, builderExtras: builderArgs, ...extras } }, cmd),
+			runHandler<R>({ builder, handler, extras: { graph, ...extras } }, cmd),
 	};
 }
 
@@ -161,6 +157,6 @@ type Extras = { builderExtras?: BuilderExtras } & Omit<
 >;
 
 type BuilderExtras = {
-	argv?: Array<string>;
+	executable?: string;
 	env?: Exclude<typeof process.env, 'clear'>;
 };

--- a/modules/test-cli/src/index.ts
+++ b/modules/test-cli/src/index.ts
@@ -21,14 +21,25 @@ const testRunner: typeof vitest | typeof jest =
 const mocker = testRunner.mock;
 mocker('yargs');
 
-export async function runBuilder<R = Record<string, unknown>>(builder: Builder<R>, cmd = ''): Promise<Argv<R>> {
+export async function runBuilder<R = Record<string, unknown>>(
+	builder: Builder<R>,
+	cmd = '',
+	builderExtras?: BuilderExtras,
+): Promise<Argv<R>> {
 	const inputArgs = parser(cmd, {
 		configuration: parserConfiguration,
 	});
 
 	process.env.ONE_REPO_VERBOSITY = '4';
 	process.env.ONE_REPO_HEAD_BRANCH = 'main';
-	process.argv[1] = 'onerepo-test-runner';
+	process.env = {
+		...process.env,
+		ONE_REPO_VERBOSITY: '4',
+		ONE_REPO_HEAD_BRANCH: 'main',
+		...(builderExtras?.env ?? {}),
+	};
+
+	process.argv = builderExtras?.argv ?? ['', 'onerepo-test-runner'];
 
 	const spy = testRunner.spyOn(console, 'error').mockImplementation(() => {});
 
@@ -93,8 +104,8 @@ export async function runHandler<R = Record<string, unknown>>(
 	destroyLogger();
 	const logger = getLogger({ verbosity: 5, stream });
 
-	const { graph = getGraph(path.join(dirname, 'fixtures', 'repo')) } = extras;
-	const argv = await runBuilder(builder, cmd);
+	const { builderExtras, graph = getGraph(path.join(dirname, 'fixtures', 'repo')) } = extras;
+	const argv = await runBuilder(builder, cmd, builderExtras);
 
 	const wrappedGetAffected = (opts?: Parameters<typeof builders.getAffected>[1]) => builders.getAffected(graph, opts);
 	const wrappedGetWorkspaces = (opts?: Parameters<typeof builders.getWorkspaces>[2]) =>
@@ -129,17 +140,27 @@ export async function runHandler<R = Record<string, unknown>>(
 export function getCommand<R = Record<string, unknown>>({
 	builder,
 	handler,
+	builderArgs = undefined,
 }: {
 	builder: Builder<R>;
 	handler: Handler<R>;
+	builderArgs?: BuilderExtras;
 }) {
 	const graph = getGraph(path.join(dirname, 'fixtures', 'repo'));
 	return {
-		build: async (cmd = '') => runBuilder<R>(builder, cmd),
+		build: async (cmd = '') => runBuilder<R>(builder, cmd, builderArgs),
 		graph,
 		run: async (cmd = '', extras: Partial<Extras> = {}) =>
-			runHandler<R>({ builder, handler, extras: { graph, ...extras } }, cmd),
+			runHandler<R>({ builder, handler, extras: { graph, builderExtras: builderArgs, ...extras } }, cmd),
 	};
 }
 
-type Extras = Omit<HandlerExtra, 'getAffected' | 'getFilepaths' | 'getWorkspaces' | 'logger'>;
+type Extras = { builderExtras?: BuilderExtras } & Omit<
+	HandlerExtra,
+	'getAffected' | 'getFilepaths' | 'getWorkspaces' | 'logger'
+>;
+
+type BuilderExtras = {
+	argv?: Array<string>;
+	env?: Exclude<typeof process.env, 'clear'>;
+};


### PR DESCRIPTION
**Problem:**
When installing the onerepo cli, if the user installs while under a path that includes spaces the installation fails to escape the spaces breaking the command 

**Solution:**
Escape any spaces in the installation path during install