### PR TITLE
feat: add engines check

### DIFF
--- a/modules/create/src/index.ts
+++ b/modules/create/src/index.ts
@@ -3,7 +3,8 @@ import { commandDirOptions, setupYargs } from '@onerepo/yargs';
 import { getLogger } from '@onerepo/logger';
 import * as command from './command';
 
-const yargs = setupYargs(createYargs(process.argv.slice(2)));
+const logger = getLogger();
+const yargs = setupYargs(createYargs(process.argv.slice(2)), { logger });
 
 const { emit: originalEmit } = process;
 
@@ -24,7 +25,7 @@ const { visit } = commandDirOptions({
 	// @ts-ignore
 	graph: null,
 	startup: () => Promise.resolve(),
-	logger: getLogger(),
+	logger,
 });
 
 yargs.demandCommand(0).command(visit(command));

--- a/modules/yargs/package.json
+++ b/modules/yargs/package.json
@@ -23,7 +23,8 @@
 	"dependencies": {
 		"@onerepo/builders": "0.5.5",
 		"@onerepo/logger": "0.5.0",
-		"@onerepo/subprocess": "0.6.0"
+		"@onerepo/subprocess": "0.6.0",
+		"semver": "^7.5.4"
 	},
 	"devDependencies": {
 		"@internal/tsconfig": "workspace:^",

--- a/modules/yargs/src/middleware/engine-check.ts
+++ b/modules/yargs/src/middleware/engine-check.ts
@@ -1,0 +1,33 @@
+import { intersects } from 'semver';
+import type { Graph } from '@onerepo/graph';
+import type { Logger } from '@onerepo/logger';
+import type { Argv as Yargv } from 'yargs';
+import type { Argv } from '@onerepo/yargs';
+
+export function checkEnginesMiddleware(yargs: Yargv, graph: Graph, logger: Logger) {
+	return async function checkEnginesMiddleware(argv: Omit<Argv, '--'>) {
+		if (argv['skip-engine-check']) {
+			return;
+		}
+
+		const supportedRange = graph.root.packageJson.engines?.node;
+		if (!supportedRange) {
+			return;
+		}
+
+		const currentVersion = process.versions.node;
+		if (intersects(currentVersion, supportedRange)) {
+			return;
+		}
+
+		logger.error(`\u0000
+Node.js version mismatch.
+
+Expected curren version ("${currentVersion}") to intersect "${supportedRange}".
+
+Install a version matching "${supportedRange}" or bypass this check by passing "--skip-engine-check".
+\u0000`);
+		await logger.end();
+		yargs.exit(1, new Error());
+	};
+}

--- a/modules/yargs/src/middleware/index.ts
+++ b/modules/yargs/src/middleware/index.ts
@@ -1,2 +1,3 @@
 export * from './environment';
 export * from './sudo-check';
+export * from './engine-check';

--- a/modules/yargs/src/middleware/sudo-check.ts
+++ b/modules/yargs/src/middleware/sudo-check.ts
@@ -1,13 +1,18 @@
-import { getLogger } from '@onerepo/logger';
-import type { Argv } from 'yargs';
+import type { Logger } from '@onerepo/logger';
+import type { Argv as Yargv } from 'yargs';
 
-export const sudoCheckMiddleware = (yargs: Argv) =>
-	function sudoCheckMiddleware() {
-		if (process.env.SUDO_UID) {
-			yargs.showHelp();
-			const msg =
-				'Do not run commands with `sudo`! If elevated permissions are required, commands will prompt you for your password only if and when necessary.';
-			getLogger().error(msg);
-			yargs.exit(1, new Error(msg));
+export function sudoCheckMiddleware(yargs: Yargv, logger: Logger) {
+	return async function sudoCheckMiddleware() {
+		if (!process.env.SUDO_UID) {
+			return;
 		}
+
+		logger.error(`\u0000
+Do not run commands with sudo!
+
+If elevated permissions are required, commands will prompt you for your password only if and when necessary.
+\u0000`);
+		await logger.end();
+		yargs.exit(1, new Error());
 	};
+}

--- a/package.json
+++ b/package.json
@@ -37,5 +37,8 @@
 		"prettier": "^3.0.0",
 		"typescript": "^5.0.4",
 		"vitest": "^1.1.1"
+	},
+	"engines": {
+		"node": "^18 || ^20"
 	}
 }

--- a/plugins/performance-writer/src/__tests__/index.test.ts
+++ b/plugins/performance-writer/src/__tests__/index.test.ts
@@ -10,7 +10,15 @@ async function tick() {
 	});
 }
 
-const argv = { $0: 'test-runner', _: [], '--': [], 'dry-run': false, silent: false, verbosity: 2 };
+const argv = {
+	$0: 'test-runner',
+	_: [],
+	'--': [],
+	'dry-run': false,
+	silent: false,
+	verbosity: 2,
+	'skip-engine-check': false,
+};
 
 describe('measure', () => {
 	beforeEach(() => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3409,6 +3409,7 @@ __metadata:
     "@onerepo/logger": 0.5.0
     "@onerepo/subprocess": 0.6.0
     "@types/yargs": ^17.0.26
+    semver: ^7.5.4
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
**Problem:**

In organizations where you may use multiple node versions due to legacy applications or don't have a distributed MDE, you might end up on the wrong node version, causing issues.

**Solution:**

We can build in a middleware check that can always run on every command to ensure the current engine matches that which is defined in the root package.json