### PR TITLE
perf(package-manager): use npm_config_user_agent env var

### DIFF
--- a/.changeset/tough-news-allow.md
+++ b/.changeset/tough-news-allow.md
@@ -1,0 +1,6 @@
+---
+'onerepo': minor
+'@onerepo/package-manager': minor
+---
+
+Potentially speed up package manager determination by using the `npm_config_user_agent` environment variable.

--- a/modules/package-manager/src/__tests__/get-package-manager.test.ts
+++ b/modules/package-manager/src/__tests__/get-package-manager.test.ts
@@ -2,6 +2,15 @@ import path from 'path';
 import { getPackageManagerName } from '../get-package-manager';
 
 describe('getPackageManagerName', () => {
+	let ua: string | undefined;
+	beforeAll(() => {
+		ua = process.env.npm_config_user_agent;
+	});
+
+	afterAll(() => {
+		process.env.npm_config_user_agent = ua;
+	});
+
 	test.concurrent.each([
 		['yarn', 'yarn@latest'],
 		['yarn', 'yarn@3.3.1'],
@@ -22,6 +31,16 @@ describe('getPackageManagerName', () => {
 		['yarn', 'yarnrcyml'],
 		['npm', 'unknown'],
 	])('gets "%s" from %s fixture', async (expected, fixture) => {
+		process.env.npm_config_user_agent = undefined;
 		expect(getPackageManagerName(path.join(__dirname, '__fixtures__', fixture))).toEqual(expected);
+	});
+
+	test.each([
+		['pnpm', 'pnpm/7.29.3 npm/? node/v20.5.1 darwin x64'],
+		['yarn', 'yarn/3.3.1 npm/? node/v20.5.1 darwin x64'],
+		['npm', 'npm/9.8.0 node/v20.5.1 darwin x64 workspaces/false'],
+	])('gets %s from the npm_config_user_agent var', async (expected, envvar) => {
+		process.env.npm_config_user_agent = envvar;
+		expect(getPackageManagerName('.')).toEqual(expected);
 	});
 });

--- a/modules/package-manager/src/get-package-manager.ts
+++ b/modules/package-manager/src/get-package-manager.ts
@@ -17,6 +17,17 @@ export function getPackageManagerName(cwd: string, fromPkgJson?: string): 'npm' 
 		}
 	}
 
+	const ua = process.env.npm_config_user_agent;
+	if (ua?.includes('yarn/')) {
+		return 'yarn';
+	}
+	if (ua?.includes('pnpm/')) {
+		return 'pnpm';
+	}
+	if (ua?.includes('npm/')) {
+		return 'npm';
+	}
+
 	return guessPackageManager(cwd) ?? 'npm';
 }
 


### PR DESCRIPTION
**Problem:**

Not really a problem, but determining the package manager through file lookups takes extra processing.

**Solution:**

If it is set, use the environment variable `npm_config_user_agent`