### PR TITLE
pref(prettier): enable prettier cache

### DIFF
--- a/.changeset/weak-pumpkins-kick.md
+++ b/.changeset/weak-pumpkins-kick.md
@@ -1,0 +1,5 @@
+---
+'@onerepo/plugin-prettier': minor
+---
+
+Enable using cache to speed up formatting files. This feature can be disabled at the plugin configuration level by setting `useCache: false` or by passing `--no-cache` to the command.

--- a/plugins/prettier/src/commands/__tests__/prettier.test.ts
+++ b/plugins/prettier/src/commands/__tests__/prettier.test.ts
@@ -48,7 +48,7 @@ describe('handler', () => {
 		expect(graph.packageManager.run).toHaveBeenCalledWith(
 			expect.objectContaining({
 				cmd: 'prettier',
-				args: ['--ignore-unknown', '--write', '.'],
+				args: ['--ignore-unknown', '--write', '--cache', '--cache-strategy', 'content', '.'],
 			}),
 		);
 	});
@@ -66,7 +66,15 @@ describe('handler', () => {
 		expect(graph.packageManager.run).toHaveBeenCalledWith(
 			expect.objectContaining({
 				cmd: 'prettier',
-				args: ['--ignore-unknown', '--write', 'modules/burritos', 'modules/tacos'],
+				args: [
+					'--ignore-unknown',
+					'--write',
+					'--cache',
+					'--cache-strategy',
+					'content',
+					'modules/burritos',
+					'modules/tacos',
+				],
 			}),
 		);
 	});
@@ -79,7 +87,7 @@ describe('handler', () => {
 		expect(graph.packageManager.run).toHaveBeenCalledWith(
 			expect.objectContaining({
 				cmd: 'prettier',
-				args: ['--ignore-unknown', '--list-different', '.'],
+				args: ['--ignore-unknown', '--list-different', '--cache', '--cache-strategy', 'content', '.'],
 			}),
 		);
 	});
@@ -102,7 +110,7 @@ bar/**/*
 		expect(graph.packageManager.run).toHaveBeenCalledWith(
 			expect.objectContaining({
 				cmd: 'prettier',
-				args: ['--ignore-unknown', '--write', 'foo.js'],
+				args: ['--ignore-unknown', '--write', '--cache', '--cache-strategy', 'content', 'foo.js'],
 			}),
 		);
 	});
@@ -126,7 +134,7 @@ bar/**/*
 		expect(graph.packageManager.run).toHaveBeenCalledWith(
 			expect.objectContaining({
 				cmd: 'prettier',
-				args: ['--ignore-unknown', '--write', 'bar.js'],
+				args: ['--ignore-unknown', '--write', '--cache', '--cache-strategy', 'content', 'bar.js'],
 			}),
 		);
 		expect(git.updateIndex).toHaveBeenCalledWith(['bar.js']);
@@ -146,5 +154,18 @@ bar/**/*
 		expect(core.error).toHaveBeenCalledWith(expect.stringContaining('This file needs formatting'), { file: 'foo.js' });
 		expect(core.error).toHaveBeenCalledWith(expect.stringContaining('This file needs formatting'), { file: 'bop.js' });
 		expect(core.error).not.toHaveBeenCalledWith(expect.any(String), { file: 'bar.js' });
+	});
+
+	test('can disable cache', async () => {
+		vi.spyOn(graph.packageManager, 'run').mockResolvedValue(['', '']);
+
+		await run('--all --no-cache');
+
+		expect(graph.packageManager.run).toHaveBeenCalledWith(
+			expect.objectContaining({
+				cmd: 'prettier',
+				args: ['--ignore-unknown', '--write', '.'],
+			}),
+		);
 	});
 });

--- a/plugins/prettier/src/index.ts
+++ b/plugins/prettier/src/index.ts
@@ -21,8 +21,14 @@ export type Options = {
 	name?: string | Array<string>;
 	/**
 	 * When `true` or unset and run in GitHub Actions, any files failing format checks will be annotated with an error in the GitHub user interface.
+	 * @default true
 	 */
 	githubAnnotate?: boolean;
+	/**
+	 * Whether to use Prettier's built-in cache determinism.
+	 * @default true
+	 */
+	useCache?: boolean;
 };
 
 /**
@@ -51,7 +57,8 @@ export function prettier(opts: Options = {}): Plugin {
 				(yargs) =>
 					builder(yargs)
 						.usage(`$0 ${Array.isArray(name) ? name[0] : name} [options]`)
-						.default('github-annotate', opts.githubAnnotate ?? true),
+						.default('github-annotate', opts.githubAnnotate ?? true)
+						.default('cache', opts.useCache ?? true),
 				handler,
 			);
 		},


### PR DESCRIPTION
**Problem:**

Prettier can be slow when there are many files (particularly with large repos and running with `--all`).

**Solution:**

Enable Prettier' cache by default.