### PR TITLE
fix: remove verbosity on non project ref tsc runs

### DIFF
--- a/plugins/typescript/src/commands/typescript.ts
+++ b/plugins/typescript/src/commands/typescript.ts
@@ -92,13 +92,7 @@ export const handler: Handler<Argv> = async (argv, { getWorkspaces, graph, logge
 			memo.push({
 				name: `Typecheck ${workspace.name}`,
 				cmd: 'tsc',
-				args: [
-					'-p',
-					workspace.resolve(tsconfig),
-					'--noEmit',
-					pretty ? '--pretty' : '--no-pretty',
-					...(verbosity > 3 ? ['--verbose'] : []),
-				],
+				args: ['-p', workspace.resolve(tsconfig), '--noEmit', pretty ? '--pretty' : '--no-pretty'],
 			});
 		}
 		return memo;


### PR DESCRIPTION
**Problem:**

Non project reference enabled project started erroring during `tsc` with this error message

>    │ ERR error TS5093: Compiler option '--verbose' may only be used with '--build'.

**Solultion:**

Remove `--verbosity` flag from `tsc` when running on non project reference enabled workspaces