### PR TITLE
fix(core): install bin search location

### DIFF
--- a/modules/onerepo/src/core/install/__tests__/install.test.ts
+++ b/modules/onerepo/src/core/install/__tests__/install.test.ts
@@ -28,6 +28,7 @@ describe('handler', () => {
 	beforeEach(() => {
 		vi.spyOn(file, 'copy').mockResolvedValue();
 		vi.spyOn(file, 'remove').mockResolvedValue();
+		vi.spyOn(file, 'exists').mockResolvedValue(true);
 		vi.spyOn(file, 'write').mockResolvedValue();
 		vi.spyOn(file, 'writeSafe').mockResolvedValue();
 		vi.spyOn(subprocess, 'run').mockResolvedValue(['', '']);
@@ -57,6 +58,7 @@ describe('handler', () => {
 			// @ts-ignore acceptable in test
 			{ homedir: '/Users/test-user', shell: '/bin/bash' },
 		);
+		vi.spyOn(file, 'exists').mockResolvedValueOnce(false).mockResolvedValue(true);
 		await expect(run(args)).resolves.toMatch('source /Users/test-user/.bash_profile');
 
 		expect(file.write).toHaveBeenCalledWith(

--- a/modules/onerepo/src/core/install/install.ts
+++ b/modules/onerepo/src/core/install/install.ts
@@ -112,8 +112,24 @@ export default {
 BASEDIR=$(dirname $0)
 node "$BASEDIR/one.js" "$@"
 `;
+
+	let binLocation: string = '';
+	let cwd = fileURLToPath(import.meta.url);
+	while (!binLocation && cwd !== '/') {
+		const searchLocation = path.join(path.dirname(cwd), pkg.publishConfig.bin.one);
+		installStep.debug(`searching for bin: ${searchLocation}`);
+		if (await file.exists(searchLocation, { step: installStep })) {
+			installStep.debug(`found bin: ${searchLocation}`);
+			binLocation = searchLocation;
+		}
+		cwd = path.dirname(cwd);
+	}
+	if (!binLocation) {
+		installStep.error('Critical: unable to find oneRepo bin.');
+	}
+
 	await file.remove(path.join(location!, 'bin'), { step: installStep });
-	await file.copy(fileURLToPath(import.meta.url), path.join(location!, 'bin', 'one.js'), {
+	await file.copy(binLocation, path.join(location!, 'bin', 'one.js'), {
 		step: installStep,
 	});
 	await file.write(path.join(location!, 'bin', 'one'), binContents, { step: installStep });


### PR DESCRIPTION
<!--

Please make sure you have read the contributing guidelines and code of conduct before submitting a pull request:

1. Contributing guidlines: https://onerepo.tools/project/contributing/
2. Code of conduct: https://onerepo.tools/project/code-of-conduct/

-->

**Problem:**

Install doesn't work after you've added `onerepo` as a dependency and try to run `npm exec one install`

**Solution:**

Fix the `bin` file lookup for copying the correct file to the `~/.onerepo` folder.

**Related issues:**

<!--
- Link the issue or issues being fixed so they are appropriately tracked and marked closed.
-->

Fixes #

**Checklist:**

- [x] Added or updated tests
- [ ] Added or updated documentation
- [x] Ensured the pre-commit hooks ran successfully

_By opening this pull request, you agree that this submission can be released under the same [License](https://github.com/paularmstrong/onerepo/blob/main/LICENSE.md) that covers the project._
