### PR TITLE
fix(logger): completed never logs 'with errors'

### DIFF
--- a/modules/logger/src/Logger.ts
+++ b/modules/logger/src/Logger.ts
@@ -366,6 +366,7 @@ export class Logger {
 		switch (type) {
 			case 'error':
 				this.#hasError = true;
+				this.#defaultLogger.hasError = true;
 				break;
 			case 'warn':
 				this.#hasWarning = true;

--- a/modules/logger/src/__tests__/Logger.test.ts
+++ b/modules/logger/src/__tests__/Logger.test.ts
@@ -91,6 +91,24 @@ describe('Logger', () => {
 		expect(out).toMatch(`${pc.dim(pc.bold('■'))} ${pc.green('✔')} Completed`);
 	});
 
+	test('logs "completed with errors" message', async () => {
+		const stream = new PassThrough();
+		let out = '';
+		stream.on('data', (chunk) => {
+			out += chunk.toString();
+		});
+
+		const logger = new Logger({ verbosity: 2, stream });
+
+		const step = logger.createStep('tacos');
+		step.error('foo');
+		await step.end();
+
+		await logger.end();
+
+		expect(out).toMatch(`${pc.dim(pc.bold('■'))} ${pc.red('✘')} Completed with errors`);
+	});
+
 	test('writes logs if verbosity increased after construction', async () => {
 		const stream = new PassThrough();
 		let out = '';


### PR DESCRIPTION
<!--

Please make sure you have read the contributing guidelines and code of conduct before submitting a pull request:

1. Contributing guidlines: https://onerepo.tools/project/contributing/
2. Code of conduct: https://onerepo.tools/project/code-of-conduct/

-->

**Problem:**

The logger was never clearly logging `Completed with errors`, only `Completed`

**Solution:**

Proxy the `hasErrors` through to the `defaultLogger` when an error message is received in any step.

**Related issues:**

<!--
- Link the issue or issues being fixed so they are appropriately tracked and marked closed.
-->

Fixes #565

**Checklist:**

- [x] Added or updated tests
- [x] ~Added or updated documentation~
- [x] Ensured the pre-commit hooks ran successfully

_By opening this pull request, you agree that this submission can be released under the same [License](https://github.com/paularmstrong/onerepo/blob/main/LICENSE.md) that covers the project._
