### PR TITLE
fix: prevent adding deps to all when only root requested

### DIFF
--- a/.changeset/beige-buckets-explain.md
+++ b/.changeset/beige-buckets-explain.md
@@ -1,0 +1,5 @@
+---
+'onerepo': minor
+---
+
+Disallows adding production-level dependencies to the root Workspace. Prompts to change to devDependencies or exit.

--- a/.changeset/purple-candles-exist.md
+++ b/.changeset/purple-candles-exist.md
@@ -1,0 +1,5 @@
+---
+'onerepo': patch
+---
+
+When adding a dependency to the repository root, do not also add the dependency to every workspace.


### PR DESCRIPTION
**Problem:**

```sh
one deps add -w root -d normalizr
```

results in the dependency being added to every workspace.

**Solution:**

- Stop using `getWorkspaces` when adding deps and manually look up the requested directly
- Bonus: prevent adding prod dependencies to the root workspace

**Related issues:**

**Checklist:**

- [x] Added or updated tests
- [ ] Added or updated documentation
- [x] Ensured the pre-commit hooks ran successfully
