### PR TITLE
refactor(core changesets): move publishablePackageJson into Workspace

### DIFF
--- a/.changeset/calm-goats-train.md
+++ b/.changeset/calm-goats-train.md
@@ -1,0 +1,7 @@
+---
+'@onerepo/graph': minor
+'onerepo': minor
+'@onerepo/plugin-changesets': minor
+---
+
+Refactored internals for applying `package.json` `publishConfig` entries. Use `workspace.publishablePackageJson` to get a safe version of the Workspace's `package.json` file, ready for publishing.

--- a/.changeset/new-rockets-study.md
+++ b/.changeset/new-rockets-study.md
@@ -1,5 +1,5 @@
 ---
-"onerepo": patch
+'onerepo': patch
 ---
 
 Fixed bug in writing out URLs for visualizer in which they may end up truncated prematurely.

--- a/modules/graph/src/Graph.ts
+++ b/modules/graph/src/Graph.ts
@@ -6,7 +6,7 @@ import { globSync } from 'glob';
 import { Graph as graph } from 'graph-data-structure';
 import type { PackageManager } from '@onerepo/package-manager';
 import { Workspace } from './Workspace';
-import type { PackageJson, PrivatePackageJson } from './Workspace';
+import type { PackageJson } from './Workspace';
 
 /**
  * @group Graph
@@ -95,7 +95,7 @@ export class Graph {
 	/**
 	 * @internal
 	 */
-	constructor(location: string, packageJson: PrivatePackageJson, workspaces: Array<string>, moduleRequire = require) {
+	constructor(location: string, packageJson: PackageJson, workspaces: Array<string>, moduleRequire = require) {
 		this.#require = moduleRequire;
 		this.#rootLocation = location;
 		this.#addWorkspace(location, packageJson);

--- a/modules/graph/src/__tests__/Workspace.test.ts
+++ b/modules/graph/src/__tests__/Workspace.test.ts
@@ -1,0 +1,94 @@
+import type { PublicPackageJson } from '../Workspace';
+import { Workspace } from '../Workspace';
+
+describe('Workspace', () => {
+	describe('publishablePackageJson', () => {
+		test('applies known keys over the root', async () => {
+			const pkg: PublicPackageJson = {
+				name: 'tacos',
+				version: '1.0.0',
+				main: './src/tacos.ts',
+				publishConfig: {
+					main: './dist/tacos.js',
+					typings: './dist/types/tacos.d.ts',
+				},
+			};
+			const ws = new Workspace(
+				'/root',
+				'/root/modules/bar',
+				pkg,
+				// @ts-ignore
+				vi.fn(() => ({})),
+			);
+
+			expect(ws.publishablePackageJson).toEqual({
+				name: 'tacos',
+				version: '1.0.0',
+				main: './dist/tacos.js',
+				typings: './dist/types/tacos.d.ts',
+				publishConfig: {},
+			});
+		});
+
+		test('preserves known publishConfig keys from npm', async () => {
+			const pkg: PublicPackageJson = {
+				name: 'tacos',
+				version: '1.0.0',
+				main: './src/tacos.ts',
+				publishConfig: {
+					main: './dist/tacos.js',
+					typings: './dist/types/tacos.d.ts',
+					access: 'public',
+					preid: '123',
+				},
+			};
+			const ws = new Workspace(
+				'/root',
+				'/root/modules/bar',
+				pkg,
+				// @ts-ignore
+				vi.fn(() => ({})),
+			);
+
+			expect(ws.publishablePackageJson).toEqual({
+				name: 'tacos',
+				version: '1.0.0',
+				main: './dist/tacos.js',
+				typings: './dist/types/tacos.d.ts',
+				publishConfig: {
+					access: 'public',
+					preid: '123',
+				},
+			});
+		});
+
+		test('strips devDependencies', async () => {
+			const pkg: PublicPackageJson = {
+				name: 'tacos',
+				version: '1.0.0',
+				dependencies: {
+					lettuce: '4.0.0',
+				},
+				devDependencies: {
+					grill: '1.5.0',
+				},
+			};
+			const ws = new Workspace(
+				'/root',
+				'/root/modules/bar',
+				pkg,
+				// @ts-ignore
+				vi.fn(() => ({})),
+			);
+
+			expect(ws.publishablePackageJson).toEqual({
+				name: 'tacos',
+				version: '1.0.0',
+				publishConfig: {},
+				dependencies: {
+					lettuce: '4.0.0',
+				},
+			});
+		});
+	});
+});

--- a/modules/graph/src/index.ts
+++ b/modules/graph/src/index.ts
@@ -4,7 +4,7 @@ import yaml from 'js-yaml';
 import { getLockfile, getPackageManagerName } from '@onerepo/package-manager';
 import initJiti from 'jiti';
 import { Graph } from './Graph';
-import type { PackageJson, PrivatePackageJson } from './Workspace';
+import type { PackageJson } from './Workspace';
 
 export * from './Graph';
 export * from './Workspace';
@@ -35,14 +35,14 @@ export function getGraph(workingDir: string = process.cwd()) {
 		}
 	}
 
-	return new Graph(workingDir, json as PrivatePackageJson, workspaces, jiti);
+	return new Graph(workingDir, json as PackageJson, workspaces, jiti);
 }
 
 /**
  * @internal
  */
-export function getRootPackageJson(searchLocation: string): { filePath: string; json: PrivatePackageJson } {
-	const match = getPackageJson<PrivatePackageJson>(searchLocation);
+export function getRootPackageJson(searchLocation: string): { filePath: string; json: PackageJson } {
+	const match = getPackageJson<PackageJson>(searchLocation);
 	if (getLockfile(path.dirname(match.filePath))) {
 		return match;
 	}

--- a/modules/onerepo/src/core/create/create.ts
+++ b/modules/onerepo/src/core/create/create.ts
@@ -8,7 +8,7 @@ import { exists, mkdirp, read, write, writeSafe } from '@onerepo/file';
 import { run } from '@onerepo/subprocess';
 import { getPackageManager, getPackageManagerName } from '@onerepo/package-manager';
 import type { Builder, Handler } from '@onerepo/yargs';
-import type { PrivatePackageJson } from '@onerepo/graph';
+import type { PackageJson } from '@onerepo/graph';
 
 export const command = ['create', 'init'];
 
@@ -75,10 +75,10 @@ export const handler: Handler<Argv> = async (argv, { logger }) => {
 	const outdir = dir ?? path.join(process.cwd(), location || '.');
 	const isExistingRepo = await exists(path.join(outdir, 'package.json'), { step: existStep });
 	let pkgManager: 'npm' | 'pnpm' | 'yarn' = 'npm';
-	let packageJson: PrivatePackageJson | null = null;
+	let packageJson: PackageJson | null = null;
 	if (isExistingRepo) {
 		const raw = await read(path.join(outdir, 'package.json'), 'r', { step: existStep });
-		packageJson = JSON.parse(raw) as PrivatePackageJson;
+		packageJson = JSON.parse(raw) as PackageJson;
 		pkgManager = getPackageManagerName(outdir, 'packageManager' in packageJson ? `${packageJson.packageManager}` : '');
 	}
 	let workspaces: Array<string> = packageJson?.workspaces ?? inputWorkspaces ?? [];
@@ -143,9 +143,9 @@ export const handler: Handler<Argv> = async (argv, { logger }) => {
 
 	logger.debug({ outdir, workspaces, plugins });
 
-	const outPackageJson: PrivatePackageJson = {
+	const outPackageJson = {
 		name: path.basename(outdir),
-		license: 'UNLICENSED',
+		license: 'UNLICENSED' as const,
 		private: true,
 		packageManager: `${pkgManager}@${pkgManagerVersion}`,
 		...packageJson,
@@ -160,7 +160,7 @@ export const handler: Handler<Argv> = async (argv, { logger }) => {
 				{} as Record<string, string>,
 			),
 		},
-	};
+	} as PackageJson;
 
 	if (pkgManager !== 'pnpm') {
 		outPackageJson.workspaces = workspaces.map((ws) => (/\/\*?$/.test(ws) ? ws : `${ws}/*`));

--- a/modules/package-manager/src/methods.ts
+++ b/modules/package-manager/src/methods.ts
@@ -60,7 +60,7 @@ export interface PackageManager {
 		/**
 		 * The base URL of your NPM registry. PNPM and NPM ignore scope and look up per-registry.
 		 */
-		registry?: string;
+		registry?: string | undefined;
 	}): Promise<boolean>;
 
 	/**

--- a/plugins/changesets/src/publish-config.ts
+++ b/plugins/changesets/src/publish-config.ts
@@ -1,33 +1,12 @@
 import { write } from '@onerepo/file';
 import { stepWrapper } from '@onerepo/logger';
 import type { LogStep } from '@onerepo/logger';
-import type { PublicPackageJson, Workspace } from '@onerepo/graph';
+import type { Workspace } from '@onerepo/graph';
 
 type Options = {
 	step?: LogStep;
 	write?: boolean;
 };
-
-const availableKeys = ['bin', 'main', 'module', 'typings', 'exports'];
-
-export function applyPublishConfig(packageJson: PublicPackageJson): PublicPackageJson {
-	const { devDependencies, publishConfig = {}, ...rest } = packageJson;
-
-	const newPackageJson: PublicPackageJson = rest;
-
-	for (const key of availableKeys) {
-		if (key in publishConfig) {
-			// @ts-ignore it's okay, probably
-			newPackageJson[key] = publishConfig[key];
-		}
-	}
-
-	if ('registry' in publishConfig) {
-		newPackageJson.publishConfig = { registry: publishConfig.registry };
-	}
-
-	return newPackageJson;
-}
 
 export function resetPackageJson(workspace: Workspace, { step }: Options = {}) {
 	return stepWrapper({ step, name: `Reset ${workspace.name} package.json` }, async (step) => {


### PR DESCRIPTION
**Problem:**

- Looking toward #569, there is some custom core functionality that should be moved up.
- Source dependencies are a core part of the reasoning for oneRepo, and the `publishConfig` merging is a key piece of that puzzle.

**Solution:**

Moves `applyPublishConfig` out of `@onerepo/plugin-changesets` and into the Workspace as `get publishablePackageJson()`

**Related issues:**

Relates to #569 

**Checklist:**

- [ ] Added or updated tests
- [ ] Added or updated documentation
- [ ] Ensured the pre-commit hooks ran successfully
