### PR TITLE
feat(file): add readJson with jsonc support

### DIFF
--- a/.changeset/silent-flowers-clean.md
+++ b/.changeset/silent-flowers-clean.md
@@ -1,0 +1,6 @@
+---
+'@onerepo/file': minor
+'onerepo': minor
+---
+
+Adds `file.readJson` to read and parse JSON files with the optional ability to support JSONC by stripping out comments and trailing commas

--- a/docs/package.json
+++ b/docs/package.json
@@ -23,7 +23,7 @@
 		"rehype-autolink-headings": "^7.1.0",
 		"rehype-slug": "^6.0.0",
 		"typedoc": "^0.25.7",
-		"typedoc-plugin-markdown": "^4.0.0-next.40",
+		"typedoc-plugin-markdown": "4.0.0-next.40",
 		"typescript": "^5.3.3"
 	},
 	"dependencies": {

--- a/docs/src/content/docs/api/namespaces/file.md
+++ b/docs/src/content/docs/api/namespaces/file.md
@@ -14,7 +14,7 @@ All content is auto-generated using a oneRepo command:
 -->
 
 <!-- start-onerepo-sentinel -->
-<!-- @generated SignedSource<<6b39faa68f07a155b881e91a2c54d872>> -->
+<!-- @generated SignedSource<<38a2db581b4944d1f161693f0dfa71bd>> -->
 
 File manipulation functions.
 
@@ -50,6 +50,28 @@ step?: LogStep;
 
 Avoid creating a new step in output for each function.
 Pass a Logger Step to pipe all logs and output to that instead.
+
+**Source:** [modules/file/src/index.ts](https://github.com/paularmstrong/onerepo/blob/main/modules/file/src/index.ts)
+
+---
+
+### ReadJsonOptions
+
+```ts
+type ReadJsonOptions: {
+  jsonc: boolean;
+  } & Options;
+```
+
+**Type declaration:**
+
+##### jsonc?
+
+```ts
+jsonc?: boolean;
+```
+
+Parse the file as JSONC (JSON with comments).
 
 **Source:** [modules/file/src/index.ts](https://github.com/paularmstrong/onerepo/blob/main/modules/file/src/index.ts)
 
@@ -373,6 +395,43 @@ const contents = await file.read('/path/to/file/');
 | `options`? | [`Options`](#options) |
 
 **Returns:** `Promise`\<`string`\>  
+**Source:** [modules/file/src/index.ts](https://github.com/paularmstrong/onerepo/blob/main/modules/file/src/index.ts)
+
+---
+
+### readJson()
+
+```ts
+readJson<T>(
+   filename,
+   flag?,
+options?): Promise<T>
+```
+
+Read and parse a JSON files.
+
+Compatible with jsonc by stripping comments before running `JSON.parse()`. Pass `jsonc: true` to the options to enable jsonc.
+
+```ts
+const contents = await file.readJson('/path/to/package.json');
+const strippedJsonc = await file.readJson('/path/to/tsconfig.json', 'r', { jsonc: true });
+```
+
+**Type parameters:**
+
+| Type parameter                              |
+| :------------------------------------------ |
+| `T` extends `Record`\<`string`, `unknown`\> |
+
+**Parameters:**
+
+| Parameter  | Type                                  |
+| :--------- | :------------------------------------ |
+| `filename` | `string`                              |
+| `flag`?    | `OpenMode`                            |
+| `options`? | [`ReadJsonOptions`](#readjsonoptions) |
+
+**Returns:** `Promise`\<`T`\>  
 **Source:** [modules/file/src/index.ts](https://github.com/paularmstrong/onerepo/blob/main/modules/file/src/index.ts)
 
 ---

--- a/modules/file/src/utils/strip-json-comments.ts
+++ b/modules/file/src/utils/strip-json-comments.ts
@@ -1,0 +1,114 @@
+/**
+ * This code is adapted from strip-json-commands: https://github.com/sindresorhus/strip-json-comments/tree/main
+ *
+ * Licensed under the MIT license
+ * Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (https://sindresorhus.com)
+ */
+
+const singleComment = Symbol('singleComment');
+const multiComment = Symbol('multiComment');
+
+const isEscaped = (jsonString: string, quotePosition: number) => {
+	let index = quotePosition - 1;
+	let backslashCount = 0;
+
+	while (jsonString[index] === '\\') {
+		index -= 1;
+		backslashCount += 1;
+	}
+
+	return Boolean(backslashCount % 2);
+};
+
+export default function stripJsonComments(jsonString: string) {
+	if (typeof jsonString !== 'string') {
+		throw new TypeError(`Expected argument \`jsonString\` to be a \`string\`, got \`${typeof jsonString}\``);
+	}
+
+	let isInsideString: symbol | boolean = false;
+	let isInsideComment: symbol | boolean = false;
+	let offset = 0;
+	let buffer = '';
+	let result = '';
+	let commaIndex = -1;
+
+	for (let index = 0; index < jsonString.length; index++) {
+		const currentCharacter = jsonString[index];
+		const nextCharacter = jsonString[index + 1];
+
+		if (!isInsideComment && currentCharacter === '"') {
+			// Enter or exit string
+			const escaped = isEscaped(jsonString, index);
+			if (!escaped) {
+				isInsideString = !isInsideString;
+			}
+		}
+
+		if (isInsideString) {
+			continue;
+		}
+
+		if (!isInsideComment && currentCharacter + nextCharacter === '//') {
+			// Enter single-line comment
+			buffer += jsonString.slice(offset, index);
+			offset = index;
+			isInsideComment = singleComment;
+			index++;
+		} else if (isInsideComment === singleComment && currentCharacter + nextCharacter === '\r\n') {
+			// Exit single-line comment via \r\n
+			index++;
+			isInsideComment = false;
+			buffer += jsonString;
+			offset = index;
+			continue;
+		} else if (isInsideComment === singleComment && currentCharacter === '\n') {
+			// Exit single-line comment via \n
+			isInsideComment = false;
+			buffer += jsonString;
+			offset = index;
+		} else if (!isInsideComment && currentCharacter + nextCharacter === '/*') {
+			// Enter multiline comment
+			buffer += jsonString.slice(offset, index);
+			offset = index;
+			isInsideComment = multiComment;
+			index++;
+			continue;
+		} else if (isInsideComment === multiComment && currentCharacter + nextCharacter === '*/') {
+			// Exit multiline comment
+			index++;
+			isInsideComment = false;
+			buffer += jsonString;
+			offset = index + 1;
+			continue;
+		} else if (!isInsideComment) {
+			if (commaIndex !== -1) {
+				if (currentCharacter === '}' || currentCharacter === ']') {
+					// Strip trailing comma
+					buffer += jsonString.slice(offset, index);
+					result += buffer.slice(0, 1) + buffer.slice(1);
+					buffer = '';
+					offset = index;
+					commaIndex = -1;
+				} else if (
+					currentCharacter !== ' ' &&
+					currentCharacter !== '\t' &&
+					currentCharacter !== '\r' &&
+					currentCharacter !== '\n'
+				) {
+					// Hit non-whitespace following a comma; comma is not trailing
+					buffer += jsonString.slice(offset, index);
+					offset = index;
+					commaIndex = -1;
+				}
+			} else if (currentCharacter === ',') {
+				// Flush buffer prior to this point, and save new comma index
+				result += buffer + jsonString.slice(offset, index);
+				buffer = '';
+				offset = index;
+				commaIndex = index;
+			}
+		}
+	}
+
+	return result + buffer + (isInsideComment ? jsonString.slice(offset) : jsonString.slice(offset));
+}

--- a/modules/onerepo/package.json
+++ b/modules/onerepo/package.json
@@ -40,7 +40,6 @@
 		"@onerepo/yargs": "0.6.0",
 		"ajv": "^8.12.0",
 		"ajv-errors": "^3.0.0",
-		"cjson": "^0.5.0",
 		"cliui": "^8.0.1",
 		"defaults": "^3.0.0",
 		"ejs": "^3.1.8",

--- a/modules/onerepo/src/core/create/create.ts
+++ b/modules/onerepo/src/core/create/create.ts
@@ -4,7 +4,7 @@ import { homedir } from 'node:os';
 import inquirer from 'inquirer';
 import pc from 'picocolors';
 import yaml from 'js-yaml';
-import { exists, mkdirp, read, write, writeSafe } from '@onerepo/file';
+import { exists, mkdirp, read, readJson, write, writeSafe } from '@onerepo/file';
 import { run } from '@onerepo/subprocess';
 import { getPackageManager, getPackageManagerName } from '@onerepo/package-manager';
 import type { Builder, Handler } from '@onerepo/yargs';
@@ -77,8 +77,7 @@ export const handler: Handler<Argv> = async (argv, { logger }) => {
 	let pkgManager: 'npm' | 'pnpm' | 'yarn' = 'npm';
 	let packageJson: PackageJson | null = null;
 	if (isExistingRepo) {
-		const raw = await read(path.join(outdir, 'package.json'), 'r', { step: existStep });
-		packageJson = JSON.parse(raw) as PackageJson;
+		packageJson = await readJson<PackageJson>(path.join(outdir, 'package.json'), 'r', { step: existStep });
 		pkgManager = getPackageManagerName(outdir, 'packageManager' in packageJson ? `${packageJson.packageManager}` : '');
 	}
 	let workspaces: Array<string> = packageJson?.workspaces ?? inputWorkspaces ?? [];

--- a/modules/onerepo/src/core/graph/verify.ts
+++ b/modules/onerepo/src/core/graph/verify.ts
@@ -1,9 +1,8 @@
 import initJiti from 'jiti';
-import cjson from 'cjson';
 import { glob } from 'glob';
 import { minimatch } from 'minimatch';
 import yaml from 'js-yaml';
-import { read } from '@onerepo/file';
+import { read, readJson } from '@onerepo/file';
 // NB: important to keep extension because AJV does not properly declare this export
 import Ajv from 'ajv/dist/2019.js';
 import type { AnySchema } from 'ajv';
@@ -104,8 +103,7 @@ export const handler: Handler<Argv> = async function handler(argv, { graph, logg
 				schemaStep.debug(`Using schema for "${schemaKey}"`);
 				let contents: Record<string, unknown> = {};
 				if (file.endsWith('json')) {
-					const rawContents: string = await read(workspace.resolve(file), 'r', { step: schemaStep });
-					contents = cjson.parse(rawContents);
+					contents = await readJson(workspace.resolve(file), 'r', { jsonc: true, step: schemaStep });
 				} else if (minimatch(file, '**/*.{js,ts,cjs,mjs}')) {
 					contents = require(workspace.resolve(file));
 				} else if (minimatch(file, '**/*.{yml,yaml}')) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3103,7 +3103,7 @@ __metadata:
     rehype-slug: ^6.0.0
     starlight-links-validator: ^0.5.2
     typedoc: ^0.25.7
-    typedoc-plugin-markdown: ^4.0.0-next.40
+    typedoc-plugin-markdown: 4.0.0-next.40
     typescript: ^5.3.3
     unist-util-visit: ^5.0.0
   languageName: unknown
@@ -6792,15 +6792,6 @@ __metadata:
   version: 1.2.2
   resolution: "cjs-module-lexer@npm:1.2.2"
   checksum: 977f3f042bd4f08e368c890d91eecfbc4f91da0bc009a3c557bc4dfbf32022ad1141244ac1178d44de70fc9f3dea7add7cd9a658a34b9fae98a55d8f92331ce5
-  languageName: node
-  linkType: hard
-
-"cjson@npm:^0.5.0":
-  version: 0.5.0
-  resolution: "cjson@npm:0.5.0"
-  dependencies:
-    json-parse-helpfulerror: ^1.0.3
-  checksum: 63a839949c63eba999804e0c6611a7a96c74084845777a4cabd5c34cd284ee696b9934fbe4f65f77ac73912ca1f49b4ed79468f0bee1108c337647798748e9ef
   languageName: node
   linkType: hard
 
@@ -13096,13 +13087,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jju@npm:^1.1.0":
-  version: 1.4.0
-  resolution: "jju@npm:1.4.0"
-  checksum: 3790481bd2b7827dd6336e6e3dc2dcc6d425679ba7ebde7b679f61dceb4457ea0cda330972494de608571f4973c6dfb5f70fab6f3c5037dbab19ac449a60424f
-  languageName: node
-  linkType: hard
-
 "js-base64@npm:^3.7.5":
   version: 3.7.5
   resolution: "js-base64@npm:3.7.5"
@@ -13214,15 +13198,6 @@ __metadata:
   version: 2.3.1
   resolution: "json-parse-even-better-errors@npm:2.3.1"
   checksum: 798ed4cf3354a2d9ccd78e86d2169515a0097a5c133337807cdf7f1fc32e1391d207ccfc276518cc1d7d8d4db93288b8a50ba4293d212ad1336e52a8ec0a941f
-  languageName: node
-  linkType: hard
-
-"json-parse-helpfulerror@npm:^1.0.3":
-  version: 1.0.3
-  resolution: "json-parse-helpfulerror@npm:1.0.3"
-  dependencies:
-    jju: ^1.1.0
-  checksum: 376d85c3728ab4446e30fa943ad2cf5fe63d8a780be16bade9f846f2e4c1431ef61ae01746011d815fb3627abb3d21b0cc74fe9ed6cc74b93819e720afb05cae
   languageName: node
   linkType: hard
 
@@ -16256,7 +16231,6 @@ __metadata:
     "@types/yargs-unparser": ^2.0.3
     ajv: ^8.12.0
     ajv-errors: ^3.0.0
-    cjson: ^0.5.0
     cliui: ^8.0.1
     defaults: ^3.0.0
     ejs: ^3.1.8
@@ -20264,12 +20238,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typedoc-plugin-markdown@npm:^4.0.0-next.40":
-  version: 4.0.0-next.48
-  resolution: "typedoc-plugin-markdown@npm:4.0.0-next.48"
+"typedoc-plugin-markdown@npm:4.0.0-next.40":
+  version: 4.0.0-next.40
+  resolution: "typedoc-plugin-markdown@npm:4.0.0-next.40"
   peerDependencies:
     typedoc: 0.25.x
-  checksum: 7f9ca09fad99a11da456556c28624c06822e05fc92002ed959e592391c81049dfb7199be687f4a198adde06e7e57047b566cd7225865b00fa7ccfe236fd5ea57
+  checksum: ef6e2a6b26dc4d804ce868027d081cd3f923ee316efa2c8ad8e9663964052a9c2a6e163795c91da91b2b2a16267214f3abd8e5abb9d94362ce1bac2df4cbb450
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
**Problem:**

[Prettier 3.2.0](https://prettier.io/blog/2024/01/12/3.2.0) added support for JSONC. This becomes problematic because it will start writing certain files (eg tsconfig.json) with trailing commas. This will break certain places that we're reading and parsing JSON files, like `one graph verify`.

**Solution:**

Pull in [strip-json-comments](https://github.com/sindresorhus/strip-json-comments/tree/main) with some modifications, because we _always_ want to strip trailing commas for the purpose of running `JSON.parse()`.

Add `file.readJSON()` with optional ability to specify `jsonc` and run the `stripJsonComments` function.

**Related issues:**

#595 

**Checklist:**

- [x] Added or updated tests
- [x] Added or updated documentation
- [x] Ensured the pre-commit hooks ran successfully
