### PR TITLE
fix(test-cli): remove unnecessary parse/unparse steps in test builder

### DIFF
--- a/.changeset/hip-rockets-retire.md
+++ b/.changeset/hip-rockets-retire.md
@@ -1,0 +1,5 @@
+---
+'@onerepo/test-cli': patch
+---
+
+Made parsing input arguments to `run()` and `build()` in tests more reliable by going straight to Yargs instead of parse/unparse.

--- a/.changeset/orange-books-study.md
+++ b/.changeset/orange-books-study.md
@@ -1,0 +1,6 @@
+---
+'@onerepo/core': patch
+'onerepo': patch
+---
+
+Add missing dependency, 'semver'.

--- a/modules/core/package.json
+++ b/modules/core/package.json
@@ -28,7 +28,6 @@
 		"@onerepo/logger": "0.4.0",
 		"@onerepo/subprocess": "0.5.0",
 		"@onerepo/yargs": "0.5.0",
-		"@types/semver": "^7.5.3",
 		"ajv": "^8.12.0",
 		"ajv-errors": "^3.0.0",
 		"cjson": "^0.5.0",
@@ -46,6 +45,7 @@
 		"remark-gfm": "^3.0.1",
 		"remark-parse": "^10.0.1",
 		"remark-stringify": "^10.0.2",
+		"semver": "^7.5.4",
 		"unified": "^10.1.2",
 		"yargs": "^17.6.2"
 	},
@@ -58,6 +58,7 @@
 		"@types/inquirer": "^9.0.3",
 		"@types/js-yaml": "^4.0.6",
 		"@types/npmlog": "^4.1.4",
+		"@types/semver": "^7.5.3",
 		"@types/unist": "^2.0.8",
 		"@types/yargs": "^17.0.26",
 		"typescript": "^5.0.4"

--- a/modules/test-cli/package.json
+++ b/modules/test-cli/package.json
@@ -25,13 +25,10 @@
 		"@onerepo/graph": "0.9.0",
 		"@onerepo/logger": "0.4.0",
 		"@onerepo/yargs": "0.5.0",
-		"yargs": "^17.6.2",
-		"yargs-parser": "^21.1.1",
-		"yargs-unparser": "^2.0.0"
+		"yargs": "^17.6.2"
 	},
 	"devDependencies": {
 		"@internal/tsconfig": "workspace:^",
-		"@types/yargs-unparser": "^2.0.1",
 		"typescript": "^5.0.4"
 	},
 	"engines": {

--- a/modules/test-cli/src/index.ts
+++ b/modules/test-cli/src/index.ts
@@ -2,15 +2,12 @@ import { PassThrough } from 'node:stream';
 import path from 'node:path';
 import url from 'node:url';
 import Yargs from 'yargs';
-import parser from 'yargs-parser';
-import unparser from 'yargs-unparser';
 import * as builders from '@onerepo/builders';
 import { parserConfiguration, setupYargs } from '@onerepo/yargs';
 import { destroyLogger, getLogger } from '@onerepo/logger';
 import { getGraph } from '@onerepo/graph';
 import type { MiddlewareFunction } from 'yargs';
 import type { Argv, Builder, Handler, HandlerExtra } from '@onerepo/yargs';
-import type { Arguments } from 'yargs-unparser';
 
 // @ts-ignore
 const testRunner: typeof vitest | typeof jest =
@@ -26,10 +23,6 @@ export async function runBuilder<R = Record<string, unknown>>(
 	cmd = '',
 	builderExtras?: BuilderExtras,
 ): Promise<Argv<R>> {
-	const inputArgs = parser(cmd, {
-		configuration: parserConfiguration,
-	});
-
 	process.env = {
 		...process.env,
 		ONE_REPO_VERBOSITY: '4',
@@ -41,7 +34,7 @@ export async function runBuilder<R = Record<string, unknown>>(
 
 	const spy = testRunner.spyOn(console, 'error').mockImplementation(() => {});
 
-	const yargs = Yargs(unparser(inputArgs as Arguments).join(' '));
+	const yargs = Yargs(cmd).parserConfiguration(parserConfiguration);
 
 	testRunner.spyOn(yargs, 'exit').mockImplementation(() => {
 		throw new Error('Process unexpectedly exited early');

--- a/plugins/jest/package.json
+++ b/plugins/jest/package.json
@@ -25,15 +25,13 @@
 	"dependencies": {
 		"@onerepo/builders": "0.4.0",
 		"@onerepo/git": "0.3.0",
-		"@onerepo/subprocess": "0.5.0",
-		"yargs-unparser": "^2.0.0"
+		"@onerepo/subprocess": "0.5.0"
 	},
 	"devDependencies": {
 		"@internal/jest-config": "workspace:^",
 		"@internal/tsconfig": "workspace:^",
 		"@onerepo/core": "workspace:^",
 		"@onerepo/test-cli": "workspace:^",
-		"@types/yargs-unparser": "^2.0.1",
 		"esbuild-register": "^3.5.0",
 		"onerepo": "workspace:^",
 		"typescript": "^5.0.4"

--- a/plugins/vitest/package.json
+++ b/plugins/vitest/package.json
@@ -25,15 +25,13 @@
 	"dependencies": {
 		"@onerepo/builders": "0.4.0",
 		"@onerepo/git": "0.3.0",
-		"@onerepo/subprocess": "0.5.0",
-		"yargs-unparser": "^2.0.0"
+		"@onerepo/subprocess": "0.5.0"
 	},
 	"devDependencies": {
 		"@internal/tsconfig": "workspace:^",
 		"@internal/vitest-config": "workspace:^",
 		"@onerepo/core": "workspace:^",
 		"@onerepo/test-cli": "workspace:^",
-		"@types/yargs-unparser": "^2.0.1",
 		"esbuild-register": "^3.5.0",
 		"onerepo": "workspace:^",
 		"typescript": "^5.0.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2865,6 +2865,7 @@ __metadata:
     remark-gfm: ^3.0.1
     remark-parse: ^10.0.1
     remark-stringify: ^10.0.2
+    semver: ^7.5.4
     typescript: ^5.0.4
     unified: ^10.1.2
     yargs: ^17.6.2
@@ -3049,11 +3050,9 @@ __metadata:
     "@onerepo/git": 0.3.0
     "@onerepo/subprocess": 0.5.0
     "@onerepo/test-cli": "workspace:^"
-    "@types/yargs-unparser": ^2.0.1
     esbuild-register: ^3.5.0
     onerepo: "workspace:^"
     typescript: ^5.0.4
-    yargs-unparser: ^2.0.0
   peerDependencies:
     jest: ">=29"
   languageName: unknown
@@ -3120,11 +3119,9 @@ __metadata:
     "@onerepo/git": 0.3.0
     "@onerepo/subprocess": 0.5.0
     "@onerepo/test-cli": "workspace:^"
-    "@types/yargs-unparser": ^2.0.1
     esbuild-register: ^3.5.0
     onerepo: "workspace:^"
     typescript: ^5.0.4
-    yargs-unparser: ^2.0.0
   peerDependencies:
     vitest: ^0
   languageName: unknown
@@ -3181,11 +3178,8 @@ __metadata:
     "@onerepo/graph": 0.9.0
     "@onerepo/logger": 0.4.0
     "@onerepo/yargs": 0.5.0
-    "@types/yargs-unparser": ^2.0.1
     typescript: ^5.0.4
     yargs: ^17.6.2
-    yargs-parser: ^21.1.1
-    yargs-unparser: ^2.0.0
   languageName: unknown
   linkType: soft
 
@@ -4213,13 +4207,6 @@ __metadata:
   version: 21.0.0
   resolution: "@types/yargs-parser@npm:21.0.0"
   checksum: b2f4c8d12ac18a567440379909127cf2cec393daffb73f246d0a25df36ea983b93b7e9e824251f959e9f928cbc7c1aab6728d0a0ff15d6145f66cec2be67d9a2
-  languageName: node
-  linkType: hard
-
-"@types/yargs-unparser@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "@types/yargs-unparser@npm:2.0.1"
-  checksum: 487da23fec6749efc888f1540a30ff229572e680fe2b8a440c974283ab51a093490ba8fefc8f478f68dc4416a226ccac9f7ed0e60c2e5dc4695a57a40b3fdf65
   languageName: node
   linkType: hard
 
@@ -5938,7 +5925,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"camelcase@npm:^6.0.0, camelcase@npm:^6.2.0":
+"camelcase@npm:^6.2.0":
   version: 6.3.0
   resolution: "camelcase@npm:6.3.0"
   checksum: 8c96818a9076434998511251dcb2761a94817ea17dbdc37f47ac080bd088fc62c7369429a19e2178b993497132c8cbcf5cc1f44ba963e76782ba469c0474938d
@@ -6904,13 +6891,6 @@ __metadata:
   dependencies:
     callsite: ^1.0.0
   checksum: e88d0c5b27266d3dcab96aed5c34c02551cea4b5ec4df452a07ea89b35426e63053ba5f07d6837ecb958f7ebfea5adaa12c353da7b2f242f89cdef1aa3ba30c2
-  languageName: node
-  linkType: hard
-
-"decamelize@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "decamelize@npm:4.0.0"
-  checksum: b7d09b82652c39eead4d6678bb578e3bebd848add894b76d0f6b395bc45b2d692fb88d977e7cfb93c4ed6c119b05a1347cef261174916c2e75c0a8ca57da1809
   languageName: node
   linkType: hard
 
@@ -8893,15 +8873,6 @@ __metadata:
     flatted: ^3.1.0
     rimraf: ^3.0.2
   checksum: 4fdd10ecbcbf7d520f9040dd1340eb5dfe951e6f0ecf2252edeec03ee68d989ec8b9a20f4434270e71bcfd57800dc09b3344fca3966b2eb8f613072c7d9a2365
-  languageName: node
-  linkType: hard
-
-"flat@npm:^5.0.2":
-  version: 5.0.2
-  resolution: "flat@npm:5.0.2"
-  bin:
-    flat: cli.js
-  checksum: 12a1536ac746db74881316a181499a78ef953632ddd28050b7a3a43c62ef5462e3357c8c29d76072bb635f147f7a9a1f0c02efef6b4be28f8db62ceb3d5c7f5d
   languageName: node
   linkType: hard
 
@@ -19387,18 +19358,6 @@ __metadata:
   version: 21.1.1
   resolution: "yargs-parser@npm:21.1.1"
   checksum: ed2d96a616a9e3e1cc7d204c62ecc61f7aaab633dcbfab2c6df50f7f87b393993fe6640d017759fe112d0cb1e0119f2b4150a87305cc873fd90831c6a58ccf1c
-  languageName: node
-  linkType: hard
-
-"yargs-unparser@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "yargs-unparser@npm:2.0.0"
-  dependencies:
-    camelcase: ^6.0.0
-    decamelize: ^4.0.0
-    flat: ^5.0.2
-    is-plain-obj: ^2.1.0
-  checksum: 68f9a542c6927c3768c2f16c28f71b19008710abd6b8f8efbac6dcce26bbb68ab6503bed1d5994bdbc2df9a5c87c161110c1dfe04c6a3fe5c6ad1b0e15d9a8a3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
**Problem:**

When attempting to run a test with something like `run('-w "foo bar"')`, the argument parser in tests was resulting in arguments `{ _: ['bar'], 'w': 'foo' }`, but we expect it to be `{ _: [], 'w': 'foo bar' }`

**Solution:**

There was a `parse` + `unparse` step within the `builder` for the test-cli, likely existed for some historical reasons that are no longer relevant. This removes them.

Also sneaking in a fix for missing semver dependency.