### PR TITLE
fix: ensure getWorkspaces respects --staged flag

### DIFF
--- a/.changeset/young-roses-divide.md
+++ b/.changeset/young-roses-divide.md
@@ -3,4 +3,4 @@
 'onerepo': minor
 ---
 
-`tasks` will now stash any unstaged changes when running the `pre-commit` lifecycle and reapply them after completion. This option is configurable using the `stagedOnly` option on `core.tasks` in `setup()`. Alternatively, you can manully pass `--staged` to the command.
+`tasks` will now stash any unstaged changes when running the `pre-commit` lifecycle and reapply them after completion. This option is configurable using the `stagedOnly` option on `core.tasks` in `setup()`. Alternatively, you can manually pass `--staged` to the command.

--- a/.changeset/young-roses-divide.md
+++ b/.changeset/young-roses-divide.md
@@ -3,4 +3,4 @@
 'onerepo': minor
 ---
 
-`tasks` will now stash any unstaged changes when running the `pre-commit` lifecycle and reapply them after completion. This option is configurable using the `stagedOnly` option on `core.tasks` in `setup()`.
+`tasks` will now stash any unstaged changes when running the `pre-commit` lifecycle and reapply them after completion. This option is configurable using the `stagedOnly` option on `core.tasks` in `setup()`. Alternatively, you can manully pass `--staged` to the command.

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
-./bin/one.cjs tasks -c pre-commit
+./bin/one.cjs tasks -c pre-commit --staged

--- a/docs/.eslintrc.cjs
+++ b/docs/.eslintrc.cjs
@@ -30,5 +30,3 @@ module.exports = {
 		},
 	],
 };
-
-// test

--- a/docs/.eslintrc.cjs
+++ b/docs/.eslintrc.cjs
@@ -30,3 +30,5 @@ module.exports = {
 		},
 	],
 };
+
+// test

--- a/modules/builders/src/getters.ts
+++ b/modules/builders/src/getters.ts
@@ -133,12 +133,13 @@ export async function getWorkspaces(
 		if ('affected' in argv && argv.affected) {
 			if (!workspaces.length) {
 				step.log(`\`affected\` requested`);
-				workspaces = await getAffected(graph, {
-					...opts,
-					from: argv['from-ref'] ?? from,
-					through: argv['through-ref'] ?? through,
-					step,
-				});
+				let affectedOptions: Parameters<typeof getAffected>[1];
+				if (argv.staged ?? staged) {
+					affectedOptions = { ...opts, staged: true, step };
+				} else {
+					affectedOptions = { ...opts, from: argv['from-ref'] ?? from, through: argv['through-ref'] ?? through, step };
+				}
+				workspaces = await getAffected(graph, affectedOptions);
 			} else {
 				const names = workspaces.map((ws) => ws.name);
 				step.log(`\`affected\` requested from • ${names.join('\n • ')}`);

--- a/modules/core/src/core/tasks/README.md
+++ b/modules/core/src/core/tasks/README.md
@@ -17,7 +17,11 @@ Next, create a `onerepo.config.js` file in your root workspace.
 /** @type import('onerepo').TaskConfig */
 export default {
 	'pre-commit': {
-		serial: [{ match: '**/*.{ts,tsx,js,jsx}', cmd: '$0 lint --add' }, '$0 format --add', '$0 tsc'],
+		serial: [
+			{ match: '**/*.{ts,tsx,js,jsx}', cmd: '$0 lint --staged --add' },
+			'$0 format --staged --add',
+			'$0 tsc --staged',
+		],
 		parallel: [
 			{ match: '**/commands/**/*.ts', cmd: '$0 docgen --add' },
 			{ match: '**/package.json', cmd: '$0 graph verify' },

--- a/modules/core/src/core/tasks/commands/tasks.ts
+++ b/modules/core/src/core/tasks/commands/tasks.ts
@@ -29,11 +29,10 @@ export const command = 'tasks';
 export const description =
 	'Run tasks against repo-defined lifecycles. This command will limit the tasks across the affected workspace set based on the current state of the repository.';
 
-type Argv = {
+export type Argv = {
 	ignore: Array<string>;
 	lifecycle: Lifecycle;
 	list?: boolean;
-	'staged-only-lifecycles': Array<string>;
 	'ignore-unstaged'?: boolean;
 } & builders.WithWorkspaces &
 	builders.WithAffected;
@@ -80,13 +79,10 @@ export const builder: Builder<Argv> = (yargs) =>
 				'Force staged-changes mode on or off. If `true`, task determination and runners will ignore unstaged changes.',
 			type: 'boolean',
 		})
-		.option('staged-only-lifecycles', {
-			description: 'Ignore unstaged changes for these lifecycles.',
-			type: 'array',
-			string: true,
-			default: ['pre-commit'],
-			hidden: true,
-		});
+		.describe(
+			'staged',
+			'Backup unstaged files and use only those on the git stage to calculate affected files or workspaces. Will re-apply the unstaged files upon exit.',
+		);
 
 export const handler: Handler<Argv> = async (argv, { getWorkspaces, graph, logger, config }) => {
 	const { affected, ignore, lifecycle, list, 'from-ref': fromRef, staged, 'through-ref': throughRef } = argv;

--- a/modules/core/src/core/tasks/commands/tasks.ts
+++ b/modules/core/src/core/tasks/commands/tasks.ts
@@ -96,15 +96,14 @@ export const handler: Handler<Argv> = async (argv, { getWorkspaces, graph, logge
 		lifecycle,
 		list,
 		'from-ref': fromRef,
-		staged,
 		'staged-only-lifecycles': stagedOnly,
 		'through-ref': throughRef,
 	} = argv;
 
-	const unstagedOnly = stagedOnly.includes(lifecycle) || ignoreUnstaged;
+	const isStagedOnlyLifecycle = stagedOnly.includes(lifecycle) || ignoreUnstaged;
 
 	const stagingWorkflow = new StagingWorkflow({ graph, logger });
-	if (unstagedOnly) {
+	if (isStagedOnlyLifecycle) {
 		await stagingWorkflow.saveUnstaged();
 	}
 
@@ -114,7 +113,7 @@ export const handler: Handler<Argv> = async (argv, { getWorkspaces, graph, logge
 	const workspaces = affected ? graph.affected(requested) : requested;
 	const workspaceNames = workspaces.map(({ name }) => name);
 
-	const modifiedOpts = staged
+	const modifiedOpts = isStagedOnlyLifecycle
 		? { staged: true, step: setupStep }
 		: { from: fromRef, through: throughRef, step: setupStep };
 	const allFiles = await git.getModifiedFiles(modifiedOpts);
@@ -204,7 +203,7 @@ export const handler: Handler<Argv> = async (argv, { getWorkspaces, graph, logge
 		}
 	}
 
-	if (unstagedOnly) {
+	if (isStagedOnlyLifecycle) {
 		await stagingWorkflow.restoreUnstaged();
 	}
 

--- a/modules/core/src/core/tasks/commands/tasks.ts
+++ b/modules/core/src/core/tasks/commands/tasks.ts
@@ -89,21 +89,10 @@ export const builder: Builder<Argv> = (yargs) =>
 		});
 
 export const handler: Handler<Argv> = async (argv, { getWorkspaces, graph, logger, config }) => {
-	const {
-		affected,
-		ignore,
-		'ignore-unstaged': ignoreUnstaged,
-		lifecycle,
-		list,
-		'from-ref': fromRef,
-		'staged-only-lifecycles': stagedOnly,
-		'through-ref': throughRef,
-	} = argv;
-
-	const isStagedOnlyLifecycle = stagedOnly.includes(lifecycle) || ignoreUnstaged;
+	const { affected, ignore, lifecycle, list, 'from-ref': fromRef, staged, 'through-ref': throughRef } = argv;
 
 	const stagingWorkflow = new StagingWorkflow({ graph, logger });
-	if (isStagedOnlyLifecycle) {
+	if (staged) {
 		await stagingWorkflow.saveUnstaged();
 	}
 
@@ -113,7 +102,7 @@ export const handler: Handler<Argv> = async (argv, { getWorkspaces, graph, logge
 	const workspaces = affected ? graph.affected(requested) : requested;
 	const workspaceNames = workspaces.map(({ name }) => name);
 
-	const modifiedOpts = isStagedOnlyLifecycle
+	const modifiedOpts = staged
 		? { staged: true, step: setupStep }
 		: { from: fromRef, through: throughRef, step: setupStep };
 	const allFiles = await git.getModifiedFiles(modifiedOpts);
@@ -203,7 +192,7 @@ export const handler: Handler<Argv> = async (argv, { getWorkspaces, graph, logge
 		}
 	}
 
-	if (isStagedOnlyLifecycle) {
+	if (staged) {
 		await stagingWorkflow.restoreUnstaged();
 	}
 

--- a/modules/git/src/index.ts
+++ b/modules/git/src/index.ts
@@ -191,7 +191,8 @@ export async function getModifiedFiles(
 		const isMain = base === currentSha;
 		const isCleanState = await isClean({ step });
 
-		const uncleanArgs = ['diff', '--name-only', '-z', ...(staged ? ['--cached'] : []), '--diff-filter', 'ACMR', base];
+		const uncleanArgs = ['diff', '--name-only', '-z', '--diff-filter', 'ACMR'];
+		uncleanArgs.push(!staged ? base : '--cached');
 		const cleanMainArgs = [
 			'diff-tree',
 			'-r',

--- a/onerepo.config.js
+++ b/onerepo.config.js
@@ -1,7 +1,7 @@
 /** @type import('onerepo').graph.TaskConfig */
 export default {
 	'pre-commit': {
-		serial: [['$0 lint --add', '$0 format --add'], '$0 tsc'],
+		serial: [['$0 lint --staged --add', '$0 format --staged --add'], '$0 tsc --staged'],
 		parallel: [{ match: '**/package.json', cmd: '$0 graph verify' }],
 	},
 	'pre-merge': {


### PR DESCRIPTION
**Problem:**

You may only want to run some commands against `--staged` files, which is an option on `getAffected`. However, `getWorkspaces` does not respect nor pass this flag along through when getting affected files.

**Solution:**

Ensure `getWorkspaces()` passes the `staged` option through.