### PR TITLE
fix: remove verbosity on non project ref tsc runs

### DIFF
--- a/.changeset/thin-plums-accept.md
+++ b/.changeset/thin-plums-accept.md
@@ -1,0 +1,5 @@
+---
+'@onerepo/plugin-typescript': patch
+---
+
+Removes incorrect `--verbose` flag on `tsc` when not using project references.

--- a/plugins/typescript/src/commands/__tests__/typescript.test.ts
+++ b/plugins/typescript/src/commands/__tests__/typescript.test.ts
@@ -78,4 +78,35 @@ describe('handler', () => {
 			}),
 		);
 	});
+
+	test('does not include verbose flag in non-build mode', async () => {
+		vi.spyOn(graph.packageManager, 'run').mockResolvedValue(['', '']);
+		vi.spyOn(graph.packageManager, 'batch').mockResolvedValue([['', '']]);
+		await run('-a -vvvvv');
+
+		expect(graph.packageManager.batch).toHaveBeenCalledWith(
+			expect.arrayContaining([
+				expect.objectContaining({
+					cmd: 'tsc',
+					args: expect.not.arrayContaining(['--verbose']),
+				}),
+			]),
+		);
+	});
+
+	test('includes verbose flag in in build mode (project references)', async () => {
+		vi.spyOn(graph.packageManager, 'run').mockResolvedValue(['', '']);
+		vi.spyOn(graph.packageManager, 'batch').mockResolvedValue([['', '']]);
+		vi.spyOn(file, 'read').mockResolvedValue('{}');
+		vi.spyOn(file, 'write').mockResolvedValue();
+
+		await run('-a --use-project-references -vvvv');
+
+		expect(graph.packageManager.run).toHaveBeenCalledWith(
+			expect.objectContaining({
+				cmd: 'tsc',
+				args: expect.arrayContaining(['--verbose']),
+			}),
+		);
+	});
 });

--- a/plugins/typescript/src/commands/typescript.ts
+++ b/plugins/typescript/src/commands/typescript.ts
@@ -92,13 +92,7 @@ export const handler: Handler<Argv> = async (argv, { getWorkspaces, graph, logge
 			memo.push({
 				name: `Typecheck ${workspace.name}`,
 				cmd: 'tsc',
-				args: [
-					'-p',
-					workspace.resolve(tsconfig),
-					'--noEmit',
-					pretty ? '--pretty' : '--no-pretty',
-					...(verbosity > 3 ? ['--verbose'] : []),
-				],
+				args: ['-p', workspace.resolve(tsconfig), '--noEmit', pretty ? '--pretty' : '--no-pretty'],
 			});
 		}
 		return memo;


### PR DESCRIPTION
(nb: copied from #506)

**Problem:**

Non project reference enabled project started erroring during `tsc` with this error message

>    │ ERR error TS5093: Compiler option '--verbose' may only be used with '--build'.

**Solultion:**

Remove `--verbosity` flag from `tsc` when running on non project reference enabled workspaces