### PR TITLE
feat(docgen): clarify aliases, reduce table sizes

### DIFF
--- a/.changeset/afraid-peas-kiss.md
+++ b/.changeset/afraid-peas-kiss.md
@@ -1,0 +1,5 @@
+---
+'@onerepo/plugin-docgen': minor
+---
+
+Changed format for command aliases to show the full command (with all parent commands) instead of just the individual alias names. This means `'$0'` aliases will now show as the correct incantation for the command.

--- a/.changeset/gorgeous-cobras-rule.md
+++ b/.changeset/gorgeous-cobras-rule.md
@@ -1,0 +1,5 @@
+---
+'@onerepo/plugin-docgen': minor
+---
+
+Will no longer render the "Required" column if no arguments are required.

--- a/docs/src/content/docs/core/codeowners.mdx
+++ b/docs/src/content/docs/core/codeowners.mdx
@@ -55,11 +55,11 @@ The following providers are currently enabled:
 ## Commands
 
 {/* start-auto-generated-from-cli-codeowners */}
-{/* @generated SignedSource<<15aeaa4a6e2fd1dffe6ad1ac5f99c017>> */}
+{/* @generated SignedSource<<edc3af3512a5479a6e609f5249739c9e>> */}
 
 ### `one codeowners`
 
-Aliases: `owners`
+Aliases: `one owners`
 
 Manage codeowners
 
@@ -77,10 +77,10 @@ Sync code owners from Workspace configurations to the repository’s CODEOWNERS 
 one codeowners sync
 ```
 
-| Option            | Type      | Description                                       | Required |
-| ----------------- | --------- | ------------------------------------------------- | -------- |
-| `--add`           | `boolean` | Add the updated CODEOWNERS file to the git stage. |          |
-| `--show-advanced` | `boolean` | Pair with `--help` to show advanced options.      |          |
+| Option            | Type      | Description                                       |
+| ----------------- | --------- | ------------------------------------------------- |
+| `--add`           | `boolean` | Add the updated CODEOWNERS file to the git stage. |
+| `--show-advanced` | `boolean` | Pair with `--help` to show advanced options.      |
 
 <details>
 
@@ -102,9 +102,9 @@ Verify the CODEOWNERS file is up to date and unmodified.
 one codeowners verify
 ```
 
-| Option            | Type      | Description                                  | Required |
-| ----------------- | --------- | -------------------------------------------- | -------- |
-| `--show-advanced` | `boolean` | Pair with `--help` to show advanced options. |          |
+| Option            | Type      | Description                                  |
+| ----------------- | --------- | -------------------------------------------- |
+| `--show-advanced` | `boolean` | Pair with `--help` to show advanced options. |
 
 <details>
 

--- a/docs/src/content/docs/core/dependencies.mdx
+++ b/docs/src/content/docs/core/dependencies.mdx
@@ -37,11 +37,11 @@ No configuration necessary! oneRepo automatically detects which package manager 
 </div>
 
 {/* start-auto-generated-from-cli-dependencies */}
-{/* @generated SignedSource<<29fc8b0a064abca21cbbf62dfdbcf3ed>> */}
+{/* @generated SignedSource<<fd2516a190a5c215b9b3ad060184ef57>> */}
 
 ### `one dependencies`
 
-Aliases: `dependency`, `deps`, `dep`
+Aliases: `one dependency`, `one deps`, `one dep`
 
 Safely manage Workspace dependencies across your repository.
 
@@ -65,15 +65,15 @@ If multiple versions of the requested dependencies are found in the Workspace Gr
 
 Otherwise, the latest version will be requested from the registry.
 
-| Option               | Type                                               | Description                                                                                                                            | Required |
-| -------------------- | -------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- | -------- |
-| `--all`, `-a`        | `boolean`                                          | Run across all workspaces                                                                                                              |          |
-| `--dedupe`           | `boolean`, default: `true`                         | Deduplicate dependencies across the repository after install is complete.                                                              |          |
-| `--dev`, `-d`        | `array`                                            | Add dependencies for development purposes only.                                                                                        |          |
-| `--mode`             | `"strict"`, `"loose"`, `"off"`, default: `"loose"` | Version selection mode. Use `strict` to use strict version numbers, `loose` to use caret (`^`) ranges, and `off` for nothing specific. |          |
-| `--prod`, `-p`       | `array`                                            | Add dependencies for production purposes.                                                                                              |          |
-| `--show-advanced`    | `boolean`                                          | Pair with `--help` to show advanced options.                                                                                           |          |
-| `--workspaces`, `-w` | `array`                                            | One or more Workspaces to add dependencies into                                                                                        |          |
+| Option             | Type                                               | Description                                                                                                                            |
+| ------------------ | -------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| `--all, -a`        | `boolean`                                          | Run across all workspaces                                                                                                              |
+| `--dedupe`         | `boolean`, default: `true`                         | Deduplicate dependencies across the repository after install is complete.                                                              |
+| `--dev, -d`        | `array`                                            | Add dependencies for development purposes only.                                                                                        |
+| `--mode`           | `"strict"`, `"loose"`, `"off"`, default: `"loose"` | Version selection mode. Use `strict` to use strict version numbers, `loose` to use caret (`^`) ranges, and `off` for nothing specific. |
+| `--prod, -p`       | `array`                                            | Add dependencies for production purposes.                                                                                              |
+| `--show-advanced`  | `boolean`                                          | Pair with `--help` to show advanced options.                                                                                           |
+| `--workspaces, -w` | `array`                                            | One or more Workspaces to add dependencies into                                                                                        |
 
 Install the latest version of `normalizr` from the registry, using a strict version number.
 
@@ -103,13 +103,13 @@ Remove dependencies from Workspaces.
 one dependencies remove -w [workspaces...] -d [dependencies...] [options...]
 ```
 
-| Option                 | Type                       | Description                                                               | Required |
-| ---------------------- | -------------------------- | ------------------------------------------------------------------------- | -------- |
-| `--all`, `-a`          | `boolean`                  | Run across all workspaces                                                 |          |
-| `--dedupe`             | `boolean`, default: `true` | Deduplicate dependencies across the repository after install is complete. |          |
-| `--dependencies`, `-d` | `array`                    | Dependency names that should be removed.                                  | ✅       |
-| `--show-advanced`      | `boolean`                  | Pair with `--help` to show advanced options.                              |          |
-| `--workspaces`, `-w`   | `array`                    | List of Workspace names to run against                                    |          |
+| Option               | Type                       | Description                                                               | Required |
+| -------------------- | -------------------------- | ------------------------------------------------------------------------- | -------- |
+| `--all, -a`          | `boolean`                  | Run across all workspaces                                                 |          |
+| `--dedupe`           | `boolean`, default: `true` | Deduplicate dependencies across the repository after install is complete. |          |
+| `--dependencies, -d` | `array`                    | Dependency names that should be removed.                                  | ✅       |
+| `--show-advanced`    | `boolean`                  | Pair with `--help` to show advanced options.                              |          |
+| `--workspaces, -w`   | `array`                    | List of Workspace names to run against                                    |          |
 
 ---
 
@@ -127,11 +127,11 @@ Dependencies across Workspaces can be validated using one of the various modes:
 - `loose`: Reused third-party dependencies will be required to have semantic version overlap across unique branches of the Graph.
 - `strict`: Versions of all dependencies across each discrete Workspace dependency tree must be strictly equal.
 
-| Option               | Type                                               | Description                                                                                                                                                   | Required |
-| -------------------- | -------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
-| `--all`, `-a`        | `boolean`                                          | Run across all workspaces                                                                                                                                     |          |
-| `--mode`             | `"strict"`, `"loose"`, `"off"`, default: `"loose"` | Version selection mode. Use `strict` to use exact version matches, `loose` to accept within defined ranges (`^` or `~` range), and `off` for no verification. |          |
-| `--show-advanced`    | `boolean`                                          | Pair with `--help` to show advanced options.                                                                                                                  |          |
-| `--workspaces`, `-w` | `array`                                            | List of Workspace names to run against                                                                                                                        |          |
+| Option             | Type                                               | Description                                                                                                                                                   |
+| ------------------ | -------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--all, -a`        | `boolean`                                          | Run across all workspaces                                                                                                                                     |
+| `--mode`           | `"strict"`, `"loose"`, `"off"`, default: `"loose"` | Version selection mode. Use `strict` to use exact version matches, `loose` to accept within defined ranges (`^` or `~` range), and `off` for no verification. |
+| `--show-advanced`  | `boolean`                                          | Pair with `--help` to show advanced options.                                                                                                                  |
+| `--workspaces, -w` | `array`                                            | List of Workspace names to run against                                                                                                                        |
 
 {/* end-auto-generated-from-cli-dependencies */}

--- a/docs/src/content/docs/core/generate.mdx
+++ b/docs/src/content/docs/core/generate.mdx
@@ -110,11 +110,11 @@ Please see the [inquirer documentation](https://github.com/SBoudrias/Inquirer.js
 ## Commands
 
 {/* start-auto-generated-from-cli-generate */}
-{/* @generated SignedSource<<b3adf43229fe8d047a5bb03c154623fe>> */}
+{/* @generated SignedSource<<5e16c178886d49963ec634318a4ffb2f>> */}
 
 ### `one generate`
 
-Aliases: `gen`
+Aliases: `one gen`
 
 Generate files, folders, and Workspaces from templates.
 
@@ -124,10 +124,10 @@ one generate [options]
 
 To create new templates add a new folder to config/templates and create a `.onegen.cjs` configuration file. Follow the instructions online for more: https\://onerepo.tools/plugins/generate/
 
-| Option            | Type      | Description                                                                         | Required |
-| ----------------- | --------- | ----------------------------------------------------------------------------------- | -------- |
-| `--show-advanced` | `boolean` | Pair with `--help` to show advanced options.                                        |          |
-| `--type`, `-t`    | `string`  | Template type to generate. If not provided, a list will be provided to choose from. |          |
+| Option            | Type      | Description                                                                         |
+| ----------------- | --------- | ----------------------------------------------------------------------------------- |
+| `--show-advanced` | `boolean` | Pair with `--help` to show advanced options.                                        |
+| `--type, -t`      | `string`  | Template type to generate. If not provided, a list will be provided to choose from. |
 
 <details>
 

--- a/docs/src/content/docs/core/graph.mdx
+++ b/docs/src/content/docs/core/graph.mdx
@@ -35,7 +35,7 @@ export default {
 ## Commands
 
 {/* start-auto-generated-from-cli-graph */}
-{/* @generated SignedSource<<4e755685291bb0585078e765e5788682>> */}
+{/* @generated SignedSource<<d4b2c55de5ea3a4a675dab441f5a2aa2>> */}
 
 ### `one graph`
 
@@ -59,25 +59,25 @@ This command can generate representations of your Workspace Graph for use in deb
 
 Pass `--open` to auto-open your default browser with the URL or use one of the `--format` options to print out various other representations.
 
-| Option               | Type                             | Description                                                                                                                                                                 | Required |
-| -------------------- | -------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
-| `--affected`         | `boolean`                        | Select all affected Workspaces. If no other inputs are chosen, this will default to `true`.                                                                                 |          |
-| `--all`, `-a`        | `boolean`                        | Run across all workspaces                                                                                                                                                   |          |
-| `--format`, `-f`     | `"mermaid"`, `"plain"`, `"json"` | Output format for inspecting the Workspace Graph.                                                                                                                           |          |
-| `--open`             | `boolean`                        | Auto-open the browser for the online visualizer.                                                                                                                            |          |
-| `--show-advanced`    | `boolean`                        | Pair with `--help` to show advanced options.                                                                                                                                |          |
-| `--staged`           | `boolean`                        | Use files on the git stage to calculate affected files or Workspaces. When unset or `--no-staged`, changes will be calculated from the entire branch, since its fork point. |          |
-| `--workspaces`, `-w` | `array`                          | List of Workspace names to run against                                                                                                                                      |          |
+| Option             | Type                             | Description                                                                                                                                                                 |
+| ------------------ | -------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--affected`       | `boolean`                        | Select all affected Workspaces. If no other inputs are chosen, this will default to `true`.                                                                                 |
+| `--all, -a`        | `boolean`                        | Run across all workspaces                                                                                                                                                   |
+| `--format, -f`     | `"mermaid"`, `"plain"`, `"json"` | Output format for inspecting the Workspace Graph.                                                                                                                           |
+| `--open`           | `boolean`                        | Auto-open the browser for the online visualizer.                                                                                                                            |
+| `--show-advanced`  | `boolean`                        | Pair with `--help` to show advanced options.                                                                                                                                |
+| `--staged`         | `boolean`                        | Use files on the git stage to calculate affected files or Workspaces. When unset or `--no-staged`, changes will be calculated from the entire branch, since its fork point. |
+| `--workspaces, -w` | `array`                          | List of Workspace names to run against                                                                                                                                      |
 
 <details>
 
 <summary>Advanced options</summary>
 
-| Option          | Type                                                    | Description                                                                                                                                                           | Required |
-| --------------- | ------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
-| `--from-ref`    | `string`                                                | Git ref to start looking for affected files or workspaces                                                                                                             |          |
-| `--through-ref` | `string`                                                | Git ref to start looking for affected files or workspaces                                                                                                             |          |
-| `--url`         | `string`, default: `"https://onerepo.tools/visualize/"` | Override the URL used to visualize the Graph. The Graph data will be attached the the `g` query parameter as a JSON string of the DAG, compressed using zLib deflate. |          |
+| Option          | Type                                                    | Description                                                                                                                                                           |
+| --------------- | ------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--from-ref`    | `string`                                                | Git ref to start looking for affected files or workspaces                                                                                                             |
+| `--through-ref` | `string`                                                | Git ref to start looking for affected files or workspaces                                                                                                             |
+| `--url`         | `string`, default: `"https://onerepo.tools/visualize/"` | Override the URL used to visualize the Graph. The Graph data will be attached the the `g` query parameter as a JSON string of the DAG, compressed using zLib deflate. |
 
 </details>
 
@@ -117,18 +117,18 @@ Dependencies across Workspaces can be validated using one of the various modes:
 - `loose`: Reused third-party dependencies will be required to have semantic version overlap across unique branches of the Graph.
 - `strict`: Versions of all dependencies across each discrete Workspace dependency tree must be strictly equal.
 
-| Option            | Type                                               | Description                                  | Required |
-| ----------------- | -------------------------------------------------- | -------------------------------------------- | -------- |
-| `--mode`          | `"strict"`, `"loose"`, `"off"`, default: `"loose"` | Dependency overlap validation method.        |          |
-| `--show-advanced` | `boolean`                                          | Pair with `--help` to show advanced options. |          |
+| Option            | Type                                               | Description                                  |
+| ----------------- | -------------------------------------------------- | -------------------------------------------- |
+| `--mode`          | `"strict"`, `"loose"`, `"off"`, default: `"loose"` | Dependency overlap validation method.        |
+| `--show-advanced` | `boolean`                                          | Pair with `--help` to show advanced options. |
 
 <details>
 
 <summary>Advanced options</summary>
 
-| Option            | Type                                          | Description                             | Required |
-| ----------------- | --------------------------------------------- | --------------------------------------- | -------- |
-| `--custom-schema` | `string`, default: `"config/graph-schema.ts"` | Path to a custom JSON schema definition |          |
+| Option            | Type                                          | Description                             |
+| ----------------- | --------------------------------------------- | --------------------------------------- |
+| `--custom-schema` | `string`, default: `"config/graph-schema.ts"` | Path to a custom JSON schema definition |
 
 </details>
 

--- a/docs/src/content/docs/core/hooks.mdx
+++ b/docs/src/content/docs/core/hooks.mdx
@@ -81,7 +81,7 @@ git config --unset core.hooksPath
 ## Commands
 
 {/* start-auto-generated-from-cli-hooks */}
-{/* @generated SignedSource<<4e161842f4ab1c433ec277a208bbebb9>> */}
+{/* @generated SignedSource<<1398ccb2bc14058361a9d8f4e2bc9d45>> */}
 
 ### `one hooks`
 
@@ -101,12 +101,12 @@ Create git hooks
 one hooks create
 ```
 
-| Option            | Type                                                                                                                                                                                                                                                                                                                                                                                                                                          | Description                                                                | Required |
-| ----------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- | -------- |
-| `--add`           | `boolean`, default: `true`                                                                                                                                                                                                                                                                                                                                                                                                                    | Add the hooks to the git stage for committing.                             |          |
-| `--hook`          | `"applypatch-msg"`, `"pre-applypatch"`, `"post-applypatch"`, `"pre-commit"`, `"pre-merge-commit"`, `"prepare-commit-msg"`, `"commit-msg"`, `"post-commit"`, `"pre-rebase"`, `"post-checkout"`, `"post-merge"`, `"pre-receive"`, `"update"`, `"post-receive"`, `"post-update"`, `"pre-auto-gc"`, `"post-rewrite"`, `"pre-push"`, `"proc-receive"`, `"push-to-checkout"`, default: `["pre-commit","post-checkout","post-merge","post-rewrite"]` | The git hook to create. Omit this option to auto-create recommended hooks. |          |
-| `--overwrite`     | `boolean`                                                                                                                                                                                                                                                                                                                                                                                                                                     | Overwrite existing hooks                                                   |          |
-| `--show-advanced` | `boolean`                                                                                                                                                                                                                                                                                                                                                                                                                                     | Pair with `--help` to show advanced options.                               |          |
+| Option            | Type                                                                                                                                                                                                                                                                                                                                                                                                                                          | Description                                                                |
+| ----------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
+| `--add`           | `boolean`, default: `true`                                                                                                                                                                                                                                                                                                                                                                                                                    | Add the hooks to the git stage for committing.                             |
+| `--hook`          | `"applypatch-msg"`, `"pre-applypatch"`, `"post-applypatch"`, `"pre-commit"`, `"pre-merge-commit"`, `"prepare-commit-msg"`, `"commit-msg"`, `"post-commit"`, `"pre-rebase"`, `"post-checkout"`, `"post-merge"`, `"pre-receive"`, `"update"`, `"post-receive"`, `"post-update"`, `"pre-auto-gc"`, `"post-rewrite"`, `"pre-push"`, `"proc-receive"`, `"push-to-checkout"`, default: `["pre-commit","post-checkout","post-merge","post-rewrite"]` | The git hook to create. Omit this option to auto-create recommended hooks. |
+| `--overwrite`     | `boolean`                                                                                                                                                                                                                                                                                                                                                                                                                                     | Overwrite existing hooks                                                   |
+| `--show-advanced` | `boolean`                                                                                                                                                                                                                                                                                                                                                                                                                                     | Pair with `--help` to show advanced options.                               |
 
 <details>
 
@@ -122,7 +122,7 @@ one hooks create
 
 #### `one hooks init`
 
-Aliases: `sync`
+Aliases: `one hooks sync`
 
 Initialize and sync git hook settings for this repository.
 
@@ -130,9 +130,9 @@ Initialize and sync git hook settings for this repository.
 one hooks init
 ```
 
-| Option            | Type      | Description                                  | Required |
-| ----------------- | --------- | -------------------------------------------- | -------- |
-| `--show-advanced` | `boolean` | Pair with `--help` to show advanced options. |          |
+| Option            | Type      | Description                                  |
+| ----------------- | --------- | -------------------------------------------- |
+| `--show-advanced` | `boolean` | Pair with `--help` to show advanced options. |
 
 <details>
 

--- a/docs/src/content/docs/core/install.mdx
+++ b/docs/src/content/docs/core/install.mdx
@@ -11,7 +11,7 @@ A helper command to enable you to _install_ global access to your oneRepo CLI. T
 ## Commands
 
 {/* start-auto-generated-from-cli-install */}
-{/* @generated SignedSource<<63ae54f62426ac2d80f2a5ab09cc8400>> */}
+{/* @generated SignedSource<<c98a806ff74e20f1e72fe2cbc2bff0c8>> */}
 
 ### `one install`
 
@@ -21,11 +21,11 @@ Install the oneRepo CLI into your environment.
 one install [options]
 ```
 
-| Option            | Type                          | Description                                                                                                         | Required |
-| ----------------- | ----------------------------- | ------------------------------------------------------------------------------------------------------------------- | -------- |
-| `--force`         | `boolean`                     | Force installation regardless of pre-existing command.                                                              |          |
-| `--location`      | `string`                      | Install location for the binary. Default location is chosen as default option for usr/bin dependent on the OS type. |          |
-| `--show-advanced` | `boolean`                     | Pair with `--help` to show advanced options.                                                                        |          |
-| `--version`       | `string`, default: `"0.16.0"` | Version of oneRepo to install. Defaults to the current version.                                                     |          |
+| Option            | Type                          | Description                                                                                                         |
+| ----------------- | ----------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| `--force`         | `boolean`                     | Force installation regardless of pre-existing command.                                                              |
+| `--location`      | `string`                      | Install location for the binary. Default location is chosen as default option for usr/bin dependent on the OS type. |
+| `--show-advanced` | `boolean`                     | Pair with `--help` to show advanced options.                                                                        |
+| `--version`       | `string`, default: `"0.16.0"` | Version of oneRepo to install. Defaults to the current version.                                                     |
 
 {/* end-auto-generated-from-cli-install */}

--- a/docs/src/content/docs/core/tasks.mdx
+++ b/docs/src/content/docs/core/tasks.mdx
@@ -286,7 +286,7 @@ jobs:
 ## Commands
 
 {/* start-auto-generated-from-cli-tasks */}
-{/* @generated SignedSource<<f177497985a1ac83b25e0c58dfd7fdca>> */}
+{/* @generated SignedSource<<859aa6ba9fc5cbcae460c585d1d04013>> */}
 
 ### `one tasks`
 
@@ -298,27 +298,27 @@ one tasks --lifecycle=<lifecycle> [options]
 
 You can fine-tune the determination of affected Workspaces by providing a `--from-ref` and/or `through-ref`. For more information, get help with `--help --show-advanced`.
 
-| Option               | Type                                                                                                                  | Description                                                                                                                                      | Required |
-| -------------------- | --------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ | -------- |
-| `--affected`         | `boolean`                                                                                                             | Select all affected Workspaces. If no other inputs are chosen, this will default to `true`.                                                      |          |
-| `--all`, `-a`        | `boolean`                                                                                                             | Run across all workspaces                                                                                                                        |          |
-| `--ignore-unstaged`  | `boolean`                                                                                                             | Force staged-changes mode on or off. If `true`, task determination and runners will ignore unstaged changes.                                     |          |
-| `--lifecycle`, `-c`  | `"pre-commit"`, `"post-commit"`, `"post-checkout"`, `"pre-merge"`, `"post-merge"`, `"build"`, `"deploy"`, `"publish"` | Task lifecycle to run. All tasks for the given lifecycle will be run as merged parallel tasks, followed by the merged set of serial tasks.       | ✅       |
-| `--list`             | `boolean`                                                                                                             | List found tasks. Implies dry run and will not actually run any tasks.                                                                           |          |
-| `--shard`            | `string`                                                                                                              | Shard the lifecycle across multiple instances. Format as `<shard-number>/<total-shards>`                                                         |          |
-| `--show-advanced`    | `boolean`                                                                                                             | Pair with `--help` to show advanced options.                                                                                                     |          |
-| `--staged`           | `boolean`                                                                                                             | Backup unstaged files and use only those on the git stage to calculate affected files or workspaces. Will re-apply the unstaged files upon exit. |          |
-| `--workspaces`, `-w` | `array`                                                                                                               | List of Workspace names to run against                                                                                                           |          |
+| Option              | Type                                                                                                                  | Description                                                                                                                                      | Required |
+| ------------------- | --------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ | -------- |
+| `--affected`        | `boolean`                                                                                                             | Select all affected Workspaces. If no other inputs are chosen, this will default to `true`.                                                      |          |
+| `--all, -a`         | `boolean`                                                                                                             | Run across all workspaces                                                                                                                        |          |
+| `--ignore-unstaged` | `boolean`                                                                                                             | Force staged-changes mode on or off. If `true`, task determination and runners will ignore unstaged changes.                                     |          |
+| `--lifecycle, -c`   | `"pre-commit"`, `"post-commit"`, `"post-checkout"`, `"pre-merge"`, `"post-merge"`, `"build"`, `"deploy"`, `"publish"` | Task lifecycle to run. All tasks for the given lifecycle will be run as merged parallel tasks, followed by the merged set of serial tasks.       | ✅       |
+| `--list`            | `boolean`                                                                                                             | List found tasks. Implies dry run and will not actually run any tasks.                                                                           |          |
+| `--shard`           | `string`                                                                                                              | Shard the lifecycle across multiple instances. Format as `<shard-number>/<total-shards>`                                                         |          |
+| `--show-advanced`   | `boolean`                                                                                                             | Pair with `--help` to show advanced options.                                                                                                     |          |
+| `--staged`          | `boolean`                                                                                                             | Backup unstaged files and use only those on the git stage to calculate affected files or workspaces. Will re-apply the unstaged files upon exit. |          |
+| `--workspaces, -w`  | `array`                                                                                                               | List of Workspace names to run against                                                                                                           |          |
 
 <details>
 
 <summary>Advanced options</summary>
 
-| Option          | Type                                                                                   | Description                                                               | Required |
-| --------------- | -------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- | -------- |
-| `--from-ref`    | `string`                                                                               | Git ref to start looking for affected files or workspaces                 |          |
-| `--ignore`      | `array`, default: `[".changesets/*","**/README.md","**/CHANGELOG.md",".changeset/**"]` | List of filepath strings or globs to ignore when matching tasks to files. |          |
-| `--through-ref` | `string`                                                                               | Git ref to start looking for affected files or workspaces                 |          |
+| Option          | Type                                                                                   | Description                                                               |
+| --------------- | -------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
+| `--from-ref`    | `string`                                                                               | Git ref to start looking for affected files or workspaces                 |
+| `--ignore`      | `array`, default: `[".changesets/*","**/README.md","**/CHANGELOG.md",".changeset/**"]` | List of filepath strings or globs to ignore when matching tasks to files. |
+| `--through-ref` | `string`                                                                               | Git ref to start looking for affected files or workspaces                 |
 
 </details>
 

--- a/docs/src/content/docs/plugins/changesets.mdx
+++ b/docs/src/content/docs/plugins/changesets.mdx
@@ -97,11 +97,11 @@ name?: string | string[];
 ## Commands
 
 {/* start-auto-generated-from-cli-changesets */}
-{/* @generated SignedSource<<1aeb61d2d142116c78a9aac4b8efa16b>> */}
+{/* @generated SignedSource<<53551c3fc59ea2d2163a6dc5344915ff>> */}
 
 ### `one change`
 
-Aliases: `changeset`, `changesets`
+Aliases: `one changeset`, `one changesets`
 
 Manage changesets, versioning, and publishing your public Workspaces to packages.
 
@@ -113,7 +113,7 @@ one change <command> [options]
 
 #### `one change add`
 
-Aliases: `$0`
+Aliases: `one change`
 
 Add a changeset
 
@@ -121,25 +121,25 @@ Add a changeset
 one change add [options]
 ```
 
-| Option               | Type                            | Description                                                                                                                                                                 | Required |
-| -------------------- | ------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
-| `--add`              | `boolean`, default: `true`      | Add the modified `package.json` files to the git stage for committing.                                                                                                      |          |
-| `--affected`         | `boolean`                       | Select all affected Workspaces. If no other inputs are chosen, this will default to `true`.                                                                                 |          |
-| `--all`, `-a`        | `boolean`                       | Run across all workspaces                                                                                                                                                   |          |
-| `--files`, `-f`      | `array`                         | Determine Workspaces from specific files                                                                                                                                    |          |
-| `--show-advanced`    | `boolean`                       | Pair with `--help` to show advanced options.                                                                                                                                |          |
-| `--staged`           | `boolean`                       | Use files on the git stage to calculate affected files or Workspaces. When unset or `--no-staged`, changes will be calculated from the entire branch, since its fork point. |          |
-| `--type`             | `"major"`, `"minor"`, `"patch"` | Provide a semantic version bump type. If not given, a prompt will guide you through selecting the appropriate type.                                                         |          |
-| `--workspaces`, `-w` | `array`                         | List of Workspace names to run against                                                                                                                                      |          |
+| Option             | Type                            | Description                                                                                                                                                                 |
+| ------------------ | ------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--add`            | `boolean`, default: `true`      | Add the modified `package.json` files to the git stage for committing.                                                                                                      |
+| `--affected`       | `boolean`                       | Select all affected Workspaces. If no other inputs are chosen, this will default to `true`.                                                                                 |
+| `--all, -a`        | `boolean`                       | Run across all workspaces                                                                                                                                                   |
+| `--files, -f`      | `array`                         | Determine Workspaces from specific files                                                                                                                                    |
+| `--show-advanced`  | `boolean`                       | Pair with `--help` to show advanced options.                                                                                                                                |
+| `--staged`         | `boolean`                       | Use files on the git stage to calculate affected files or Workspaces. When unset or `--no-staged`, changes will be calculated from the entire branch, since its fork point. |
+| `--type`           | `"major"`, `"minor"`, `"patch"` | Provide a semantic version bump type. If not given, a prompt will guide you through selecting the appropriate type.                                                         |
+| `--workspaces, -w` | `array`                         | List of Workspace names to run against                                                                                                                                      |
 
 <details>
 
 <summary>Advanced options</summary>
 
-| Option          | Type     | Description                                               | Required |
-| --------------- | -------- | --------------------------------------------------------- | -------- |
-| `--from-ref`    | `string` | Git ref to start looking for affected files or workspaces |          |
-| `--through-ref` | `string` | Git ref to start looking for affected files or workspaces |          |
+| Option          | Type     | Description                                               |
+| --------------- | -------- | --------------------------------------------------------- |
+| `--from-ref`    | `string` | Git ref to start looking for affected files or workspaces |
+| `--through-ref` | `string` | Git ref to start looking for affected files or workspaces |
 
 </details>
 
@@ -155,15 +155,15 @@ one change init
 
 You should only ever have to do this once.
 
-| Option            | Type      | Description                                  | Required |
-| ----------------- | --------- | -------------------------------------------- | -------- |
-| `--show-advanced` | `boolean` | Pair with `--help` to show advanced options. |          |
+| Option            | Type      | Description                                  |
+| ----------------- | --------- | -------------------------------------------- |
+| `--show-advanced` | `boolean` | Pair with `--help` to show advanced options. |
 
 ---
 
 #### `one change prerelease`
 
-Aliases: `pre-release`, `pre`
+Aliases: `one change pre-release`, `one change pre`
 
 Pre-release available Workspaces.
 
@@ -171,20 +171,20 @@ Pre-release available Workspaces.
 one change prerelease
 ```
 
-| Option            | Type                       | Description                                                                                   | Required |
-| ----------------- | -------------------------- | --------------------------------------------------------------------------------------------- | -------- |
-| `--build`         | `boolean`, default: `true` | Build Workspaces before publishing                                                            |          |
-| `--otp`           | `boolean`                  | Set to true if your publishes require an OTP for NPM.                                         |          |
-| `--show-advanced` | `boolean`                  | Pair with `--help` to show advanced options.                                                  |          |
-| `--skip-auth`     | `boolean`                  | Skip NPM auth check. This may be necessary for some internal registries using PATs or tokens. |          |
+| Option            | Type                       | Description                                                                                   |
+| ----------------- | -------------------------- | --------------------------------------------------------------------------------------------- |
+| `--build`         | `boolean`, default: `true` | Build Workspaces before publishing                                                            |
+| `--otp`           | `boolean`                  | Set to true if your publishes require an OTP for NPM.                                         |
+| `--show-advanced` | `boolean`                  | Pair with `--help` to show advanced options.                                                  |
+| `--skip-auth`     | `boolean`                  | Skip NPM auth check. This may be necessary for some internal registries using PATs or tokens. |
 
 <details>
 
 <summary>Advanced options</summary>
 
-| Option          | Type      | Description                                                 | Required |
-| --------------- | --------- | ----------------------------------------------------------- | -------- |
-| `--allow-dirty` | `boolean` | Bypass checks to ensure no local changes before publishing. |          |
+| Option          | Type      | Description                                                 |
+| --------------- | --------- | ----------------------------------------------------------- |
+| `--allow-dirty` | `boolean` | Bypass checks to ensure no local changes before publishing. |
 
 </details>
 
@@ -192,7 +192,7 @@ one change prerelease
 
 #### `one change publish`
 
-Aliases: `release`
+Aliases: `one change release`
 
 Publish all Workspaces with versions not available in the registry.
 
@@ -202,20 +202,20 @@ one change publish [options]
 
 This command is safe to run any time – only packages that have previously gone through the `version` process will end up being published.
 
-| Option            | Type                       | Description                                                                                   | Required |
-| ----------------- | -------------------------- | --------------------------------------------------------------------------------------------- | -------- |
-| `--build`         | `boolean`, default: `true` | Build Workspaces before publishing                                                            |          |
-| `--otp`           | `boolean`                  | Set to true if your publishes require an OTP for NPM.                                         |          |
-| `--show-advanced` | `boolean`                  | Pair with `--help` to show advanced options.                                                  |          |
-| `--skip-auth`     | `boolean`                  | Skip NPM auth check. This may be necessary for some internal registries using PATs or tokens. |          |
+| Option            | Type                       | Description                                                                                   |
+| ----------------- | -------------------------- | --------------------------------------------------------------------------------------------- |
+| `--build`         | `boolean`, default: `true` | Build Workspaces before publishing                                                            |
+| `--otp`           | `boolean`                  | Set to true if your publishes require an OTP for NPM.                                         |
+| `--show-advanced` | `boolean`                  | Pair with `--help` to show advanced options.                                                  |
+| `--skip-auth`     | `boolean`                  | Skip NPM auth check. This may be necessary for some internal registries using PATs or tokens. |
 
 <details>
 
 <summary>Advanced options</summary>
 
-| Option          | Type      | Description                                                 | Required |
-| --------------- | --------- | ----------------------------------------------------------- | -------- |
-| `--allow-dirty` | `boolean` | Bypass checks to ensure no local changes before publishing. |          |
+| Option          | Type      | Description                                                 |
+| --------------- | --------- | ----------------------------------------------------------- |
+| `--allow-dirty` | `boolean` | Bypass checks to ensure no local changes before publishing. |
 
 </details>
 
@@ -229,18 +229,18 @@ Version Workspaces for publishing. Allows you to select a minimal set of Workspa
 one change version
 ```
 
-| Option            | Type                       | Description                                                                                          | Required |
-| ----------------- | -------------------------- | ---------------------------------------------------------------------------------------------------- | -------- |
-| `--add`           | `boolean`, default: `true` | Add the modified files like `package.json` and `CHANGELOG.md` files to the git stage for committing. |          |
-| `--show-advanced` | `boolean`                  | Pair with `--help` to show advanced options.                                                         |          |
+| Option            | Type                       | Description                                                                                          |
+| ----------------- | -------------------------- | ---------------------------------------------------------------------------------------------------- |
+| `--add`           | `boolean`, default: `true` | Add the modified files like `package.json` and `CHANGELOG.md` files to the git stage for committing. |
+| `--show-advanced` | `boolean`                  | Pair with `--help` to show advanced options.                                                         |
 
 <details>
 
 <summary>Advanced options</summary>
 
-| Option          | Type      | Description                                                 | Required |
-| --------------- | --------- | ----------------------------------------------------------- | -------- |
-| `--allow-dirty` | `boolean` | Bypass checks to ensure no local changes before publishing. |          |
+| Option          | Type      | Description                                                 |
+| --------------- | --------- | ----------------------------------------------------------- |
+| `--allow-dirty` | `boolean` | Bypass checks to ensure no local changes before publishing. |
 
 </details>
 

--- a/docs/src/content/docs/plugins/docgen.mdx
+++ b/docs/src/content/docs/plugins/docgen.mdx
@@ -149,7 +149,7 @@ Set to true to amend content to the given file using the file.writeSafe | `file.
 ## Commands
 
 {/* start-auto-generated-from-cli-docgen */}
-{/* @generated SignedSource<<89cebedc4a33eb9586e88ad0cf13443c>> */}
+{/* @generated SignedSource<<4673a8de2f1d979aecc9b936d589a437>> */}
 
 ### `one docgen`
 
@@ -163,22 +163,22 @@ Help documentation should always be easy to find. This command will help automat
 
 Add this command to your one Repo tasks on pre-commit to ensure that your documentation is always up-to-date.
 
-| Option            | Type                                                                      | Description                                                                | Required |
-| ----------------- | ------------------------------------------------------------------------- | -------------------------------------------------------------------------- | -------- |
-| `--add`           | `boolean`                                                                 | Add the output file to the git stage                                       |          |
-| `--format`        | `"markdown"`, `"json"`, default: `"markdown"`                             | Output format for documentation                                            |          |
-| `--heading-level` | `number`                                                                  | Heading level to start at for Markdown output                              |          |
-| `--out-file`      | `string`, default: `"./docs/src/content/docs/plugins/docgen/example.mdx"` | File to write output to. If not provided, stdout will be used              |          |
-| `--out-workspace` | `string`, default: `"root"`                                               | Workspace name to write the --out-file to                                  |          |
-| `--safe-write`    | `boolean`, default: `true`                                                | Write documentation to a portion of the file with start and end sentinels. |          |
+| Option            | Type                                                                      | Description                                                                |
+| ----------------- | ------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
+| `--add`           | `boolean`                                                                 | Add the output file to the git stage                                       |
+| `--format`        | `"markdown"`, `"json"`, default: `"markdown"`                             | Output format for documentation                                            |
+| `--heading-level` | `number`                                                                  | Heading level to start at for Markdown output                              |
+| `--out-file`      | `string`, default: `"./docs/src/content/docs/plugins/docgen/example.mdx"` | File to write output to. If not provided, stdout will be used              |
+| `--out-workspace` | `string`, default: `"root"`                                               | Workspace name to write the --out-file to                                  |
+| `--safe-write`    | `boolean`, default: `true`                                                | Write documentation to a portion of the file with start and end sentinels. |
 
 <details>
 
 <summary>Advanced options</summary>
 
-| Option      | Type     | Description                                              | Required |
-| ----------- | -------- | -------------------------------------------------------- | -------- |
-| `--command` | `string` | Start at the given command, skip the root and any others |          |
+| Option      | Type     | Description                                              |
+| ----------- | -------- | -------------------------------------------------------- |
+| `--command` | `string` | Start at the given command, skip the root and any others |
 
 </details>
 

--- a/docs/src/content/docs/plugins/docgen/example.mdx
+++ b/docs/src/content/docs/plugins/docgen/example.mdx
@@ -10,7 +10,7 @@ The following content is auto-generated using the [official documentation plugin
 :::
 
 {/* start-auto-generated-from-cli */}
-{/* @generated SignedSource<<70768699568e52e1a01be77fea0a4273>> */}
+{/* @generated SignedSource<<46fffee68c0c3f21e75e50830aa3200b>> */}
 
 ## `one`
 
@@ -18,23 +18,23 @@ The following content is auto-generated using the [official documentation plugin
 one <command> [options]
 ```
 
-| Option              | Type                  | Description                                                                                                                            | Required |
-| ------------------- | --------------------- | -------------------------------------------------------------------------------------------------------------------------------------- | -------- |
-| `--0.16.0`          | `boolean`             | Show this CLI’s version number                                                                                                         |          |
-| `--dry-run`         | `boolean`             | Run without actually making modifications or destructive operations                                                                    |          |
-| `--show-advanced`   | `boolean`             | Pair with `--help` to show advanced options.                                                                                           |          |
-| `--verbosity`, `-v` | `count`, default: `2` | Set the verbosity of the script output. Increase verbosity with `-vvv`, `-vvvv`, or `-vvvvv`. Reduce verbosity with `-v` or `--silent` |          |
-| `--undefined`       | ``                    | Show the oneRepo CLI version.                                                                                                          |          |
+| Option            | Type                  | Description                                                                                                                            |
+| ----------------- | --------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| `--0.16.0`        | `boolean`             | Show this CLI’s version number                                                                                                         |
+| `--dry-run`       | `boolean`             | Run without actually making modifications or destructive operations                                                                    |
+| `--show-advanced` | `boolean`             | Pair with `--help` to show advanced options.                                                                                           |
+| `--verbosity, -v` | `count`, default: `2` | Set the verbosity of the script output. Increase verbosity with `-vvv`, `-vvvv`, or `-vvvvv`. Reduce verbosity with `-v` or `--silent` |
+| ``                | ``                    | Show the oneRepo CLI version.                                                                                                          |
 
 <details>
 
 <summary>Advanced options</summary>
 
-| Option                | Type      | Description                                                                                     | Required |
-| --------------------- | --------- | ----------------------------------------------------------------------------------------------- | -------- |
-| `--help`, `-h`        | `boolean` | Show this help screen                                                                           |          |
-| `--silent`            | `boolean` | Silence all output from the logger. Effectively sets verbosity to 0.                            |          |
-| `--skip-engine-check` | `boolean` | Skip the engines check, which ensures the current Node.js version is within the expected range. |          |
+| Option                | Type      | Description                                                                                     |
+| --------------------- | --------- | ----------------------------------------------------------------------------------------------- |
+| `--help, -h`          | `boolean` | Show this help screen                                                                           |
+| `--silent`            | `boolean` | Silence all output from the logger. Effectively sets verbosity to 0.                            |
+| `--skip-engine-check` | `boolean` | Skip the engines check, which ensures the current Node.js version is within the expected range. |
 
 </details>
 
@@ -48,22 +48,22 @@ Build public Workspaces using esbuild.
 one build [options]
 ```
 
-| Option               | Type      | Description                                                                                                                                                                 | Required |
-| -------------------- | --------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
-| `--affected`         | `boolean` | Select all affected Workspaces. If no other inputs are chosen, this will default to `true`.                                                                                 |          |
-| `--all`, `-a`        | `boolean` | Run across all workspaces                                                                                                                                                   |          |
-| `--show-advanced`    | `boolean` | Pair with `--help` to show advanced options.                                                                                                                                |          |
-| `--staged`           | `boolean` | Use files on the git stage to calculate affected files or Workspaces. When unset or `--no-staged`, changes will be calculated from the entire branch, since its fork point. |          |
-| `--workspaces`, `-w` | `array`   | List of Workspace names to run against                                                                                                                                      |          |
+| Option             | Type      | Description                                                                                                                                                                 |
+| ------------------ | --------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--affected`       | `boolean` | Select all affected Workspaces. If no other inputs are chosen, this will default to `true`.                                                                                 |
+| `--all, -a`        | `boolean` | Run across all workspaces                                                                                                                                                   |
+| `--show-advanced`  | `boolean` | Pair with `--help` to show advanced options.                                                                                                                                |
+| `--staged`         | `boolean` | Use files on the git stage to calculate affected files or Workspaces. When unset or `--no-staged`, changes will be calculated from the entire branch, since its fork point. |
+| `--workspaces, -w` | `array`   | List of Workspace names to run against                                                                                                                                      |
 
 <details>
 
 <summary>Advanced options</summary>
 
-| Option          | Type     | Description                                               | Required |
-| --------------- | -------- | --------------------------------------------------------- | -------- |
-| `--from-ref`    | `string` | Git ref to start looking for affected files or workspaces |          |
-| `--through-ref` | `string` | Git ref to start looking for affected files or workspaces |          |
+| Option          | Type     | Description                                               |
+| --------------- | -------- | --------------------------------------------------------- |
+| `--from-ref`    | `string` | Git ref to start looking for affected files or workspaces |
+| `--through-ref` | `string` | Git ref to start looking for affected files or workspaces |
 
 </details>
 
@@ -89,7 +89,7 @@ one build -w graph cli logger
 
 ### `one change`
 
-Aliases: `changeset`, `changesets`
+Aliases: `one changeset`, `one changesets`
 
 Manage changesets, versioning, and publishing your public Workspaces to packages.
 
@@ -101,7 +101,7 @@ one change <command> [options]
 
 #### `one change add`
 
-Aliases: `$0`
+Aliases: `one change`
 
 Add a changeset
 
@@ -109,25 +109,25 @@ Add a changeset
 one change add [options]
 ```
 
-| Option               | Type                            | Description                                                                                                                                                                 | Required |
-| -------------------- | ------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
-| `--add`              | `boolean`, default: `true`      | Add the modified `package.json` files to the git stage for committing.                                                                                                      |          |
-| `--affected`         | `boolean`                       | Select all affected Workspaces. If no other inputs are chosen, this will default to `true`.                                                                                 |          |
-| `--all`, `-a`        | `boolean`                       | Run across all workspaces                                                                                                                                                   |          |
-| `--files`, `-f`      | `array`                         | Determine Workspaces from specific files                                                                                                                                    |          |
-| `--show-advanced`    | `boolean`                       | Pair with `--help` to show advanced options.                                                                                                                                |          |
-| `--staged`           | `boolean`                       | Use files on the git stage to calculate affected files or Workspaces. When unset or `--no-staged`, changes will be calculated from the entire branch, since its fork point. |          |
-| `--type`             | `"major"`, `"minor"`, `"patch"` | Provide a semantic version bump type. If not given, a prompt will guide you through selecting the appropriate type.                                                         |          |
-| `--workspaces`, `-w` | `array`                         | List of Workspace names to run against                                                                                                                                      |          |
+| Option             | Type                            | Description                                                                                                                                                                 |
+| ------------------ | ------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--add`            | `boolean`, default: `true`      | Add the modified `package.json` files to the git stage for committing.                                                                                                      |
+| `--affected`       | `boolean`                       | Select all affected Workspaces. If no other inputs are chosen, this will default to `true`.                                                                                 |
+| `--all, -a`        | `boolean`                       | Run across all workspaces                                                                                                                                                   |
+| `--files, -f`      | `array`                         | Determine Workspaces from specific files                                                                                                                                    |
+| `--show-advanced`  | `boolean`                       | Pair with `--help` to show advanced options.                                                                                                                                |
+| `--staged`         | `boolean`                       | Use files on the git stage to calculate affected files or Workspaces. When unset or `--no-staged`, changes will be calculated from the entire branch, since its fork point. |
+| `--type`           | `"major"`, `"minor"`, `"patch"` | Provide a semantic version bump type. If not given, a prompt will guide you through selecting the appropriate type.                                                         |
+| `--workspaces, -w` | `array`                         | List of Workspace names to run against                                                                                                                                      |
 
 <details>
 
 <summary>Advanced options</summary>
 
-| Option          | Type     | Description                                               | Required |
-| --------------- | -------- | --------------------------------------------------------- | -------- |
-| `--from-ref`    | `string` | Git ref to start looking for affected files or workspaces |          |
-| `--through-ref` | `string` | Git ref to start looking for affected files or workspaces |          |
+| Option          | Type     | Description                                               |
+| --------------- | -------- | --------------------------------------------------------- |
+| `--from-ref`    | `string` | Git ref to start looking for affected files or workspaces |
+| `--through-ref` | `string` | Git ref to start looking for affected files or workspaces |
 
 </details>
 
@@ -143,15 +143,15 @@ one change init
 
 You should only ever have to do this once.
 
-| Option            | Type      | Description                                  | Required |
-| ----------------- | --------- | -------------------------------------------- | -------- |
-| `--show-advanced` | `boolean` | Pair with `--help` to show advanced options. |          |
+| Option            | Type      | Description                                  |
+| ----------------- | --------- | -------------------------------------------- |
+| `--show-advanced` | `boolean` | Pair with `--help` to show advanced options. |
 
 ---
 
 #### `one change prerelease`
 
-Aliases: `pre-release`, `pre`
+Aliases: `one change pre-release`, `one change pre`
 
 Pre-release available Workspaces.
 
@@ -159,20 +159,20 @@ Pre-release available Workspaces.
 one change prerelease
 ```
 
-| Option            | Type                       | Description                                                                                   | Required |
-| ----------------- | -------------------------- | --------------------------------------------------------------------------------------------- | -------- |
-| `--build`         | `boolean`, default: `true` | Build Workspaces before publishing                                                            |          |
-| `--otp`           | `boolean`                  | Set to true if your publishes require an OTP for NPM.                                         |          |
-| `--show-advanced` | `boolean`                  | Pair with `--help` to show advanced options.                                                  |          |
-| `--skip-auth`     | `boolean`                  | Skip NPM auth check. This may be necessary for some internal registries using PATs or tokens. |          |
+| Option            | Type                       | Description                                                                                   |
+| ----------------- | -------------------------- | --------------------------------------------------------------------------------------------- |
+| `--build`         | `boolean`, default: `true` | Build Workspaces before publishing                                                            |
+| `--otp`           | `boolean`                  | Set to true if your publishes require an OTP for NPM.                                         |
+| `--show-advanced` | `boolean`                  | Pair with `--help` to show advanced options.                                                  |
+| `--skip-auth`     | `boolean`                  | Skip NPM auth check. This may be necessary for some internal registries using PATs or tokens. |
 
 <details>
 
 <summary>Advanced options</summary>
 
-| Option          | Type      | Description                                                 | Required |
-| --------------- | --------- | ----------------------------------------------------------- | -------- |
-| `--allow-dirty` | `boolean` | Bypass checks to ensure no local changes before publishing. |          |
+| Option          | Type      | Description                                                 |
+| --------------- | --------- | ----------------------------------------------------------- |
+| `--allow-dirty` | `boolean` | Bypass checks to ensure no local changes before publishing. |
 
 </details>
 
@@ -180,7 +180,7 @@ one change prerelease
 
 #### `one change publish`
 
-Aliases: `release`
+Aliases: `one change release`
 
 Publish all Workspaces with versions not available in the registry.
 
@@ -190,20 +190,20 @@ one change publish [options]
 
 This command is safe to run any time – only packages that have previously gone through the `version` process will end up being published.
 
-| Option            | Type                       | Description                                                                                   | Required |
-| ----------------- | -------------------------- | --------------------------------------------------------------------------------------------- | -------- |
-| `--build`         | `boolean`, default: `true` | Build Workspaces before publishing                                                            |          |
-| `--otp`           | `boolean`                  | Set to true if your publishes require an OTP for NPM.                                         |          |
-| `--show-advanced` | `boolean`                  | Pair with `--help` to show advanced options.                                                  |          |
-| `--skip-auth`     | `boolean`                  | Skip NPM auth check. This may be necessary for some internal registries using PATs or tokens. |          |
+| Option            | Type                       | Description                                                                                   |
+| ----------------- | -------------------------- | --------------------------------------------------------------------------------------------- |
+| `--build`         | `boolean`, default: `true` | Build Workspaces before publishing                                                            |
+| `--otp`           | `boolean`                  | Set to true if your publishes require an OTP for NPM.                                         |
+| `--show-advanced` | `boolean`                  | Pair with `--help` to show advanced options.                                                  |
+| `--skip-auth`     | `boolean`                  | Skip NPM auth check. This may be necessary for some internal registries using PATs or tokens. |
 
 <details>
 
 <summary>Advanced options</summary>
 
-| Option          | Type      | Description                                                 | Required |
-| --------------- | --------- | ----------------------------------------------------------- | -------- |
-| `--allow-dirty` | `boolean` | Bypass checks to ensure no local changes before publishing. |          |
+| Option          | Type      | Description                                                 |
+| --------------- | --------- | ----------------------------------------------------------- |
+| `--allow-dirty` | `boolean` | Bypass checks to ensure no local changes before publishing. |
 
 </details>
 
@@ -217,18 +217,18 @@ Version Workspaces for publishing. Allows you to select a minimal set of Workspa
 one change version
 ```
 
-| Option            | Type                       | Description                                                                                          | Required |
-| ----------------- | -------------------------- | ---------------------------------------------------------------------------------------------------- | -------- |
-| `--add`           | `boolean`, default: `true` | Add the modified files like `package.json` and `CHANGELOG.md` files to the git stage for committing. |          |
-| `--show-advanced` | `boolean`                  | Pair with `--help` to show advanced options.                                                         |          |
+| Option            | Type                       | Description                                                                                          |
+| ----------------- | -------------------------- | ---------------------------------------------------------------------------------------------------- |
+| `--add`           | `boolean`, default: `true` | Add the modified files like `package.json` and `CHANGELOG.md` files to the git stage for committing. |
+| `--show-advanced` | `boolean`                  | Pair with `--help` to show advanced options.                                                         |
 
 <details>
 
 <summary>Advanced options</summary>
 
-| Option          | Type      | Description                                                 | Required |
-| --------------- | --------- | ----------------------------------------------------------- | -------- |
-| `--allow-dirty` | `boolean` | Bypass checks to ensure no local changes before publishing. |          |
+| Option          | Type      | Description                                                 |
+| --------------- | --------- | ----------------------------------------------------------- |
+| `--allow-dirty` | `boolean` | Bypass checks to ensure no local changes before publishing. |
 
 </details>
 
@@ -236,7 +236,7 @@ one change version
 
 ### `one codeowners`
 
-Aliases: `owners`
+Aliases: `one owners`
 
 Manage codeowners
 
@@ -254,10 +254,10 @@ Sync code owners from Workspace configurations to the repository’s CODEOWNERS 
 one codeowners sync
 ```
 
-| Option            | Type      | Description                                       | Required |
-| ----------------- | --------- | ------------------------------------------------- | -------- |
-| `--add`           | `boolean` | Add the updated CODEOWNERS file to the git stage. |          |
-| `--show-advanced` | `boolean` | Pair with `--help` to show advanced options.      |          |
+| Option            | Type      | Description                                       |
+| ----------------- | --------- | ------------------------------------------------- |
+| `--add`           | `boolean` | Add the updated CODEOWNERS file to the git stage. |
+| `--show-advanced` | `boolean` | Pair with `--help` to show advanced options.      |
 
 <details>
 
@@ -279,9 +279,9 @@ Verify the CODEOWNERS file is up to date and unmodified.
 one codeowners verify
 ```
 
-| Option            | Type      | Description                                  | Required |
-| ----------------- | --------- | -------------------------------------------- | -------- |
-| `--show-advanced` | `boolean` | Pair with `--help` to show advanced options. |          |
+| Option            | Type      | Description                                  |
+| ----------------- | --------- | -------------------------------------------- |
+| `--show-advanced` | `boolean` | Pair with `--help` to show advanced options. |
 
 <details>
 
@@ -297,7 +297,7 @@ one codeowners verify
 
 ### `one dependencies`
 
-Aliases: `dependency`, `deps`, `dep`
+Aliases: `one dependency`, `one deps`, `one dep`
 
 Safely manage Workspace dependencies across your repository.
 
@@ -321,15 +321,15 @@ If multiple versions of the requested dependencies are found in the Workspace Gr
 
 Otherwise, the latest version will be requested from the registry.
 
-| Option               | Type                                               | Description                                                                                                                            | Required |
-| -------------------- | -------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- | -------- |
-| `--all`, `-a`        | `boolean`                                          | Run across all workspaces                                                                                                              |          |
-| `--dedupe`           | `boolean`, default: `true`                         | Deduplicate dependencies across the repository after install is complete.                                                              |          |
-| `--dev`, `-d`        | `array`                                            | Add dependencies for development purposes only.                                                                                        |          |
-| `--mode`             | `"strict"`, `"loose"`, `"off"`, default: `"loose"` | Version selection mode. Use `strict` to use strict version numbers, `loose` to use caret (`^`) ranges, and `off` for nothing specific. |          |
-| `--prod`, `-p`       | `array`                                            | Add dependencies for production purposes.                                                                                              |          |
-| `--show-advanced`    | `boolean`                                          | Pair with `--help` to show advanced options.                                                                                           |          |
-| `--workspaces`, `-w` | `array`                                            | One or more Workspaces to add dependencies into                                                                                        |          |
+| Option             | Type                                               | Description                                                                                                                            |
+| ------------------ | -------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| `--all, -a`        | `boolean`                                          | Run across all workspaces                                                                                                              |
+| `--dedupe`         | `boolean`, default: `true`                         | Deduplicate dependencies across the repository after install is complete.                                                              |
+| `--dev, -d`        | `array`                                            | Add dependencies for development purposes only.                                                                                        |
+| `--mode`           | `"strict"`, `"loose"`, `"off"`, default: `"loose"` | Version selection mode. Use `strict` to use strict version numbers, `loose` to use caret (`^`) ranges, and `off` for nothing specific. |
+| `--prod, -p`       | `array`                                            | Add dependencies for production purposes.                                                                                              |
+| `--show-advanced`  | `boolean`                                          | Pair with `--help` to show advanced options.                                                                                           |
+| `--workspaces, -w` | `array`                                            | One or more Workspaces to add dependencies into                                                                                        |
 
 Install the latest version of `normalizr` from the registry, using a strict version number.
 
@@ -359,13 +359,13 @@ Remove dependencies from Workspaces.
 one dependencies remove -w [workspaces...] -d [dependencies...] [options...]
 ```
 
-| Option                 | Type                       | Description                                                               | Required |
-| ---------------------- | -------------------------- | ------------------------------------------------------------------------- | -------- |
-| `--all`, `-a`          | `boolean`                  | Run across all workspaces                                                 |          |
-| `--dedupe`             | `boolean`, default: `true` | Deduplicate dependencies across the repository after install is complete. |          |
-| `--dependencies`, `-d` | `array`                    | Dependency names that should be removed.                                  | ✅       |
-| `--show-advanced`      | `boolean`                  | Pair with `--help` to show advanced options.                              |          |
-| `--workspaces`, `-w`   | `array`                    | List of Workspace names to run against                                    |          |
+| Option               | Type                       | Description                                                               | Required |
+| -------------------- | -------------------------- | ------------------------------------------------------------------------- | -------- |
+| `--all, -a`          | `boolean`                  | Run across all workspaces                                                 |          |
+| `--dedupe`           | `boolean`, default: `true` | Deduplicate dependencies across the repository after install is complete. |          |
+| `--dependencies, -d` | `array`                    | Dependency names that should be removed.                                  | ✅       |
+| `--show-advanced`    | `boolean`                  | Pair with `--help` to show advanced options.                              |          |
+| `--workspaces, -w`   | `array`                    | List of Workspace names to run against                                    |          |
 
 ---
 
@@ -383,12 +383,12 @@ Dependencies across Workspaces can be validated using one of the various modes:
 - `loose`: Reused third-party dependencies will be required to have semantic version overlap across unique branches of the Graph.
 - `strict`: Versions of all dependencies across each discrete Workspace dependency tree must be strictly equal.
 
-| Option               | Type                                               | Description                                                                                                                                                   | Required |
-| -------------------- | -------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
-| `--all`, `-a`        | `boolean`                                          | Run across all workspaces                                                                                                                                     |          |
-| `--mode`             | `"strict"`, `"loose"`, `"off"`, default: `"loose"` | Version selection mode. Use `strict` to use exact version matches, `loose` to accept within defined ranges (`^` or `~` range), and `off` for no verification. |          |
-| `--show-advanced`    | `boolean`                                          | Pair with `--help` to show advanced options.                                                                                                                  |          |
-| `--workspaces`, `-w` | `array`                                            | List of Workspace names to run against                                                                                                                        |          |
+| Option             | Type                                               | Description                                                                                                                                                   |
+| ------------------ | -------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--all, -a`        | `boolean`                                          | Run across all workspaces                                                                                                                                     |
+| `--mode`           | `"strict"`, `"loose"`, `"off"`, default: `"loose"` | Version selection mode. Use `strict` to use exact version matches, `loose` to accept within defined ranges (`^` or `~` range), and `off` for no verification. |
+| `--show-advanced`  | `boolean`                                          | Pair with `--help` to show advanced options.                                                                                                                  |
+| `--workspaces, -w` | `array`                                            | List of Workspace names to run against                                                                                                                        |
 
 ---
 
@@ -404,22 +404,22 @@ Help documentation should always be easy to find. This command will help automat
 
 Add this command to your one Repo tasks on pre-commit to ensure that your documentation is always up-to-date.
 
-| Option            | Type                                                                      | Description                                                                | Required |
-| ----------------- | ------------------------------------------------------------------------- | -------------------------------------------------------------------------- | -------- |
-| `--add`           | `boolean`                                                                 | Add the output file to the git stage                                       |          |
-| `--format`        | `"markdown"`, `"json"`, default: `"markdown"`                             | Output format for documentation                                            |          |
-| `--heading-level` | `number`                                                                  | Heading level to start at for Markdown output                              |          |
-| `--out-file`      | `string`, default: `"./docs/src/content/docs/plugins/docgen/example.mdx"` | File to write output to. If not provided, stdout will be used              |          |
-| `--out-workspace` | `string`, default: `"root"`                                               | Workspace name to write the --out-file to                                  |          |
-| `--safe-write`    | `boolean`, default: `true`                                                | Write documentation to a portion of the file with start and end sentinels. |          |
+| Option            | Type                                                                      | Description                                                                |
+| ----------------- | ------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
+| `--add`           | `boolean`                                                                 | Add the output file to the git stage                                       |
+| `--format`        | `"markdown"`, `"json"`, default: `"markdown"`                             | Output format for documentation                                            |
+| `--heading-level` | `number`                                                                  | Heading level to start at for Markdown output                              |
+| `--out-file`      | `string`, default: `"./docs/src/content/docs/plugins/docgen/example.mdx"` | File to write output to. If not provided, stdout will be used              |
+| `--out-workspace` | `string`, default: `"root"`                                               | Workspace name to write the --out-file to                                  |
+| `--safe-write`    | `boolean`, default: `true`                                                | Write documentation to a portion of the file with start and end sentinels. |
 
 <details>
 
 <summary>Advanced options</summary>
 
-| Option      | Type     | Description                                              | Required |
-| ----------- | -------- | -------------------------------------------------------- | -------- |
-| `--command` | `string` | Start at the given command, skip the root and any others |          |
+| Option      | Type     | Description                                              |
+| ----------- | -------- | -------------------------------------------------------- |
+| `--command` | `string` | Start at the given command, skip the root and any others |
 
 </details>
 
@@ -427,7 +427,7 @@ Add this command to your one Repo tasks on pre-commit to ensure that your docume
 
 ### `one format`
 
-Aliases: `prettier`
+Aliases: `one prettier`
 
 Format files with prettier
 
@@ -435,27 +435,27 @@ Format files with prettier
 one format [options]
 ```
 
-| Option               | Type      | Description                                                                                                                                                                 | Required |
-| -------------------- | --------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
-| `--add`              | `boolean` | Add modified files after write                                                                                                                                              |          |
-| `--affected`         | `boolean` | Select all affected Workspaces. If no other inputs are chosen, this will default to `true`.                                                                                 |          |
-| `--all`, `-a`        | `boolean` | Run across all workspaces                                                                                                                                                   |          |
-| `--check`            | `boolean` | Check for changes.                                                                                                                                                          |          |
-| `--files`, `-f`      | `array`   | Determine Workspaces from specific files                                                                                                                                    |          |
-| `--show-advanced`    | `boolean` | Pair with `--help` to show advanced options.                                                                                                                                |          |
-| `--staged`           | `boolean` | Use files on the git stage to calculate affected files or Workspaces. When unset or `--no-staged`, changes will be calculated from the entire branch, since its fork point. |          |
-| `--workspaces`, `-w` | `array`   | List of Workspace names to run against                                                                                                                                      |          |
+| Option             | Type      | Description                                                                                                                                                                 |
+| ------------------ | --------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--add`            | `boolean` | Add modified files after write                                                                                                                                              |
+| `--affected`       | `boolean` | Select all affected Workspaces. If no other inputs are chosen, this will default to `true`.                                                                                 |
+| `--all, -a`        | `boolean` | Run across all workspaces                                                                                                                                                   |
+| `--check`          | `boolean` | Check for changes.                                                                                                                                                          |
+| `--files, -f`      | `array`   | Determine Workspaces from specific files                                                                                                                                    |
+| `--show-advanced`  | `boolean` | Pair with `--help` to show advanced options.                                                                                                                                |
+| `--staged`         | `boolean` | Use files on the git stage to calculate affected files or Workspaces. When unset or `--no-staged`, changes will be calculated from the entire branch, since its fork point. |
+| `--workspaces, -w` | `array`   | List of Workspace names to run against                                                                                                                                      |
 
 <details>
 
 <summary>Advanced options</summary>
 
-| Option              | Type                       | Description                                                                        | Required |
-| ------------------- | -------------------------- | ---------------------------------------------------------------------------------- | -------- |
-| `--cache`           | `boolean`, default: `true` | Use Prettier’s built-in cache to determin whether files need formatting or not.    |          |
-| `--from-ref`        | `string`                   | Git ref to start looking for affected files or workspaces                          |          |
-| `--github-annotate` | `boolean`, default: `true` | Annotate files in GitHub with errors when failing format checks in GitHub Actions. |          |
-| `--through-ref`     | `string`                   | Git ref to start looking for affected files or workspaces                          |          |
+| Option              | Type                       | Description                                                                        |
+| ------------------- | -------------------------- | ---------------------------------------------------------------------------------- |
+| `--cache`           | `boolean`, default: `true` | Use Prettier’s built-in cache to determin whether files need formatting or not.    |
+| `--from-ref`        | `string`                   | Git ref to start looking for affected files or workspaces                          |
+| `--github-annotate` | `boolean`, default: `true` | Annotate files in GitHub with errors when failing format checks in GitHub Actions. |
+| `--through-ref`     | `string`                   | Git ref to start looking for affected files or workspaces                          |
 
 </details>
 
@@ -463,7 +463,7 @@ one format [options]
 
 ### `one generate`
 
-Aliases: `gen`
+Aliases: `one gen`
 
 Generate files, folders, and Workspaces from templates.
 
@@ -473,10 +473,10 @@ one generate [options]
 
 To create new templates add a new folder to config/templates and create a `.onegen.cjs` configuration file. Follow the instructions online for more: https\://onerepo.tools/plugins/generate/
 
-| Option            | Type      | Description                                                                         | Required |
-| ----------------- | --------- | ----------------------------------------------------------------------------------- | -------- |
-| `--show-advanced` | `boolean` | Pair with `--help` to show advanced options.                                        |          |
-| `--type`, `-t`    | `string`  | Template type to generate. If not provided, a list will be provided to choose from. |          |
+| Option            | Type      | Description                                                                         |
+| ----------------- | --------- | ----------------------------------------------------------------------------------- |
+| `--show-advanced` | `boolean` | Pair with `--help` to show advanced options.                                        |
+| `--type, -t`      | `string`  | Template type to generate. If not provided, a list will be provided to choose from. |
 
 <details>
 
@@ -512,25 +512,25 @@ This command can generate representations of your Workspace Graph for use in deb
 
 Pass `--open` to auto-open your default browser with the URL or use one of the `--format` options to print out various other representations.
 
-| Option               | Type                             | Description                                                                                                                                                                 | Required |
-| -------------------- | -------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
-| `--affected`         | `boolean`                        | Select all affected Workspaces. If no other inputs are chosen, this will default to `true`.                                                                                 |          |
-| `--all`, `-a`        | `boolean`                        | Run across all workspaces                                                                                                                                                   |          |
-| `--format`, `-f`     | `"mermaid"`, `"plain"`, `"json"` | Output format for inspecting the Workspace Graph.                                                                                                                           |          |
-| `--open`             | `boolean`                        | Auto-open the browser for the online visualizer.                                                                                                                            |          |
-| `--show-advanced`    | `boolean`                        | Pair with `--help` to show advanced options.                                                                                                                                |          |
-| `--staged`           | `boolean`                        | Use files on the git stage to calculate affected files or Workspaces. When unset or `--no-staged`, changes will be calculated from the entire branch, since its fork point. |          |
-| `--workspaces`, `-w` | `array`                          | List of Workspace names to run against                                                                                                                                      |          |
+| Option             | Type                             | Description                                                                                                                                                                 |
+| ------------------ | -------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--affected`       | `boolean`                        | Select all affected Workspaces. If no other inputs are chosen, this will default to `true`.                                                                                 |
+| `--all, -a`        | `boolean`                        | Run across all workspaces                                                                                                                                                   |
+| `--format, -f`     | `"mermaid"`, `"plain"`, `"json"` | Output format for inspecting the Workspace Graph.                                                                                                                           |
+| `--open`           | `boolean`                        | Auto-open the browser for the online visualizer.                                                                                                                            |
+| `--show-advanced`  | `boolean`                        | Pair with `--help` to show advanced options.                                                                                                                                |
+| `--staged`         | `boolean`                        | Use files on the git stage to calculate affected files or Workspaces. When unset or `--no-staged`, changes will be calculated from the entire branch, since its fork point. |
+| `--workspaces, -w` | `array`                          | List of Workspace names to run against                                                                                                                                      |
 
 <details>
 
 <summary>Advanced options</summary>
 
-| Option          | Type                                                    | Description                                                                                                                                                           | Required |
-| --------------- | ------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
-| `--from-ref`    | `string`                                                | Git ref to start looking for affected files or workspaces                                                                                                             |          |
-| `--through-ref` | `string`                                                | Git ref to start looking for affected files or workspaces                                                                                                             |          |
-| `--url`         | `string`, default: `"https://onerepo.tools/visualize/"` | Override the URL used to visualize the Graph. The Graph data will be attached the the `g` query parameter as a JSON string of the DAG, compressed using zLib deflate. |          |
+| Option          | Type                                                    | Description                                                                                                                                                           |
+| --------------- | ------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--from-ref`    | `string`                                                | Git ref to start looking for affected files or workspaces                                                                                                             |
+| `--through-ref` | `string`                                                | Git ref to start looking for affected files or workspaces                                                                                                             |
+| `--url`         | `string`, default: `"https://onerepo.tools/visualize/"` | Override the URL used to visualize the Graph. The Graph data will be attached the the `g` query parameter as a JSON string of the DAG, compressed using zLib deflate. |
 
 </details>
 
@@ -570,18 +570,18 @@ Dependencies across Workspaces can be validated using one of the various modes:
 - `loose`: Reused third-party dependencies will be required to have semantic version overlap across unique branches of the Graph.
 - `strict`: Versions of all dependencies across each discrete Workspace dependency tree must be strictly equal.
 
-| Option            | Type                                               | Description                                  | Required |
-| ----------------- | -------------------------------------------------- | -------------------------------------------- | -------- |
-| `--mode`          | `"strict"`, `"loose"`, `"off"`, default: `"loose"` | Dependency overlap validation method.        |          |
-| `--show-advanced` | `boolean`                                          | Pair with `--help` to show advanced options. |          |
+| Option            | Type                                               | Description                                  |
+| ----------------- | -------------------------------------------------- | -------------------------------------------- |
+| `--mode`          | `"strict"`, `"loose"`, `"off"`, default: `"loose"` | Dependency overlap validation method.        |
+| `--show-advanced` | `boolean`                                          | Pair with `--help` to show advanced options. |
 
 <details>
 
 <summary>Advanced options</summary>
 
-| Option            | Type                                          | Description                             | Required |
-| ----------------- | --------------------------------------------- | --------------------------------------- | -------- |
-| `--custom-schema` | `string`, default: `"config/graph-schema.ts"` | Path to a custom JSON schema definition |          |
+| Option            | Type                                          | Description                             |
+| ----------------- | --------------------------------------------- | --------------------------------------- |
+| `--custom-schema` | `string`, default: `"config/graph-schema.ts"` | Path to a custom JSON schema definition |
 
 </details>
 
@@ -605,12 +605,12 @@ Create git hooks
 one hooks create
 ```
 
-| Option            | Type                                                                                                                                                                                                                                                                                                                                                                                                                                          | Description                                                                | Required |
-| ----------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- | -------- |
-| `--add`           | `boolean`, default: `true`                                                                                                                                                                                                                                                                                                                                                                                                                    | Add the hooks to the git stage for committing.                             |          |
-| `--hook`          | `"applypatch-msg"`, `"pre-applypatch"`, `"post-applypatch"`, `"pre-commit"`, `"pre-merge-commit"`, `"prepare-commit-msg"`, `"commit-msg"`, `"post-commit"`, `"pre-rebase"`, `"post-checkout"`, `"post-merge"`, `"pre-receive"`, `"update"`, `"post-receive"`, `"post-update"`, `"pre-auto-gc"`, `"post-rewrite"`, `"pre-push"`, `"proc-receive"`, `"push-to-checkout"`, default: `["pre-commit","post-checkout","post-merge","post-rewrite"]` | The git hook to create. Omit this option to auto-create recommended hooks. |          |
-| `--overwrite`     | `boolean`                                                                                                                                                                                                                                                                                                                                                                                                                                     | Overwrite existing hooks                                                   |          |
-| `--show-advanced` | `boolean`                                                                                                                                                                                                                                                                                                                                                                                                                                     | Pair with `--help` to show advanced options.                               |          |
+| Option            | Type                                                                                                                                                                                                                                                                                                                                                                                                                                          | Description                                                                |
+| ----------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
+| `--add`           | `boolean`, default: `true`                                                                                                                                                                                                                                                                                                                                                                                                                    | Add the hooks to the git stage for committing.                             |
+| `--hook`          | `"applypatch-msg"`, `"pre-applypatch"`, `"post-applypatch"`, `"pre-commit"`, `"pre-merge-commit"`, `"prepare-commit-msg"`, `"commit-msg"`, `"post-commit"`, `"pre-rebase"`, `"post-checkout"`, `"post-merge"`, `"pre-receive"`, `"update"`, `"post-receive"`, `"post-update"`, `"pre-auto-gc"`, `"post-rewrite"`, `"pre-push"`, `"proc-receive"`, `"push-to-checkout"`, default: `["pre-commit","post-checkout","post-merge","post-rewrite"]` | The git hook to create. Omit this option to auto-create recommended hooks. |
+| `--overwrite`     | `boolean`                                                                                                                                                                                                                                                                                                                                                                                                                                     | Overwrite existing hooks                                                   |
+| `--show-advanced` | `boolean`                                                                                                                                                                                                                                                                                                                                                                                                                                     | Pair with `--help` to show advanced options.                               |
 
 <details>
 
@@ -626,7 +626,7 @@ one hooks create
 
 #### `one hooks init`
 
-Aliases: `sync`
+Aliases: `one hooks sync`
 
 Initialize and sync git hook settings for this repository.
 
@@ -634,9 +634,9 @@ Initialize and sync git hook settings for this repository.
 one hooks init
 ```
 
-| Option            | Type      | Description                                  | Required |
-| ----------------- | --------- | -------------------------------------------- | -------- |
-| `--show-advanced` | `boolean` | Pair with `--help` to show advanced options. |          |
+| Option            | Type      | Description                                  |
+| ----------------- | --------- | -------------------------------------------- |
+| `--show-advanced` | `boolean` | Pair with `--help` to show advanced options. |
 
 <details>
 
@@ -658,12 +658,12 @@ Install the oneRepo CLI into your environment.
 one install [options]
 ```
 
-| Option            | Type                          | Description                                                                                                         | Required |
-| ----------------- | ----------------------------- | ------------------------------------------------------------------------------------------------------------------- | -------- |
-| `--force`         | `boolean`                     | Force installation regardless of pre-existing command.                                                              |          |
-| `--location`      | `string`                      | Install location for the binary. Default location is chosen as default option for usr/bin dependent on the OS type. |          |
-| `--show-advanced` | `boolean`                     | Pair with `--help` to show advanced options.                                                                        |          |
-| `--version`       | `string`, default: `"0.16.0"` | Version of oneRepo to install. Defaults to the current version.                                                     |          |
+| Option            | Type                          | Description                                                                                                         |
+| ----------------- | ----------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| `--force`         | `boolean`                     | Force installation regardless of pre-existing command.                                                              |
+| `--location`      | `string`                      | Install location for the binary. Default location is chosen as default option for usr/bin dependent on the OS type. |
+| `--show-advanced` | `boolean`                     | Pair with `--help` to show advanced options.                                                                        |
+| `--version`       | `string`, default: `"0.16.0"` | Version of oneRepo to install. Defaults to the current version.                                                     |
 
 ---
 
@@ -680,26 +680,26 @@ This test commad will automatically attempt to run only the test files related t
 
 Additionally, any other [Jest CLI options](https://jestjs.io/docs/cli) can be passed as passthrough arguments as well after an argument separator (two dasshes `--`)
 
-| Option               | Type                       | Description                                                                                                                                                                 | Required |
-| -------------------- | -------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
-| `--affected`         | `boolean`                  | Select all affected Workspaces. If no other inputs are chosen, this will default to `true`.                                                                                 |          |
-| `--all`, `-a`        | `boolean`                  | Run across all workspaces                                                                                                                                                   |          |
-| `--inspect`          | `boolean`                  | Break for the the Node inspector to debug tests.                                                                                                                            |          |
-| `--pretty`           | `boolean`, default: `true` | Control Jest’s `--colors` flag.                                                                                                                                             |          |
-| `--show-advanced`    | `boolean`                  | Pair with `--help` to show advanced options.                                                                                                                                |          |
-| `--staged`           | `boolean`                  | Use files on the git stage to calculate affected files or Workspaces. When unset or `--no-staged`, changes will be calculated from the entire branch, since its fork point. |          |
-| `--watch`            | `boolean`                  | Shortcut for jest `--watch` mode.                                                                                                                                           |          |
-| `--workspaces`, `-w` | `array`                    | List of Workspace names to run against                                                                                                                                      |          |
+| Option             | Type                       | Description                                                                                                                                                                 |
+| ------------------ | -------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--affected`       | `boolean`                  | Select all affected Workspaces. If no other inputs are chosen, this will default to `true`.                                                                                 |
+| `--all, -a`        | `boolean`                  | Run across all workspaces                                                                                                                                                   |
+| `--inspect`        | `boolean`                  | Break for the the Node inspector to debug tests.                                                                                                                            |
+| `--pretty`         | `boolean`, default: `true` | Control Jest’s `--colors` flag.                                                                                                                                             |
+| `--show-advanced`  | `boolean`                  | Pair with `--help` to show advanced options.                                                                                                                                |
+| `--staged`         | `boolean`                  | Use files on the git stage to calculate affected files or Workspaces. When unset or `--no-staged`, changes will be calculated from the entire branch, since its fork point. |
+| `--watch`          | `boolean`                  | Shortcut for jest `--watch` mode.                                                                                                                                           |
+| `--workspaces, -w` | `array`                    | List of Workspace names to run against                                                                                                                                      |
 
 <details>
 
 <summary>Advanced options</summary>
 
-| Option          | Type                                    | Description                                               | Required |
-| --------------- | --------------------------------------- | --------------------------------------------------------- | -------- |
-| `--config`      | `string`, default: `"./jest.config.js"` | Path to the jest.config file, relative to the repo root.  |          |
-| `--from-ref`    | `string`                                | Git ref to start looking for affected files or workspaces |          |
-| `--through-ref` | `string`                                | Git ref to start looking for affected files or workspaces |          |
+| Option          | Type                                    | Description                                               |
+| --------------- | --------------------------------------- | --------------------------------------------------------- |
+| `--config`      | `string`, default: `"./jest.config.js"` | Path to the jest.config file, relative to the repo root.  |
+| `--from-ref`    | `string`                                | Git ref to start looking for affected files or workspaces |
+| `--through-ref` | `string`                                | Git ref to start looking for affected files or workspaces |
 
 </details>
 
@@ -731,7 +731,7 @@ one jest -- --runInBand --detectOpenHandles
 
 ### `one lint`
 
-Aliases: `eslint`
+Aliases: `one eslint`
 
 Run eslint across files and workspaces
 
@@ -739,30 +739,30 @@ Run eslint across files and workspaces
 one lint [options]
 ```
 
-| Option               | Type                                                            | Description                                                                                                                                                                 | Required |
-| -------------------- | --------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
-| `--add`              | `boolean`                                                       | Add modified files after write to the git stage.                                                                                                                            |          |
-| `--affected`         | `boolean`                                                       | Select all affected Workspaces. If no other inputs are chosen, this will default to `true`.                                                                                 |          |
-| `--all`, `-a`        | `boolean`                                                       | Run across all workspaces                                                                                                                                                   |          |
-| `--cache`            | `boolean`, default: `true`                                      | Use cache if available                                                                                                                                                      |          |
-| `--extensions`       | `array`, default: `["ts","tsx","js","jsx","cjs","mjs","astro"]` |                                                                                                                                                                             |          |
-| `--files`, `-f`      | `array`                                                         | Determine Workspaces from specific files                                                                                                                                    |          |
-| `--fix`              | `boolean`, default: `true`                                      | Apply auto-fixes if possible                                                                                                                                                |          |
-| `--pretty`           | `boolean`, default: `true`                                      | Control ESLint’s `--color` flag.                                                                                                                                            |          |
-| `--quiet`            | `boolean`                                                       | Report errors only                                                                                                                                                          |          |
-| `--show-advanced`    | `boolean`                                                       | Pair with `--help` to show advanced options.                                                                                                                                |          |
-| `--staged`           | `boolean`                                                       | Use files on the git stage to calculate affected files or Workspaces. When unset or `--no-staged`, changes will be calculated from the entire branch, since its fork point. |          |
-| `--workspaces`, `-w` | `array`                                                         | List of Workspace names to run against                                                                                                                                      |          |
+| Option             | Type                                                            | Description                                                                                                                                                                 |
+| ------------------ | --------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--add`            | `boolean`                                                       | Add modified files after write to the git stage.                                                                                                                            |
+| `--affected`       | `boolean`                                                       | Select all affected Workspaces. If no other inputs are chosen, this will default to `true`.                                                                                 |
+| `--all, -a`        | `boolean`                                                       | Run across all workspaces                                                                                                                                                   |
+| `--cache`          | `boolean`, default: `true`                                      | Use cache if available                                                                                                                                                      |
+| `--extensions`     | `array`, default: `["ts","tsx","js","jsx","cjs","mjs","astro"]` |                                                                                                                                                                             |
+| `--files, -f`      | `array`                                                         | Determine Workspaces from specific files                                                                                                                                    |
+| `--fix`            | `boolean`, default: `true`                                      | Apply auto-fixes if possible                                                                                                                                                |
+| `--pretty`         | `boolean`, default: `true`                                      | Control ESLint’s `--color` flag.                                                                                                                                            |
+| `--quiet`          | `boolean`                                                       | Report errors only                                                                                                                                                          |
+| `--show-advanced`  | `boolean`                                                       | Pair with `--help` to show advanced options.                                                                                                                                |
+| `--staged`         | `boolean`                                                       | Use files on the git stage to calculate affected files or Workspaces. When unset or `--no-staged`, changes will be calculated from the entire branch, since its fork point. |
+| `--workspaces, -w` | `array`                                                         | List of Workspace names to run against                                                                                                                                      |
 
 <details>
 
 <summary>Advanced options</summary>
 
-| Option              | Type                       | Description                                                                     | Required |
-| ------------------- | -------------------------- | ------------------------------------------------------------------------------- | -------- |
-| `--from-ref`        | `string`                   | Git ref to start looking for affected files or workspaces                       |          |
-| `--github-annotate` | `boolean`, default: `true` | Annotate files in GitHub with errors when failing lint checks in GitHub Actions |          |
-| `--through-ref`     | `string`                   | Git ref to start looking for affected files or workspaces                       |          |
+| Option              | Type                       | Description                                                                     |
+| ------------------- | -------------------------- | ------------------------------------------------------------------------------- |
+| `--from-ref`        | `string`                   | Git ref to start looking for affected files or workspaces                       |
+| `--github-annotate` | `boolean`, default: `true` | Annotate files in GitHub with errors when failing lint checks in GitHub Actions |
+| `--through-ref`     | `string`                   | Git ref to start looking for affected files or workspaces                       |
 
 </details>
 
@@ -778,27 +778,27 @@ one tasks --lifecycle=<lifecycle> [options]
 
 You can fine-tune the determination of affected Workspaces by providing a `--from-ref` and/or `through-ref`. For more information, get help with `--help --show-advanced`.
 
-| Option               | Type                                                                                                                  | Description                                                                                                                                      | Required |
-| -------------------- | --------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ | -------- |
-| `--affected`         | `boolean`                                                                                                             | Select all affected Workspaces. If no other inputs are chosen, this will default to `true`.                                                      |          |
-| `--all`, `-a`        | `boolean`                                                                                                             | Run across all workspaces                                                                                                                        |          |
-| `--ignore-unstaged`  | `boolean`                                                                                                             | Force staged-changes mode on or off. If `true`, task determination and runners will ignore unstaged changes.                                     |          |
-| `--lifecycle`, `-c`  | `"pre-commit"`, `"post-commit"`, `"post-checkout"`, `"pre-merge"`, `"post-merge"`, `"build"`, `"deploy"`, `"publish"` | Task lifecycle to run. All tasks for the given lifecycle will be run as merged parallel tasks, followed by the merged set of serial tasks.       | ✅       |
-| `--list`             | `boolean`                                                                                                             | List found tasks. Implies dry run and will not actually run any tasks.                                                                           |          |
-| `--shard`            | `string`                                                                                                              | Shard the lifecycle across multiple instances. Format as `<shard-number>/<total-shards>`                                                         |          |
-| `--show-advanced`    | `boolean`                                                                                                             | Pair with `--help` to show advanced options.                                                                                                     |          |
-| `--staged`           | `boolean`                                                                                                             | Backup unstaged files and use only those on the git stage to calculate affected files or workspaces. Will re-apply the unstaged files upon exit. |          |
-| `--workspaces`, `-w` | `array`                                                                                                               | List of Workspace names to run against                                                                                                           |          |
+| Option              | Type                                                                                                                  | Description                                                                                                                                      | Required |
+| ------------------- | --------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ | -------- |
+| `--affected`        | `boolean`                                                                                                             | Select all affected Workspaces. If no other inputs are chosen, this will default to `true`.                                                      |          |
+| `--all, -a`         | `boolean`                                                                                                             | Run across all workspaces                                                                                                                        |          |
+| `--ignore-unstaged` | `boolean`                                                                                                             | Force staged-changes mode on or off. If `true`, task determination and runners will ignore unstaged changes.                                     |          |
+| `--lifecycle, -c`   | `"pre-commit"`, `"post-commit"`, `"post-checkout"`, `"pre-merge"`, `"post-merge"`, `"build"`, `"deploy"`, `"publish"` | Task lifecycle to run. All tasks for the given lifecycle will be run as merged parallel tasks, followed by the merged set of serial tasks.       | ✅       |
+| `--list`            | `boolean`                                                                                                             | List found tasks. Implies dry run and will not actually run any tasks.                                                                           |          |
+| `--shard`           | `string`                                                                                                              | Shard the lifecycle across multiple instances. Format as `<shard-number>/<total-shards>`                                                         |          |
+| `--show-advanced`   | `boolean`                                                                                                             | Pair with `--help` to show advanced options.                                                                                                     |          |
+| `--staged`          | `boolean`                                                                                                             | Backup unstaged files and use only those on the git stage to calculate affected files or workspaces. Will re-apply the unstaged files upon exit. |          |
+| `--workspaces, -w`  | `array`                                                                                                               | List of Workspace names to run against                                                                                                           |          |
 
 <details>
 
 <summary>Advanced options</summary>
 
-| Option          | Type                                                                                   | Description                                                               | Required |
-| --------------- | -------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- | -------- |
-| `--from-ref`    | `string`                                                                               | Git ref to start looking for affected files or workspaces                 |          |
-| `--ignore`      | `array`, default: `[".changesets/*","**/README.md","**/CHANGELOG.md",".changeset/**"]` | List of filepath strings or globs to ignore when matching tasks to files. |          |
-| `--through-ref` | `string`                                                                               | Git ref to start looking for affected files or workspaces                 |          |
+| Option          | Type                                                                                   | Description                                                               |
+| --------------- | -------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
+| `--from-ref`    | `string`                                                                               | Git ref to start looking for affected files or workspaces                 |
+| `--ignore`      | `array`, default: `[".changesets/*","**/README.md","**/CHANGELOG.md",".changeset/**"]` | List of filepath strings or globs to ignore when matching tasks to files. |
+| `--through-ref` | `string`                                                                               | Git ref to start looking for affected files or workspaces                 |
 
 </details>
 
@@ -818,7 +818,7 @@ one tasks --lifecycle=pre-merge --shard=3/5
 
 ### `one test`
 
-Aliases: `vitest`
+Aliases: `one vitest`
 
 Run unit tests using Vitest
 
@@ -831,25 +831,25 @@ This test commad will automatically attempt to run only the test files related t
 
 Additionally, any other [Vitest CLI options](https://jest.dev/guide/cli.html) can be used as passthrough arguments as well after an argument separator (two dashes `--`).
 
-| Option               | Type      | Description                                                                                                                                                                 | Required |
-| -------------------- | --------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
-| `--affected`         | `boolean` | Select all affected Workspaces. If no other inputs are chosen, this will default to `true`.                                                                                 |          |
-| `--all`, `-a`        | `boolean` | Run across all workspaces                                                                                                                                                   |          |
-| `--inspect`          | `boolean` | Break for the the Node inspector to debug tests.                                                                                                                            |          |
-| `--show-advanced`    | `boolean` | Pair with `--help` to show advanced options.                                                                                                                                |          |
-| `--staged`           | `boolean` | Use files on the git stage to calculate affected files or Workspaces. When unset or `--no-staged`, changes will be calculated from the entire branch, since its fork point. |          |
-| `--watch`            | `boolean` | Shortcut for vitest `--watch` mode.                                                                                                                                         |          |
-| `--workspaces`, `-w` | `array`   | List of Workspace names to run against                                                                                                                                      |          |
+| Option             | Type      | Description                                                                                                                                                                 |
+| ------------------ | --------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--affected`       | `boolean` | Select all affected Workspaces. If no other inputs are chosen, this will default to `true`.                                                                                 |
+| `--all, -a`        | `boolean` | Run across all workspaces                                                                                                                                                   |
+| `--inspect`        | `boolean` | Break for the the Node inspector to debug tests.                                                                                                                            |
+| `--show-advanced`  | `boolean` | Pair with `--help` to show advanced options.                                                                                                                                |
+| `--staged`         | `boolean` | Use files on the git stage to calculate affected files or Workspaces. When unset or `--no-staged`, changes will be calculated from the entire branch, since its fork point. |
+| `--watch`          | `boolean` | Shortcut for vitest `--watch` mode.                                                                                                                                         |
+| `--workspaces, -w` | `array`   | List of Workspace names to run against                                                                                                                                      |
 
 <details>
 
 <summary>Advanced options</summary>
 
-| Option          | Type                                      | Description                                                | Required |
-| --------------- | ----------------------------------------- | ---------------------------------------------------------- | -------- |
-| `--config`      | `string`, default: `"./vitest.config.ts"` | Path to the vitest.config file, relative to the repo root. |          |
-| `--from-ref`    | `string`                                  | Git ref to start looking for affected files or workspaces  |          |
-| `--through-ref` | `string`                                  | Git ref to start looking for affected files or workspaces  |          |
+| Option          | Type                                      | Description                                                |
+| --------------- | ----------------------------------------- | ---------------------------------------------------------- |
+| `--config`      | `string`, default: `"./vitest.config.ts"` | Path to the vitest.config file, relative to the repo root. |
+| `--from-ref`    | `string`                                  | Git ref to start looking for affected files or workspaces  |
+| `--through-ref` | `string`                                  | Git ref to start looking for affected files or workspaces  |
 
 </details>
 
@@ -881,7 +881,7 @@ one test -w <workspace>
 
 ### `one tsc`
 
-Aliases: `typescript`, `typecheck`
+Aliases: `one typescript`, `one typecheck`
 
 Sync TS project references
 
@@ -891,25 +891,25 @@ one tsc [options]
 
 Checks for the existence of `tsconfig.json` file and batches running `tsc --noEmit` in each Workspace.
 
-| Option               | Type                       | Description                                                                                                                                                                 | Required |
-| -------------------- | -------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
-| `--affected`         | `boolean`                  | Select all affected Workspaces. If no other inputs are chosen, this will default to `true`.                                                                                 |          |
-| `--all`, `-a`        | `boolean`                  | Run across all workspaces                                                                                                                                                   |          |
-| `--pretty`           | `boolean`, default: `true` | Control TypeScript’s `--pretty` flag.                                                                                                                                       |          |
-| `--show-advanced`    | `boolean`                  | Pair with `--help` to show advanced options.                                                                                                                                |          |
-| `--staged`           | `boolean`                  | Use files on the git stage to calculate affected files or Workspaces. When unset or `--no-staged`, changes will be calculated from the entire branch, since its fork point. |          |
-| `--workspaces`, `-w` | `array`                    | List of Workspace names to run against                                                                                                                                      |          |
+| Option             | Type                       | Description                                                                                                                                                                 |
+| ------------------ | -------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--affected`       | `boolean`                  | Select all affected Workspaces. If no other inputs are chosen, this will default to `true`.                                                                                 |
+| `--all, -a`        | `boolean`                  | Run across all workspaces                                                                                                                                                   |
+| `--pretty`         | `boolean`, default: `true` | Control TypeScript’s `--pretty` flag.                                                                                                                                       |
+| `--show-advanced`  | `boolean`                  | Pair with `--help` to show advanced options.                                                                                                                                |
+| `--staged`         | `boolean`                  | Use files on the git stage to calculate affected files or Workspaces. When unset or `--no-staged`, changes will be calculated from the entire branch, since its fork point. |
+| `--workspaces, -w` | `array`                    | List of Workspace names to run against                                                                                                                                      |
 
 <details>
 
 <summary>Advanced options</summary>
 
-| Option                                                               | Type                                 | Description                                               | Required |
-| -------------------------------------------------------------------- | ------------------------------------ | --------------------------------------------------------- | -------- |
-| `--from-ref`                                                         | `string`                             | Git ref to start looking for affected files or workspaces |          |
-| `--through-ref`                                                      | `string`                             | Git ref to start looking for affected files or workspaces |          |
-| `--tsconfig`                                                         | `string`, default: `"tsconfig.json"` | The filename of the tsconfig to find in each Workspace.   |          |
-| `--use-project-references`, `--project-references`, `--project-refs` | `boolean`, default: `true`           | Automatically sync and use typescript project references  |          |
+| Option                                                           | Type                                 | Description                                               |
+| ---------------------------------------------------------------- | ------------------------------------ | --------------------------------------------------------- |
+| `--from-ref`                                                     | `string`                             | Git ref to start looking for affected files or workspaces |
+| `--through-ref`                                                  | `string`                             | Git ref to start looking for affected files or workspaces |
+| `--tsconfig`                                                     | `string`, default: `"tsconfig.json"` | The filename of the tsconfig to find in each Workspace.   |
+| `--use-project-references, --project-references, --project-refs` | `boolean`, default: `true`           | Automatically sync and use typescript project references  |
 
 </details>
 
@@ -917,7 +917,7 @@ Checks for the existence of `tsconfig.json` file and batches running `tsc --noEm
 
 ### `one workspace`
 
-Aliases: `$0`, `ws`
+Aliases: `one`, `one ws`
 
 Run Workspace-specific commands
 
@@ -927,16 +927,16 @@ one workspace <workspace-name> <command> [options]
 
 Add commands to the `commands` directory within a Workspace to create Workspace-specific commands.
 
-| Positional       | Type     | Description                       | Required |
-| ---------------- | -------- | --------------------------------- | -------- |
-| `command`        | `string` | Command to run.                   |          |
-| `workspace-name` | `string` | The name or alias of a Workspace. |          |
+| Positional       | Type     | Description                       |
+| ---------------- | -------- | --------------------------------- |
+| `command`        | `string` | Command to run.                   |
+| `workspace-name` | `string` | The name or alias of a Workspace. |
 
 ---
 
 #### `one workspace @onerepo/docs`
 
-Aliases: `docs`
+Aliases: `one workspace docs`
 
 Runs commands in the `@onerepo/docs` Workspace
 
@@ -954,27 +954,27 @@ one workspace @onerepo/docs astro
 
 ##### `one workspace @onerepo/docs changelogs`
 
-Aliases: `pull-changelogs`
+Aliases: `one workspace @onerepo/docs pull-changelogs`
 
 Update changelogs from source files
 
-| Option               | Type      | Description                                                                                                                                                                 | Required |
-| -------------------- | --------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
-| `--add`              | `boolean` | Add files to the git index                                                                                                                                                  |          |
-| `--affected`         | `boolean` | Select all affected Workspaces. If no other inputs are chosen, this will default to `true`.                                                                                 |          |
-| `--all`, `-a`        | `boolean` | Run across all workspaces                                                                                                                                                   |          |
-| `--files`, `-f`      | `array`   | Determine Workspaces from specific files                                                                                                                                    |          |
-| `--staged`           | `boolean` | Use files on the git stage to calculate affected files or Workspaces. When unset or `--no-staged`, changes will be calculated from the entire branch, since its fork point. |          |
-| `--workspaces`, `-w` | `array`   | List of Workspace names to run against                                                                                                                                      |          |
+| Option             | Type      | Description                                                                                                                                                                 |
+| ------------------ | --------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--add`            | `boolean` | Add files to the git index                                                                                                                                                  |
+| `--affected`       | `boolean` | Select all affected Workspaces. If no other inputs are chosen, this will default to `true`.                                                                                 |
+| `--all, -a`        | `boolean` | Run across all workspaces                                                                                                                                                   |
+| `--files, -f`      | `array`   | Determine Workspaces from specific files                                                                                                                                    |
+| `--staged`         | `boolean` | Use files on the git stage to calculate affected files or Workspaces. When unset or `--no-staged`, changes will be calculated from the entire branch, since its fork point. |
+| `--workspaces, -w` | `array`   | List of Workspace names to run against                                                                                                                                      |
 
 <details>
 
 <summary>Advanced options</summary>
 
-| Option          | Type     | Description                                               | Required |
-| --------------- | -------- | --------------------------------------------------------- | -------- |
-| `--from-ref`    | `string` | Git ref to start looking for affected files or workspaces |          |
-| `--through-ref` | `string` | Git ref to start looking for affected files or workspaces |          |
+| Option          | Type     | Description                                               |
+| --------------- | -------- | --------------------------------------------------------- |
+| `--from-ref`    | `string` | Git ref to start looking for affected files or workspaces |
+| `--through-ref` | `string` | Git ref to start looking for affected files or workspaces |
 
 </details>
 
@@ -984,23 +984,23 @@ Update changelogs from source files
 
 Generate docs for the oneRepo monorepo
 
-| Option               | Type      | Description                                                                                                                                                                 | Required |
-| -------------------- | --------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
-| `--add`              | `boolean` | Add files to the git index                                                                                                                                                  |          |
-| `--affected`         | `boolean` | Select all affected Workspaces. If no other inputs are chosen, this will default to `true`.                                                                                 |          |
-| `--all`, `-a`        | `boolean` | Run across all workspaces                                                                                                                                                   |          |
-| `--files`, `-f`      | `array`   | Determine Workspaces from specific files                                                                                                                                    |          |
-| `--staged`           | `boolean` | Use files on the git stage to calculate affected files or Workspaces. When unset or `--no-staged`, changes will be calculated from the entire branch, since its fork point. |          |
-| `--workspaces`, `-w` | `array`   | List of Workspace names to run against                                                                                                                                      |          |
+| Option             | Type      | Description                                                                                                                                                                 |
+| ------------------ | --------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--add`            | `boolean` | Add files to the git index                                                                                                                                                  |
+| `--affected`       | `boolean` | Select all affected Workspaces. If no other inputs are chosen, this will default to `true`.                                                                                 |
+| `--all, -a`        | `boolean` | Run across all workspaces                                                                                                                                                   |
+| `--files, -f`      | `array`   | Determine Workspaces from specific files                                                                                                                                    |
+| `--staged`         | `boolean` | Use files on the git stage to calculate affected files or Workspaces. When unset or `--no-staged`, changes will be calculated from the entire branch, since its fork point. |
+| `--workspaces, -w` | `array`   | List of Workspace names to run against                                                                                                                                      |
 
 <details>
 
 <summary>Advanced options</summary>
 
-| Option          | Type     | Description                                               | Required |
-| --------------- | -------- | --------------------------------------------------------- | -------- |
-| `--from-ref`    | `string` | Git ref to start looking for affected files or workspaces |          |
-| `--through-ref` | `string` | Git ref to start looking for affected files or workspaces |          |
+| Option          | Type     | Description                                               |
+| --------------- | -------- | --------------------------------------------------------- |
+| `--from-ref`    | `string` | Git ref to start looking for affected files or workspaces |
+| `--through-ref` | `string` | Git ref to start looking for affected files or workspaces |
 
 </details>
 
@@ -1014,9 +1014,9 @@ Start the docs development server
 one workspace @onerepo/docs start
 ```
 
-| Option            | Type      | Description              | Required |
-| ----------------- | --------- | ------------------------ | -------- |
-| `--netlify`, `-n` | `boolean` | Run with the Netlify CLI |          |
+| Option          | Type      | Description              |
+| --------------- | --------- | ------------------------ |
+| `--netlify, -n` | `boolean` | Run with the Netlify CLI |
 
 ---
 
@@ -1028,15 +1028,15 @@ Generate typedoc markdown files for the toolchain.
 one workspace @onerepo/docs typedoc
 ```
 
-| Option  | Type      | Description                | Required |
-| ------- | --------- | -------------------------- | -------- |
-| `--add` | `boolean` | Add files to the git index |          |
+| Option  | Type      | Description                |
+| ------- | --------- | -------------------------- |
+| `--add` | `boolean` | Add files to the git index |
 
 ---
 
 #### `one workspace @onerepo/github-action`
 
-Aliases: `github-action`
+Aliases: `one workspace github-action`
 
 Runs commands in the `@onerepo/github-action` Workspace
 
@@ -1050,21 +1050,21 @@ Build public Workspaces using esbuild.
 one workspace @onerepo/github-action build [options]
 ```
 
-| Option               | Type      | Description                                                                                                                                                                 | Required |
-| -------------------- | --------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
-| `--affected`         | `boolean` | Select all affected Workspaces. If no other inputs are chosen, this will default to `true`.                                                                                 |          |
-| `--all`, `-a`        | `boolean` | Run across all workspaces                                                                                                                                                   |          |
-| `--staged`           | `boolean` | Use files on the git stage to calculate affected files or Workspaces. When unset or `--no-staged`, changes will be calculated from the entire branch, since its fork point. |          |
-| `--workspaces`, `-w` | `array`   | List of Workspace names to run against                                                                                                                                      |          |
+| Option             | Type      | Description                                                                                                                                                                 |
+| ------------------ | --------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--affected`       | `boolean` | Select all affected Workspaces. If no other inputs are chosen, this will default to `true`.                                                                                 |
+| `--all, -a`        | `boolean` | Run across all workspaces                                                                                                                                                   |
+| `--staged`         | `boolean` | Use files on the git stage to calculate affected files or Workspaces. When unset or `--no-staged`, changes will be calculated from the entire branch, since its fork point. |
+| `--workspaces, -w` | `array`   | List of Workspace names to run against                                                                                                                                      |
 
 <details>
 
 <summary>Advanced options</summary>
 
-| Option          | Type     | Description                                               | Required |
-| --------------- | -------- | --------------------------------------------------------- | -------- |
-| `--from-ref`    | `string` | Git ref to start looking for affected files or workspaces |          |
-| `--through-ref` | `string` | Git ref to start looking for affected files or workspaces |          |
+| Option          | Type     | Description                                               |
+| --------------- | -------- | --------------------------------------------------------- |
+| `--from-ref`    | `string` | Git ref to start looking for affected files or workspaces |
+| `--through-ref` | `string` | Git ref to start looking for affected files or workspaces |
 
 </details>
 

--- a/docs/src/content/docs/plugins/eslint.mdx
+++ b/docs/src/content/docs/plugins/eslint.mdx
@@ -122,11 +122,11 @@ Control the ESLint setting default to suppress warnings and only report errors.
 ## Commands
 
 {/* start-auto-generated-from-cli-eslint */}
-{/* @generated SignedSource<<153cfaee9db2fece7f36f3ad3af4ae2f>> */}
+{/* @generated SignedSource<<f13b2f7d5e4f69e3e20fa29d23cf5148>> */}
 
 ### `one lint`
 
-Aliases: `eslint`
+Aliases: `one eslint`
 
 Run eslint across files and workspaces
 
@@ -134,30 +134,30 @@ Run eslint across files and workspaces
 one lint [options]
 ```
 
-| Option               | Type                                                            | Description                                                                                                                                                                 | Required |
-| -------------------- | --------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
-| `--add`              | `boolean`                                                       | Add modified files after write to the git stage.                                                                                                                            |          |
-| `--affected`         | `boolean`                                                       | Select all affected Workspaces. If no other inputs are chosen, this will default to `true`.                                                                                 |          |
-| `--all`, `-a`        | `boolean`                                                       | Run across all workspaces                                                                                                                                                   |          |
-| `--cache`            | `boolean`, default: `true`                                      | Use cache if available                                                                                                                                                      |          |
-| `--extensions`       | `array`, default: `["ts","tsx","js","jsx","cjs","mjs","astro"]` |                                                                                                                                                                             |          |
-| `--files`, `-f`      | `array`                                                         | Determine Workspaces from specific files                                                                                                                                    |          |
-| `--fix`              | `boolean`, default: `true`                                      | Apply auto-fixes if possible                                                                                                                                                |          |
-| `--pretty`           | `boolean`, default: `true`                                      | Control ESLint’s `--color` flag.                                                                                                                                            |          |
-| `--quiet`            | `boolean`                                                       | Report errors only                                                                                                                                                          |          |
-| `--show-advanced`    | `boolean`                                                       | Pair with `--help` to show advanced options.                                                                                                                                |          |
-| `--staged`           | `boolean`                                                       | Use files on the git stage to calculate affected files or Workspaces. When unset or `--no-staged`, changes will be calculated from the entire branch, since its fork point. |          |
-| `--workspaces`, `-w` | `array`                                                         | List of Workspace names to run against                                                                                                                                      |          |
+| Option             | Type                                                            | Description                                                                                                                                                                 |
+| ------------------ | --------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--add`            | `boolean`                                                       | Add modified files after write to the git stage.                                                                                                                            |
+| `--affected`       | `boolean`                                                       | Select all affected Workspaces. If no other inputs are chosen, this will default to `true`.                                                                                 |
+| `--all, -a`        | `boolean`                                                       | Run across all workspaces                                                                                                                                                   |
+| `--cache`          | `boolean`, default: `true`                                      | Use cache if available                                                                                                                                                      |
+| `--extensions`     | `array`, default: `["ts","tsx","js","jsx","cjs","mjs","astro"]` |                                                                                                                                                                             |
+| `--files, -f`      | `array`                                                         | Determine Workspaces from specific files                                                                                                                                    |
+| `--fix`            | `boolean`, default: `true`                                      | Apply auto-fixes if possible                                                                                                                                                |
+| `--pretty`         | `boolean`, default: `true`                                      | Control ESLint’s `--color` flag.                                                                                                                                            |
+| `--quiet`          | `boolean`                                                       | Report errors only                                                                                                                                                          |
+| `--show-advanced`  | `boolean`                                                       | Pair with `--help` to show advanced options.                                                                                                                                |
+| `--staged`         | `boolean`                                                       | Use files on the git stage to calculate affected files or Workspaces. When unset or `--no-staged`, changes will be calculated from the entire branch, since its fork point. |
+| `--workspaces, -w` | `array`                                                         | List of Workspace names to run against                                                                                                                                      |
 
 <details>
 
 <summary>Advanced options</summary>
 
-| Option              | Type                       | Description                                                                     | Required |
-| ------------------- | -------------------------- | ------------------------------------------------------------------------------- | -------- |
-| `--from-ref`        | `string`                   | Git ref to start looking for affected files or workspaces                       |          |
-| `--github-annotate` | `boolean`, default: `true` | Annotate files in GitHub with errors when failing lint checks in GitHub Actions |          |
-| `--through-ref`     | `string`                   | Git ref to start looking for affected files or workspaces                       |          |
+| Option              | Type                       | Description                                                                     |
+| ------------------- | -------------------------- | ------------------------------------------------------------------------------- |
+| `--from-ref`        | `string`                   | Git ref to start looking for affected files or workspaces                       |
+| `--github-annotate` | `boolean`, default: `true` | Annotate files in GitHub with errors when failing lint checks in GitHub Actions |
+| `--through-ref`     | `string`                   | Git ref to start looking for affected files or workspaces                       |
 
 </details>
 

--- a/docs/src/content/docs/plugins/jest.mdx
+++ b/docs/src/content/docs/plugins/jest.mdx
@@ -123,7 +123,7 @@ Rename the default command name.
 ## Commands
 
 {/* start-auto-generated-from-cli-jest */}
-{/* @generated SignedSource<<ee7f1a85bac3b3f5123d83949df89fac>> */}
+{/* @generated SignedSource<<6285b7b62a98fde902106bd8c682cdc1>> */}
 
 ### `one jest`
 
@@ -138,26 +138,26 @@ This test commad will automatically attempt to run only the test files related t
 
 Additionally, any other [Jest CLI options](https://jestjs.io/docs/cli) can be passed as passthrough arguments as well after an argument separator (two dasshes `--`)
 
-| Option               | Type                       | Description                                                                                                                                                                 | Required |
-| -------------------- | -------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
-| `--affected`         | `boolean`                  | Select all affected Workspaces. If no other inputs are chosen, this will default to `true`.                                                                                 |          |
-| `--all`, `-a`        | `boolean`                  | Run across all workspaces                                                                                                                                                   |          |
-| `--inspect`          | `boolean`                  | Break for the the Node inspector to debug tests.                                                                                                                            |          |
-| `--pretty`           | `boolean`, default: `true` | Control Jest’s `--colors` flag.                                                                                                                                             |          |
-| `--show-advanced`    | `boolean`                  | Pair with `--help` to show advanced options.                                                                                                                                |          |
-| `--staged`           | `boolean`                  | Use files on the git stage to calculate affected files or Workspaces. When unset or `--no-staged`, changes will be calculated from the entire branch, since its fork point. |          |
-| `--watch`            | `boolean`                  | Shortcut for jest `--watch` mode.                                                                                                                                           |          |
-| `--workspaces`, `-w` | `array`                    | List of Workspace names to run against                                                                                                                                      |          |
+| Option             | Type                       | Description                                                                                                                                                                 |
+| ------------------ | -------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--affected`       | `boolean`                  | Select all affected Workspaces. If no other inputs are chosen, this will default to `true`.                                                                                 |
+| `--all, -a`        | `boolean`                  | Run across all workspaces                                                                                                                                                   |
+| `--inspect`        | `boolean`                  | Break for the the Node inspector to debug tests.                                                                                                                            |
+| `--pretty`         | `boolean`, default: `true` | Control Jest’s `--colors` flag.                                                                                                                                             |
+| `--show-advanced`  | `boolean`                  | Pair with `--help` to show advanced options.                                                                                                                                |
+| `--staged`         | `boolean`                  | Use files on the git stage to calculate affected files or Workspaces. When unset or `--no-staged`, changes will be calculated from the entire branch, since its fork point. |
+| `--watch`          | `boolean`                  | Shortcut for jest `--watch` mode.                                                                                                                                           |
+| `--workspaces, -w` | `array`                    | List of Workspace names to run against                                                                                                                                      |
 
 <details>
 
 <summary>Advanced options</summary>
 
-| Option          | Type                                    | Description                                               | Required |
-| --------------- | --------------------------------------- | --------------------------------------------------------- | -------- |
-| `--config`      | `string`, default: `"./jest.config.js"` | Path to the jest.config file, relative to the repo root.  |          |
-| `--from-ref`    | `string`                                | Git ref to start looking for affected files or workspaces |          |
-| `--through-ref` | `string`                                | Git ref to start looking for affected files or workspaces |          |
+| Option          | Type                                    | Description                                               |
+| --------------- | --------------------------------------- | --------------------------------------------------------- |
+| `--config`      | `string`, default: `"./jest.config.js"` | Path to the jest.config file, relative to the repo root.  |
+| `--from-ref`    | `string`                                | Git ref to start looking for affected files or workspaces |
+| `--through-ref` | `string`                                | Git ref to start looking for affected files or workspaces |
 
 </details>
 

--- a/docs/src/content/docs/plugins/prettier.mdx
+++ b/docs/src/content/docs/plugins/prettier.mdx
@@ -121,11 +121,11 @@ Whether to use Prettier's built-in cache determinism.
 ## Commands
 
 {/* start-auto-generated-from-cli-prettier */}
-{/* @generated SignedSource<<d5d26cbfa4e1df5b956788d013f94ad2>> */}
+{/* @generated SignedSource<<06661420740212ff5497999154969309>> */}
 
 ### `one format`
 
-Aliases: `prettier`
+Aliases: `one prettier`
 
 Format files with prettier
 
@@ -133,27 +133,27 @@ Format files with prettier
 one format [options]
 ```
 
-| Option               | Type      | Description                                                                                                                                                                 | Required |
-| -------------------- | --------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
-| `--add`              | `boolean` | Add modified files after write                                                                                                                                              |          |
-| `--affected`         | `boolean` | Select all affected Workspaces. If no other inputs are chosen, this will default to `true`.                                                                                 |          |
-| `--all`, `-a`        | `boolean` | Run across all workspaces                                                                                                                                                   |          |
-| `--check`            | `boolean` | Check for changes.                                                                                                                                                          |          |
-| `--files`, `-f`      | `array`   | Determine Workspaces from specific files                                                                                                                                    |          |
-| `--show-advanced`    | `boolean` | Pair with `--help` to show advanced options.                                                                                                                                |          |
-| `--staged`           | `boolean` | Use files on the git stage to calculate affected files or Workspaces. When unset or `--no-staged`, changes will be calculated from the entire branch, since its fork point. |          |
-| `--workspaces`, `-w` | `array`   | List of Workspace names to run against                                                                                                                                      |          |
+| Option             | Type      | Description                                                                                                                                                                 |
+| ------------------ | --------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--add`            | `boolean` | Add modified files after write                                                                                                                                              |
+| `--affected`       | `boolean` | Select all affected Workspaces. If no other inputs are chosen, this will default to `true`.                                                                                 |
+| `--all, -a`        | `boolean` | Run across all workspaces                                                                                                                                                   |
+| `--check`          | `boolean` | Check for changes.                                                                                                                                                          |
+| `--files, -f`      | `array`   | Determine Workspaces from specific files                                                                                                                                    |
+| `--show-advanced`  | `boolean` | Pair with `--help` to show advanced options.                                                                                                                                |
+| `--staged`         | `boolean` | Use files on the git stage to calculate affected files or Workspaces. When unset or `--no-staged`, changes will be calculated from the entire branch, since its fork point. |
+| `--workspaces, -w` | `array`   | List of Workspace names to run against                                                                                                                                      |
 
 <details>
 
 <summary>Advanced options</summary>
 
-| Option              | Type                       | Description                                                                        | Required |
-| ------------------- | -------------------------- | ---------------------------------------------------------------------------------- | -------- |
-| `--cache`           | `boolean`, default: `true` | Use Prettier’s built-in cache to determin whether files need formatting or not.    |          |
-| `--from-ref`        | `string`                   | Git ref to start looking for affected files or workspaces                          |          |
-| `--github-annotate` | `boolean`, default: `true` | Annotate files in GitHub with errors when failing format checks in GitHub Actions. |          |
-| `--through-ref`     | `string`                   | Git ref to start looking for affected files or workspaces                          |          |
+| Option              | Type                       | Description                                                                        |
+| ------------------- | -------------------------- | ---------------------------------------------------------------------------------- |
+| `--cache`           | `boolean`, default: `true` | Use Prettier’s built-in cache to determin whether files need formatting or not.    |
+| `--from-ref`        | `string`                   | Git ref to start looking for affected files or workspaces                          |
+| `--github-annotate` | `boolean`, default: `true` | Annotate files in GitHub with errors when failing format checks in GitHub Actions. |
+| `--through-ref`     | `string`                   | Git ref to start looking for affected files or workspaces                          |
 
 </details>
 

--- a/docs/src/content/docs/plugins/typescript.mdx
+++ b/docs/src/content/docs/plugins/typescript.mdx
@@ -113,11 +113,11 @@ Use [TypeScript Project References](https://www.typescriptlang.org/docs/handbook
 ## Commands
 
 {/* start-auto-generated-from-cli-typescript */}
-{/* @generated SignedSource<<f185e6e4ab5603d8161b896bbf94f58d>> */}
+{/* @generated SignedSource<<e368491e3176772b5651be9ead8976e5>> */}
 
 ### `one tsc`
 
-Aliases: `typescript`, `typecheck`
+Aliases: `one typescript`, `one typecheck`
 
 Sync TS project references
 
@@ -127,25 +127,25 @@ one tsc [options]
 
 Checks for the existence of `tsconfig.json` file and batches running `tsc --noEmit` in each Workspace.
 
-| Option               | Type                       | Description                                                                                                                                                                 | Required |
-| -------------------- | -------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
-| `--affected`         | `boolean`                  | Select all affected Workspaces. If no other inputs are chosen, this will default to `true`.                                                                                 |          |
-| `--all`, `-a`        | `boolean`                  | Run across all workspaces                                                                                                                                                   |          |
-| `--pretty`           | `boolean`, default: `true` | Control TypeScript’s `--pretty` flag.                                                                                                                                       |          |
-| `--show-advanced`    | `boolean`                  | Pair with `--help` to show advanced options.                                                                                                                                |          |
-| `--staged`           | `boolean`                  | Use files on the git stage to calculate affected files or Workspaces. When unset or `--no-staged`, changes will be calculated from the entire branch, since its fork point. |          |
-| `--workspaces`, `-w` | `array`                    | List of Workspace names to run against                                                                                                                                      |          |
+| Option             | Type                       | Description                                                                                                                                                                 |
+| ------------------ | -------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--affected`       | `boolean`                  | Select all affected Workspaces. If no other inputs are chosen, this will default to `true`.                                                                                 |
+| `--all, -a`        | `boolean`                  | Run across all workspaces                                                                                                                                                   |
+| `--pretty`         | `boolean`, default: `true` | Control TypeScript’s `--pretty` flag.                                                                                                                                       |
+| `--show-advanced`  | `boolean`                  | Pair with `--help` to show advanced options.                                                                                                                                |
+| `--staged`         | `boolean`                  | Use files on the git stage to calculate affected files or Workspaces. When unset or `--no-staged`, changes will be calculated from the entire branch, since its fork point. |
+| `--workspaces, -w` | `array`                    | List of Workspace names to run against                                                                                                                                      |
 
 <details>
 
 <summary>Advanced options</summary>
 
-| Option                                                               | Type                                 | Description                                               | Required |
-| -------------------------------------------------------------------- | ------------------------------------ | --------------------------------------------------------- | -------- |
-| `--from-ref`                                                         | `string`                             | Git ref to start looking for affected files or workspaces |          |
-| `--through-ref`                                                      | `string`                             | Git ref to start looking for affected files or workspaces |          |
-| `--tsconfig`                                                         | `string`, default: `"tsconfig.json"` | The filename of the tsconfig to find in each Workspace.   |          |
-| `--use-project-references`, `--project-references`, `--project-refs` | `boolean`, default: `true`           | Automatically sync and use typescript project references  |          |
+| Option                                                           | Type                                 | Description                                               |
+| ---------------------------------------------------------------- | ------------------------------------ | --------------------------------------------------------- |
+| `--from-ref`                                                     | `string`                             | Git ref to start looking for affected files or workspaces |
+| `--through-ref`                                                  | `string`                             | Git ref to start looking for affected files or workspaces |
+| `--tsconfig`                                                     | `string`, default: `"tsconfig.json"` | The filename of the tsconfig to find in each Workspace.   |
+| `--use-project-references, --project-references, --project-refs` | `boolean`, default: `true`           | Automatically sync and use typescript project references  |
 
 </details>
 

--- a/docs/src/content/docs/plugins/vitest.mdx
+++ b/docs/src/content/docs/plugins/vitest.mdx
@@ -102,11 +102,11 @@ The name of the vitest command. You might change this to `'test'` or `['test', '
 ## Commands
 
 {/* start-auto-generated-from-cli-vitest */}
-{/* @generated SignedSource<<ff39b8c397d720be0e52b08cdb4b7acd>> */}
+{/* @generated SignedSource<<595d46f456184a9d2b9e5ea531e788ab>> */}
 
 ### `one test`
 
-Aliases: `vitest`
+Aliases: `one vitest`
 
 Run unit tests using Vitest
 
@@ -119,25 +119,25 @@ This test commad will automatically attempt to run only the test files related t
 
 Additionally, any other [Vitest CLI options](https://jest.dev/guide/cli.html) can be used as passthrough arguments as well after an argument separator (two dashes `--`).
 
-| Option               | Type      | Description                                                                                                                                                                 | Required |
-| -------------------- | --------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
-| `--affected`         | `boolean` | Select all affected Workspaces. If no other inputs are chosen, this will default to `true`.                                                                                 |          |
-| `--all`, `-a`        | `boolean` | Run across all workspaces                                                                                                                                                   |          |
-| `--inspect`          | `boolean` | Break for the the Node inspector to debug tests.                                                                                                                            |          |
-| `--show-advanced`    | `boolean` | Pair with `--help` to show advanced options.                                                                                                                                |          |
-| `--staged`           | `boolean` | Use files on the git stage to calculate affected files or Workspaces. When unset or `--no-staged`, changes will be calculated from the entire branch, since its fork point. |          |
-| `--watch`            | `boolean` | Shortcut for vitest `--watch` mode.                                                                                                                                         |          |
-| `--workspaces`, `-w` | `array`   | List of Workspace names to run against                                                                                                                                      |          |
+| Option             | Type      | Description                                                                                                                                                                 |
+| ------------------ | --------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--affected`       | `boolean` | Select all affected Workspaces. If no other inputs are chosen, this will default to `true`.                                                                                 |
+| `--all, -a`        | `boolean` | Run across all workspaces                                                                                                                                                   |
+| `--inspect`        | `boolean` | Break for the the Node inspector to debug tests.                                                                                                                            |
+| `--show-advanced`  | `boolean` | Pair with `--help` to show advanced options.                                                                                                                                |
+| `--staged`         | `boolean` | Use files on the git stage to calculate affected files or Workspaces. When unset or `--no-staged`, changes will be calculated from the entire branch, since its fork point. |
+| `--watch`          | `boolean` | Shortcut for vitest `--watch` mode.                                                                                                                                         |
+| `--workspaces, -w` | `array`   | List of Workspace names to run against                                                                                                                                      |
 
 <details>
 
 <summary>Advanced options</summary>
 
-| Option          | Type                                      | Description                                                | Required |
-| --------------- | ----------------------------------------- | ---------------------------------------------------------- | -------- |
-| `--config`      | `string`, default: `"./vitest.config.ts"` | Path to the vitest.config file, relative to the repo root. |          |
-| `--from-ref`    | `string`                                  | Git ref to start looking for affected files or workspaces  |          |
-| `--through-ref` | `string`                                  | Git ref to start looking for affected files or workspaces  |          |
+| Option          | Type                                      | Description                                                |
+| --------------- | ----------------------------------------- | ---------------------------------------------------------- |
+| `--config`      | `string`, default: `"./vitest.config.ts"` | Path to the vitest.config file, relative to the repo root. |
+| `--from-ref`    | `string`                                  | Git ref to start looking for affected files or workspaces  |
+| `--through-ref` | `string`                                  | Git ref to start looking for affected files or workspaces  |
 
 </details>
 


### PR DESCRIPTION
**Problem:**

> **Aliases:** `$0`

Is confusing.

**Solution:**

List the full command string required for aliases instead of just the individual command name.

| Before | After        |
| ------ | ------------ |
| `$0`   | `one change` |

Also only renders the "Required" column in the options/positional table when there are 1 or more required options. Does not include the column if not.

**Related issues:**

Fixes #585


**Checklist:**

- [ ] Added or updated tests
- [ ] Added or updated documentation
- [ ] Ensured the pre-commit hooks ran successfully

