### PR TITLE
feat(logger): add all log passthroughs for bufferSubLogger

### DIFF
--- a/modules/logger/src/Logger.ts
+++ b/modules/logger/src/Logger.ts
@@ -73,7 +73,6 @@ export class Logger {
 
 		this.#logger = new LogStep('', {
 			onEnd: this.#onEnd,
-			onError: this.#onError,
 			verbosity: this.verbosity,
 			stream: this.#stream,
 		});
@@ -120,10 +119,24 @@ export class Logger {
 	}
 
 	/**
-	 * Escape hatch, mostly for testing purposes. You probably shouldn’t use this.
+	 * Whether or not a warning has been sent to the logger or any of its steps.
 	 */
-	set hasError(has: boolean) {
-		this.#logger.hasError = has;
+	get hasWarning() {
+		return this.#logger.hasWarning;
+	}
+
+	/**
+	 * Whether or not an info message has been sent to the logger or any of its steps.
+	 */
+	get hasInfo() {
+		return this.#logger.hasInfo;
+	}
+
+	/**
+	 * Whether or not a log message has been sent to the logger or any of its steps.
+	 */
+	get hasLog() {
+		return this.#logger.hasLog;
 	}
 
 	/**
@@ -194,7 +207,6 @@ export class Logger {
 	createStep(name: string, { writePrefixes }: { writePrefixes?: boolean } = {}) {
 		const step = new LogStep(name, {
 			onEnd: this.#onEnd,
-			onError: this.#onError,
 			verbosity: this.verbosity,
 			stream: this.#stream,
 			writePrefixes,
@@ -316,9 +328,5 @@ export class Logger {
 		if (this.#steps.length) {
 			this.#activate(this.#steps[0]);
 		}
-	};
-
-	#onError = () => {
-		this.#logger.hasError = true;
 	};
 }

--- a/modules/logger/src/Logger.ts
+++ b/modules/logger/src/Logger.ts
@@ -62,6 +62,11 @@ export class Logger {
 	#paused = false;
 	#updaterTimeout: NodeJS.Timeout | undefined;
 
+	#hasError = false;
+	#hasWarning = false;
+	#hasInfo = false;
+	#hasLog = false;
+
 	/**
 	 * @internal
 	 */
@@ -115,28 +120,28 @@ export class Logger {
 	 * Whether or not an error has been sent to the logger or any of its steps. This is not necessarily indicative of uncaught thrown errors, but solely on whether `.error()` has been called in the `Logger` or any `Step` instance.
 	 */
 	get hasError() {
-		return this.#logger.hasError;
+		return this.#hasError;
 	}
 
 	/**
 	 * Whether or not a warning has been sent to the logger or any of its steps.
 	 */
 	get hasWarning() {
-		return this.#logger.hasWarning;
+		return this.#hasWarning;
 	}
 
 	/**
 	 * Whether or not an info message has been sent to the logger or any of its steps.
 	 */
 	get hasInfo() {
-		return this.#logger.hasInfo;
+		return this.#hasInfo;
 	}
 
 	/**
 	 * Whether or not a log message has been sent to the logger or any of its steps.
 	 */
 	get hasLog() {
-		return this.#logger.hasLog;
+		return this.#hasLog;
 	}
 
 	/**
@@ -314,6 +319,11 @@ export class Logger {
 		if (step === this.#logger) {
 			return;
 		}
+
+		this.#hasError = this.#hasError || step.hasError;
+		this.#hasWarning = this.#hasWarning || step.hasWarning;
+		this.#hasInfo = this.#hasInfo || step.hasInfo;
+		this.#hasLog = this.#hasLog || step.hasLog;
 
 		this.#updater.clear();
 		await step.flush();

--- a/modules/logger/src/index.ts
+++ b/modules/logger/src/index.ts
@@ -97,10 +97,16 @@ export function bufferSubLogger(step: LogStep): { logger: Logger; end: () => Pro
 		if (!step.writable) {
 			return;
 		}
-		if (subLogger.hasError) {
+		if (subLogger.hasError && logger.verbosity >= 1) {
 			step.error(chunk.toString().trimEnd());
-		} else if (logger.verbosity > 3) {
+		} else if (subLogger.hasInfo && logger.verbosity >= 1) {
+			step.info(chunk.toString().trimEnd());
+		} else if (subLogger.hasWarning && logger.verbosity >= 2) {
+			step.warn(chunk.toString().trimEnd());
+		} else if (subLogger.hasLog && logger.verbosity >= 3) {
 			step.log(chunk.toString().trimEnd());
+		} else if (logger.verbosity >= 4) {
+			step.debug(chunk.toString().trimEnd());
 		}
 	});
 


### PR DESCRIPTION
**Problem:**

When using `bufferSubLogger` (like with `tasks`), only errors are buffered through.

**Solution:**

Add `.hasWarning`, `.hasInfo`, `.hasLog` to `LogStep` and `Logger`, check those and verbosity and pass through accordingly.

Removes `onError` from `LogStep` as that's not really necessary anymore.