### PR TITLE
chore: cleanup bin references

### DIFF
--- a/bin/one.mjs
+++ b/bin/one.mjs
@@ -1,6 +1,17 @@
 #!/usr/bin/env node
 import initJiti from 'jiti';
 
+/**
+ * Important note: this file is only necessary for the oneRepo source repository
+ * because we run all CI through the source files themselves, which are written
+ * in TypeScript. Without using this file, we will see errors like:
+ *
+ *   TypeError [ERR_UNKNOWN_FILE_EXTENSION]: Unknown file extension ".ts" …
+ *
+ * This is also the reason that the root package.json overrides the `bin` for
+ * the `one` CLI to point to this file.
+ */
+
 const jiti = initJiti(import.meta.url, { interopDefault: true });
 
 jiti('onerepo/src/bin/one.ts');

--- a/docs/src/content/docs/core/tasks.mdx
+++ b/docs/src/content/docs/core/tasks.mdx
@@ -243,7 +243,7 @@ jobs:
       - uses: paularmstrong/onerepo/actions/get-tasks@main
         id: tasks # important!: this must match the ID used in the output
         with:
-          cli: ./bin/one.cjs
+          packageManager: yarn
           lifecycle: pre-merge
 
   tasks:

--- a/modules/github-action/src/get-tasks.ts
+++ b/modules/github-action/src/get-tasks.ts
@@ -7,7 +7,7 @@ const lifecycle = core.getInput('lifecycle', { required: true });
 const verbosity = parseInt(core.getInput('verbosity') ?? 2, 10);
 
 const tasks = execSync(
-	`${overrideBin ?? `${pkgManager} one`} tasks --lifecycle=${lifecycle} --list -${'v'.repeat(verbosity)}`,
+	`${overrideBin ? overrideBin : `${pkgManager} one`} tasks --lifecycle=${lifecycle} --list -${'v'.repeat(verbosity)}`,
 	{ env: { ONEREPO_USE_HOOKS: '0', ...process.env } },
 )
 	.toString()


### PR DESCRIPTION
<!--

Please make sure you have read the contributing guidelines and code of conduct before submitting a pull request:

1. Contributing guidlines: https://onerepo.tools/project/contributing/
2. Code of conduct: https://onerepo.tools/project/code-of-conduct/

-->

**Problem:**

This file was held on to during the transition from old setup method requiring a custom `bin` file to run the `one` CLI. It should no longer be necessary.

**Solution:**

Turns out that the file is still necessary.

- Adds a note relating why it's needed here, but not in consumer repositories.
- Updates some documentation
- Fixes actions to use regular ternary instead of nullish coalescing to ensure the correct bin is used.

**Related issues:**

n/a

**Checklist:**

- [x] Added or updated tests
- [x] Added or updated documentation
- [x] Ensured the pre-commit hooks ran successfully

_By opening this pull request, you agree that this submission can be released under the same [License](https://github.com/paularmstrong/onerepo/blob/main/LICENSE.md) that covers the project._
