### PR TITLE
feat(core): auto install node_modules if necessary

### DIFF
--- a/.changeset/sweet-stingrays-report.md
+++ b/.changeset/sweet-stingrays-report.md
@@ -1,0 +1,5 @@
+---
+'onerepo': minor
+---
+
+The oneRepo CLI will now automatically update node_modules using your repository's package manager whenever necessary, before running commands.

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ coverage/*
 **/*.tsbuildinfo
 *.eslintcache
 .netlify
+
+.cache

--- a/modules/onerepo/src/bin/utils/get-config.ts
+++ b/modules/onerepo/src/bin/utils/get-config.ts
@@ -1,0 +1,33 @@
+import path from 'node:path';
+import type { RootConfig } from '../../types';
+
+/**
+ * Gets the configuration file and dirname of the file starting at the process.cwd() and working upward until hitting the root of the filesystem.
+ * If not found, will return undefined.
+ */
+export function getConfig(require: NodeRequire, cwd: string = process.cwd()) {
+	// Find a root config starting at the current working directory, looking upward toward filesystem root
+	let configRoot = cwd;
+	let config: RootConfig | undefined;
+	let lastKnownPossibleRoot: string | undefined;
+	while (configRoot && configRoot !== '/') {
+		try {
+			const { default: conf } = require(path.join(configRoot, `onerepo.config`));
+			config = conf;
+			if (config?.root) {
+				break;
+			}
+			configRoot = path.dirname(configRoot);
+			config = undefined;
+		} catch (e) {
+			// @ts-ignore
+			if (e instanceof Error && e.code === 'MODULE_NOT_FOUND' && !/onerepo\.config['"]/.test(e.message)) {
+				lastKnownPossibleRoot = configRoot;
+			}
+			configRoot = path.dirname(configRoot);
+			config = undefined;
+		}
+	}
+
+	return { config, configRoot: configRoot !== '/' ? configRoot : lastKnownPossibleRoot ?? configRoot };
+}

--- a/modules/onerepo/src/bin/utils/update-node-modules.ts
+++ b/modules/onerepo/src/bin/utils/update-node-modules.ts
@@ -1,0 +1,57 @@
+import { createHash } from 'node:crypto';
+import { performance } from 'node:perf_hooks';
+import { existsSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+import { getLockfile, getLogger, Graph, file } from '../..';
+
+/**
+ * Attempt to run the `install` command for the local package manager.
+ * Bypass with env vars CI and ONEREPO_USE_HOOKS="0"
+ */
+export async function updateNodeModules(configRoot: string, require: NodeRequire) {
+	// Don't do this in CI or if the user does not like things auto-running
+	if (process.env.CI || process.env.ONEREPO_USE_HOOKS === '0') {
+		return;
+	}
+
+	const lockfile = getLockfile(configRoot);
+
+	if (!lockfile) {
+		return;
+	}
+
+	performance.mark('onerepo_start_check_modules_cache');
+	// Create a hash of the lockfile full path and use that as the cache name
+	// This should never change – if it does, it will be good to create a new cache file
+	const cacheFile = path.join(__dirname, '.cache', getHash(lockfile));
+
+	const cachedHash = existsSync(cacheFile) ? readFileSync(cacheFile, 'utf8') : '';
+	const currentHash = getHash(readFileSync(lockfile, 'utf8'));
+
+	if (currentHash !== cachedHash) {
+		// Create a logger so when there's feedback when we run the install
+		// But start it silenced, just in case.
+		const logger = getLogger({ verbosity: 0 });
+		const tempGraph = new Graph(configRoot, { name: 'onerepo-bin', private: true }, [], require);
+		process.env.ONEREPO_ROOT = configRoot;
+
+		// Increase the logger verbosity and run install
+		logger.verbosity = 1;
+		await tempGraph.packageManager.install();
+		logger.verbosity = 0;
+
+		// Back to silent, write out the hash of the lockfile to a cache for next time
+		await file.write(cacheFile, currentHash);
+		// End the logger and pop it off the global stack
+		// A new logger will be created when `setup()` is run
+		await logger.end();
+	}
+	performance.mark('onerepo_end_check_modules_cache');
+}
+
+/**
+ * Shortcut to create a hash of a string
+ */
+function getHash(contents: string) {
+	return createHash('sha1').update(contents).digest('hex');
+}


### PR DESCRIPTION
**Problem:**

One thing that comes up a bunch is needing to remember to run `npm install` periodically. If it's not done ahead of trying to run commands or work with code in the repo, developers can potentially receiving confusing errors, particularly coming from areas they haven't been working in.

**Solution:**

At the `one` level before setup, before even requiring the local `onerepo` package or any of its dependencies:

1. Ensure we are in a valid repo
2. Get the configuration and root of the repository
3. if in `CI` or `ONEREPO_USE_HOOKS="0"`, go to 9
4. Get the lockfile, if not exists, go to 9
5. get a hash of the lockfile's contents
6. check if the lockfile's content hash matches a cache from the last time we ran this (if it hasn't run, it does not match) if matches, go to 9
7. run `graph.packageManager.install()`
8. write the lockfile's content has to a cache file
9. continue importing `setup` from `'onerepo'` and run commands

Bonus: after splitting up and running the "global" version of `one` if a valid config/root does not exist, we can throw a better error message to help developers out when there are syntax errors in commands or other issues.

