### PR TITLE
fix(git): skip HUSKY during git checkout

### DIFF
--- a/.changeset/orange-cups-nail.md
+++ b/.changeset/orange-cups-nail.md
@@ -1,0 +1,7 @@
+---
+'@onerepo/git': patch
+'onerepo': patch
+'@onerepo/core': patch
+---
+
+Ensure Husky hooks are skipped during git checkout

--- a/modules/git/src/workflow.ts
+++ b/modules/git/src/workflow.ts
@@ -161,6 +161,9 @@ export class StagingWorkflow {
 				cmd: 'git',
 				args: ['checkout', '--force', '.'],
 				runDry: true,
+				opts: {
+					env: { HUSKY: '0' },
+				},
 				step,
 			});
 		}
@@ -197,6 +200,9 @@ export class StagingWorkflow {
 					cmd: 'git',
 					args: ['stash', 'apply', '--quiet', '--index', stashIndex],
 					runDry: true,
+					opts: {
+						env: { HUSKY: '0' },
+					},
 					step,
 					skipFailures: true,
 				});
@@ -211,6 +217,9 @@ export class StagingWorkflow {
 					args: ['apply', ...args],
 					skipFailures: true,
 					runDry: true,
+					opts: {
+						env: { HUSKY: '0' },
+					},
 					step,
 				});
 			} catch (e) {
@@ -220,6 +229,9 @@ export class StagingWorkflow {
 						cmd: 'git',
 						args: ['apply', '--3way', ...args],
 						runDry: true,
+						opts: {
+							env: { HUSKY: '0' },
+						},
 						step,
 					});
 				} catch (e) {
@@ -229,6 +241,9 @@ export class StagingWorkflow {
 						cmd: 'git',
 						args: ['reset', '--hard', 'HEAD'],
 						runDry: true,
+						opts: {
+							env: { HUSKY: '0' },
+						},
 						step,
 					});
 


### PR DESCRIPTION
If a repo has a long running post-checkout hook, the staging piece of the git workflow during `one tasks -c pre-commit` will end up taking a bunch of time that we really don't want to wait for. It should be safe to skip these hooks.