### PR TITLE
feat(logger): Execute zero-argument functions when logging

### DIFF
--- a/.changeset/wise-actors-sort.md
+++ b/.changeset/wise-actors-sort.md
@@ -1,0 +1,10 @@
+---
+'@onerepo/logger': minor
+'onerepo': minor
+---
+
+Logging an empty function will now execute and stringify the return value of the function. This will prevent expensive loops used to build up helpful information strings.
+
+```ts
+step.log(() => bigArray.map((item) => item.name));
+```

--- a/docs/src/content/docs/api/index.md
+++ b/docs/src/content/docs/api/index.md
@@ -8,7 +8,7 @@ oneRepo is in currently in public beta. Some APIs may not be specifically necess
 :::
 
 <!-- start-onerepo-sentinel -->
-<!-- @generated SignedSource<<edaa1c35e634eaa62235c1d001defd76>> -->
+<!-- @generated SignedSource<<21e09a71336245d7478cb8fcf29e8228>> -->
 
 ## Namespaces
 
@@ -1875,6 +1875,16 @@ debug(contents): void
 
 Extra debug logging when verbosity greater than or equal to 4.
 
+```ts
+step.debug('Log this content when verbosity is >= 4');
+```
+
+If a function with zero arguments is passed, the function will be executed before writing. This is helpful for avoiding extra work in the event that the verbosity is not actually high enough to render the logged debug information:
+
+```ts
+step.debug(() => bigArray.map((item) => item.name));
+```
+
 **Parameters:**
 
 | Parameter  | Type      | Description                                                          |
@@ -1891,6 +1901,16 @@ error(contents): void
 ```
 
 Log an error. This will cause the root logger to include an error and fail a command.
+
+```ts
+step.error('Log this content when verbosity is >= 1');
+```
+
+If a function with zero arguments is passed, the function will be executed before writing. This is helpful for avoiding extra work in the event that the verbosity is not actually high enough to render the logged error:
+
+```ts
+step.error(() => bigArray.map((item) => item.name));
+```
 
 **Parameters:**
 
@@ -1909,6 +1929,16 @@ info(contents): void
 
 Log an informative message. Should be used when trying to convey information with a user that is important enough to always be returned.
 
+```ts
+step.info('Log this content when verbosity is >= 1');
+```
+
+If a function with zero arguments is passed, the function will be executed before writing. This is helpful for avoiding extra work in the event that the verbosity is not actually high enough to render the logged information:
+
+```ts
+step.info(() => bigArray.map((item) => item.name));
+```
+
 **Parameters:**
 
 | Parameter  | Type      | Description                                                          |
@@ -1925,6 +1955,16 @@ log(contents): void
 ```
 
 General logging information. Useful for light informative debugging. Recommended to use sparingly.
+
+```ts
+step.log('Log this content when verbosity is >= 3');
+```
+
+If a function with zero arguments is passed, the function will be executed before writing. This is helpful for avoiding extra work in the event that the verbosity is not actually high enough to render the logged information:
+
+```ts
+step.log(() => bigArray.map((item) => item.name));
+```
 
 **Parameters:**
 
@@ -1960,6 +2000,16 @@ warn(contents): void
 ```
 
 Log a warning. Does not have any effect on the command run, but will be called out.
+
+```ts
+step.warn('Log this content when verbosity is >= 2');
+```
+
+If a function with zero arguments is passed, the function will be executed before writing. This is helpful for avoiding extra work in the event that the verbosity is not actually high enough to render the logged warning:
+
+```ts
+step.warn(() => bigArray.map((item) => item.name));
+```
 
 **Parameters:**
 
@@ -2133,6 +2183,16 @@ debug(contents): void
 
 Extra debug logging when verbosity greater than or equal to 4.
 
+```ts
+logger.debug('Log this content when verbosity is >= 4');
+```
+
+If a function with zero arguments is passed, the function will be executed before writing. This is helpful for avoiding extra work in the event that the verbosity is not actually high enough to render the logged debug information:
+
+```ts
+logger.debug(() => bigArray.map((item) => item.name));
+```
+
 **Parameters:**
 
 | Parameter  | Type      | Description                                                          |
@@ -2152,6 +2212,16 @@ error(contents): void
 ```
 
 Log an error. This will cause the root logger to include an error and fail a command.
+
+```ts
+logger.error('Log this content when verbosity is >= 1');
+```
+
+If a function with zero arguments is passed, the function will be executed before writing. This is helpful for avoiding extra work in the event that the verbosity is not actually high enough to render the logged error:
+
+```ts
+logger.error(() => bigArray.map((item) => item.name));
+```
 
 **Parameters:**
 
@@ -2173,6 +2243,16 @@ info(contents): void
 
 Should be used to convey information or instructions through the log, will log when verbositu >= 1
 
+```ts
+logger.info('Log this content when verbosity is >= 1');
+```
+
+If a function with zero arguments is passed, the function will be executed before writing. This is helpful for avoiding extra work in the event that the verbosity is not actually high enough to render the logged information:
+
+```ts
+logger.info(() => bigArray.map((item) => item.name));
+```
+
 **Parameters:**
 
 | Parameter  | Type      | Description                                                          |
@@ -2192,6 +2272,16 @@ log(contents): void
 ```
 
 General logging information. Useful for light informative debugging. Recommended to use sparingly.
+
+```ts
+logger.log('Log this content when verbosity is >= 3');
+```
+
+If a function with zero arguments is passed, the function will be executed before writing. This is helpful for avoiding extra work in the event that the verbosity is not actually high enough to render the logged information:
+
+```ts
+logger.log(() => bigArray.map((item) => item.name));
+```
 
 **Parameters:**
 
@@ -2233,6 +2323,16 @@ warn(contents): void
 ```
 
 Log a warning. Does not have any effect on the command run, but will be called out.
+
+```ts
+logger.warn('Log this content when verbosity is >= 2');
+```
+
+If a function with zero arguments is passed, the function will be executed before writing. This is helpful for avoiding extra work in the event that the verbosity is not actually high enough to render the logged warning:
+
+```ts
+logger.warn(() => bigArray.map((item) => item.name));
+```
 
 **Parameters:**
 

--- a/modules/builders/src/getters.ts
+++ b/modules/builders/src/getters.ts
@@ -70,7 +70,7 @@ export function getAffected(graph: Graph, { from, ignore, staged, step, through 
 		const all = await getModifiedFiles(modifiedOpts, { step });
 		const files =
 			ignore && ignore.length ? all.filter((file) => !ignore.some((ignore) => minimatch(file, ignore))) : all;
-		step.debug(`Modified files not ignored:\n${JSON.stringify(ignore)}\n • ${files.join('\n • ')}`);
+		step.debug(() => `Modified files not ignored:\n${JSON.stringify(ignore)}\n • ${files.join('\n • ')}`);
 		const workspaces = new Set<string>();
 		for (const filepath of files) {
 			const ws = graph.getByLocation(graph.root.resolve(filepath));
@@ -123,10 +123,10 @@ export async function getWorkspaces(
 			step.log('`all` requested');
 			workspaces = graph.workspaces;
 		} else if ('files' in argv && Array.isArray(argv.files)) {
-			step.log(`\`files\` requested: \n • ${argv.files.join('\n • ')}`);
+			step.log(() => `\`files\` requested: \n • ${argv.files!.join('\n • ')}`);
 			workspaces = graph.getAllByLocation(argv.files);
 		} else if ('workspaces' in argv && Array.isArray(argv.workspaces)) {
-			step.log(`\`workspaces\` requested: \n • ${argv.workspaces.join('\n • ')}`);
+			step.log(() => `\`workspaces\` requested: \n • ${argv.workspaces!.join('\n • ')}`);
 			workspaces = graph.getAllByName(argv.workspaces);
 		}
 
@@ -142,7 +142,7 @@ export async function getWorkspaces(
 				workspaces = await getAffected(graph, affectedOptions);
 			} else {
 				const names = workspaces.map((ws) => ws.name);
-				step.log(`\`affected\` requested from • ${names.join('\n • ')}`);
+				step.log(() => `\`affected\` requested from • ${names.join('\n • ')}`);
 				workspaces = await graph.affected(names);
 			}
 		}
@@ -203,10 +203,10 @@ export async function getFilepaths(
 			step.log('`all` requested');
 			return ['.'];
 		} else if ('files' in argv && Array.isArray(argv.files)) {
-			step.log(`\`files\` requested: \n • ${argv.files.join('\n • ')}`);
+			step.log(() => `\`files\` requested: \n • ${argv.files!.join('\n • ')}`);
 			paths.push(...argv.files);
 		} else if ('workspaces' in argv && Array.isArray(argv.workspaces)) {
-			step.log(`\`workspaces\` requested: \n • ${argv.workspaces.join('\n • ')}`);
+			step.log(() => `\`workspaces\` requested: \n • ${argv.workspaces!.join('\n • ')}`);
 			workspaces.push(...(graph.getAllByName(argv.workspaces) ?? Object.values(graph.workspaces)));
 			paths.push(...workspaces.map((workspace) => path.relative(graph.root.location, workspace.location)));
 		}

--- a/modules/logger/src/LogStep.ts
+++ b/modules/logger/src/LogStep.ts
@@ -240,6 +240,16 @@ export class LogStep {
 	/**
 	 * Log an informative message. Should be used when trying to convey information with a user that is important enough to always be returned.
 	 *
+	 * ```ts
+	 * step.info('Log this content when verbosity is >= 1');
+	 * ```
+	 *
+	 * If a function with zero arguments is passed, the function will be executed before writing. This is helpful for avoiding extra work in the event that the verbosity is not actually high enough to render the logged information:
+	 *
+	 * ```ts
+	 * step.info(() => bigArray.map((item) => item.name));
+	 * ```
+	 *
 	 * @group Logging
 	 * @param contents Any value that can be converted to a string for writing to `stderr`.
 	 */
@@ -253,6 +263,16 @@ export class LogStep {
 
 	/**
 	 * Log an error. This will cause the root logger to include an error and fail a command.
+	 *
+	 * ```ts
+	 * step.error('Log this content when verbosity is >= 1');
+	 * ```
+	 *
+	 * If a function with zero arguments is passed, the function will be executed before writing. This is helpful for avoiding extra work in the event that the verbosity is not actually high enough to render the logged error:
+	 *
+	 * ```ts
+	 * step.error(() => bigArray.map((item) => item.name));
+	 * ```
 	 *
 	 * @group Logging
 	 * @param contents Any value that can be converted to a string for writing to `stderr`.
@@ -268,6 +288,16 @@ export class LogStep {
 	/**
 	 * Log a warning. Does not have any effect on the command run, but will be called out.
 	 *
+	 * ```ts
+	 * step.warn('Log this content when verbosity is >= 2');
+	 * ```
+	 *
+	 * If a function with zero arguments is passed, the function will be executed before writing. This is helpful for avoiding extra work in the event that the verbosity is not actually high enough to render the logged warning:
+	 *
+	 * ```ts
+	 * step.warn(() => bigArray.map((item) => item.name));
+	 * ```
+	 *
 	 * @group Logging
 	 * @param contents Any value that can be converted to a string for writing to `stderr`.
 	 */
@@ -282,6 +312,16 @@ export class LogStep {
 	/**
 	 * General logging information. Useful for light informative debugging. Recommended to use sparingly.
 	 *
+	 * ```ts
+	 * step.log('Log this content when verbosity is >= 3');
+	 * ```
+	 *
+	 * If a function with zero arguments is passed, the function will be executed before writing. This is helpful for avoiding extra work in the event that the verbosity is not actually high enough to render the logged information:
+	 *
+	 * ```ts
+	 * step.log(() => bigArray.map((item) => item.name));
+	 * ```
+	 *
 	 * @group Logging
 	 * @param contents Any value that can be converted to a string for writing to `stderr`.
 	 */
@@ -295,6 +335,16 @@ export class LogStep {
 
 	/**
 	 * Extra debug logging when verbosity greater than or equal to 4.
+	 *
+	 * ```ts
+	 * step.debug('Log this content when verbosity is >= 4');
+	 * ```
+	 *
+	 * If a function with zero arguments is passed, the function will be executed before writing. This is helpful for avoiding extra work in the event that the verbosity is not actually high enough to render the logged debug information:
+	 *
+	 * ```ts
+	 * step.debug(() => bigArray.map((item) => item.name));
+	 * ```
 	 *
 	 * @group Logging
 	 * @param contents Any value that can be converted to a string for writing to `stderr`.
@@ -368,6 +418,10 @@ function stringify(item: unknown): string {
 
 	if (item instanceof Date) {
 		return item.toISOString();
+	}
+
+	if (typeof item === 'function' && item.length === 0) {
+		return stringify(item());
 	}
 
 	return `${String(item)}`;

--- a/modules/logger/src/Logger.ts
+++ b/modules/logger/src/Logger.ts
@@ -225,18 +225,18 @@ export class Logger {
 	}
 
 	/**
-	 * General logging information. Useful for light informative debugging. Recommended to use sparingly.
-	 *
-	 * @group Logging
-	 * @param contents Any value that can be converted to a string for writing to `stderr`.
-	 * @see {@link LogStep#log | `log()`} This is a pass-through for the main step’s {@link LogStep#log | `log()`} method.
-	 */
-	log(contents: unknown) {
-		this.#defaultLogger.log(contents);
-	}
-
-	/**
 	 * Should be used to convey information or instructions through the log, will log when verbositu >= 1
+	 *
+	 * ```ts
+	 * logger.info('Log this content when verbosity is >= 1');
+	 * ```
+	 *
+	 * If a function with zero arguments is passed, the function will be executed before writing. This is helpful for avoiding extra work in the event that the verbosity is not actually high enough to render the logged information:
+	 *
+	 * ```ts
+	 * logger.info(() => bigArray.map((item) => item.name));
+	 * ```
+	 *
 	 *
 	 * @group Logging
 	 * @param contents Any value that can be converted to a string for writing to `stderr`.
@@ -249,6 +249,16 @@ export class Logger {
 	/**
 	 * Log an error. This will cause the root logger to include an error and fail a command.
 	 *
+	 * ```ts
+	 * logger.error('Log this content when verbosity is >= 1');
+	 * ```
+	 *
+	 * If a function with zero arguments is passed, the function will be executed before writing. This is helpful for avoiding extra work in the event that the verbosity is not actually high enough to render the logged error:
+	 *
+	 * ```ts
+	 * logger.error(() => bigArray.map((item) => item.name));
+	 * ```
+	 *
 	 * @group Logging
 	 * @param contents Any value that can be converted to a string for writing to `stderr`.
 	 * @see {@link LogStep#error | `error()`} This is a pass-through for the main step’s {@link LogStep#error | `error()`} method.
@@ -260,6 +270,16 @@ export class Logger {
 	/**
 	 * Log a warning. Does not have any effect on the command run, but will be called out.
 	 *
+	 * ```ts
+	 * logger.warn('Log this content when verbosity is >= 2');
+	 * ```
+	 *
+	 * If a function with zero arguments is passed, the function will be executed before writing. This is helpful for avoiding extra work in the event that the verbosity is not actually high enough to render the logged warning:
+	 *
+	 * ```ts
+	 * logger.warn(() => bigArray.map((item) => item.name));
+	 * ```
+	 *
 	 * @group Logging
 	 * @param contents Any value that can be converted to a string for writing to `stderr`.
 	 * @see {@link LogStep#warn | `warn()`} This is a pass-through for the main step’s {@link LogStep#warn | `warn()`} method.
@@ -269,7 +289,38 @@ export class Logger {
 	}
 
 	/**
+	 * General logging information. Useful for light informative debugging. Recommended to use sparingly.
+	 *
+	 * ```ts
+	 * logger.log('Log this content when verbosity is >= 3');
+	 * ```
+	 *
+	 * If a function with zero arguments is passed, the function will be executed before writing. This is helpful for avoiding extra work in the event that the verbosity is not actually high enough to render the logged information:
+	 *
+	 * ```ts
+	 * logger.log(() => bigArray.map((item) => item.name));
+	 * ```
+	 *
+	 * @group Logging
+	 * @param contents Any value that can be converted to a string for writing to `stderr`.
+	 * @see {@link LogStep#log | `log()`} This is a pass-through for the main step’s {@link LogStep#log | `log()`} method.
+	 */
+	log(contents: unknown) {
+		this.#defaultLogger.log(contents);
+	}
+
+	/**
 	 * Extra debug logging when verbosity greater than or equal to 4.
+	 *
+	 * ```ts
+	 * logger.debug('Log this content when verbosity is >= 4');
+	 * ```
+	 *
+	 * If a function with zero arguments is passed, the function will be executed before writing. This is helpful for avoiding extra work in the event that the verbosity is not actually high enough to render the logged debug information:
+	 *
+	 * ```ts
+	 * logger.debug(() => bigArray.map((item) => item.name));
+	 * ```
 	 *
 	 * @group Logging
 	 * @param contents Any value that can be converted to a string for writing to `stderr`.

--- a/modules/logger/src/__tests__/LogStep.test.ts
+++ b/modules/logger/src/__tests__/LogStep.test.ts
@@ -146,7 +146,20 @@ describe('LogStep', () => {
 	});
 
 	test.concurrent.each([
-		['function', function foo() {}, ` │ ${pc.cyan(pc.bold('LOG'))} function foo() {`],
+		[
+			'function',
+			function foo(asdf: unknown) {
+				return asdf;
+			},
+			` │ ${pc.cyan(pc.bold('LOG'))} function foo(asdf) {`,
+		],
+		[
+			'function with zero arguments are executed',
+			function foo() {
+				return 'tacos';
+			},
+			` │ ${pc.cyan(pc.bold('LOG'))} tacos`,
+		],
 		[
 			'object',
 			{ foo: 'bar' },

--- a/modules/logger/src/index.ts
+++ b/modules/logger/src/index.ts
@@ -100,15 +100,15 @@ export function bufferSubLogger(step: LogStep): { logger: Logger; end: () => Pro
 			return;
 		}
 		if (subLogger.hasError && logger.verbosity >= 1) {
-			step.error(chunk.toString().trimEnd());
+			step.error(() => chunk.toString().trimEnd());
 		} else if (subLogger.hasInfo && logger.verbosity >= 1) {
-			step.info(chunk.toString().trimEnd());
+			step.info(() => chunk.toString().trimEnd());
 		} else if (subLogger.hasWarning && logger.verbosity >= 2) {
-			step.warn(chunk.toString().trimEnd());
+			step.warn(() => chunk.toString().trimEnd());
 		} else if (subLogger.hasLog && logger.verbosity >= 3) {
-			step.log(chunk.toString().trimEnd());
+			step.log(() => chunk.toString().trimEnd());
 		} else if (logger.verbosity >= 4) {
-			step.debug(chunk.toString().trimEnd());
+			step.debug(() => chunk.toString().trimEnd());
 		}
 	});
 

--- a/modules/onerepo/src/core/graph/show.ts
+++ b/modules/onerepo/src/core/graph/show.ts
@@ -63,7 +63,7 @@ export const handler: Handler<Args> = async function handler(argv, { graph, getW
 		serialized = graph.serialized;
 	} else {
 		const workspaces = await getWorkspaces();
-		logger.log(`Getting Graph from Workspaces:\n • ${workspaces.map(({ name }) => name).join('\n • ')}`);
+		logger.log(() => `Getting Graph from Workspaces:\n • ${workspaces.map(({ name }) => name).join('\n • ')}`);
 		const isolated = graph.isolatedGraph(workspaces);
 		serialized = isolated.serialize();
 	}

--- a/modules/onerepo/src/core/workspace/passthrough.ts
+++ b/modules/onerepo/src/core/workspace/passthrough.ts
@@ -6,7 +6,7 @@ import unparser from 'yargs-unparser';
 export const builder: Builder = (yargs) => yargs;
 
 export function getHandler(cmd: string, workspace: Workspace): Handler {
-	return async function (argv, { graph, logger }) {
+	return async function (argv, { graph }) {
 		const { '--': passthrough = [] } = argv;
 
 		const defaults = parser(cmd);
@@ -15,8 +15,6 @@ export function getHandler(cmd: string, workspace: Workspace): Handler {
 			...args
 		} = defaults;
 		const restArgs = unparser({ _: [], ...args }).map(String);
-
-		logger.info([...rest.map(String), ...restArgs, ...passthrough]);
 
 		await graph.packageManager.run({
 			name: `Run ${cmd}`,

--- a/modules/subprocess/src/index.ts
+++ b/modules/subprocess/src/index.ts
@@ -126,7 +126,8 @@ export async function run(options: RunSpec): Promise<[string, string]> {
 
 		if (!runDry && process.env.ONEREPO_DRY_RUN === 'true') {
 			step.info(
-				`DRY-RUN command:
+				() =>
+					`DRY-RUN command:
 		${JSON.stringify(withoutLogger, null, 2)}\n`,
 			);
 
@@ -262,7 +263,8 @@ export async function sudo(options: Omit<RunSpec, 'opts'> & { reason?: string })
 
 	if (!runDry && process.env.ONEREPO_DRY_RUN === 'true') {
 		step.info(
-			`DRY-RUN command:
+			() =>
+				`DRY-RUN command:
     sudo ${commandString}\n`,
 		);
 		await step.end();

--- a/plugins/changesets/src/commands/prerelease.ts
+++ b/plugins/changesets/src/commands/prerelease.ts
@@ -122,7 +122,7 @@ Commit or stash your changes to continue.`);
 			},
 		]);
 
-		logger.info(choices);
+		logger.info(() => choices);
 
 		if (!choices.includes('_ALL_')) {
 			workspaces = graph.dependencies(choices, true).filter((ws) => !ws.private);
@@ -161,7 +161,7 @@ Commit or stash your changes to continue.`);
 	});
 	const newVersion = `0.0.0-pre-${sha}`;
 
-	versionStep.info(`The following version will be used for all published workspaces: ${newVersion}`);
+	versionStep.info(() => `The following version will be used for all published workspaces: ${newVersion}`);
 	await versionStep.end();
 
 	const releases: ReleasePlan['releases'] = workspaces.map((ws) => ({

--- a/plugins/changesets/src/commands/publish.ts
+++ b/plugins/changesets/src/commands/publish.ts
@@ -81,7 +81,7 @@ export const handler: Handler<Args> = async (argv, { graph, logger }) => {
 		return;
 	}
 
-	infoStep.info(`Publishing:\n${publishable.map((ws) => `  - ${ws.name}`).join('\n')}`);
+	infoStep.info(() => `Publishing:\n${publishable.map((ws) => `  - ${ws.name}`).join('\n')}`);
 	await infoStep.end();
 
 	if (!skipAuth) {

--- a/plugins/changesets/src/commands/version.ts
+++ b/plugins/changesets/src/commands/version.ts
@@ -123,11 +123,11 @@ export const handler: Handler<Argv> = async (argv, { graph, logger }) => {
 	const { filteredChangesets, affectedChoices } = filterChangesets(changesets, choiceDependencies, filterStep);
 
 	if (!filteredChangesets.length) {
-		logger.error(`There are no changesets available for ${choices.join(', ')}`);
+		logger.error(() => `There are no changesets available for ${choices.join(', ')}`);
 		return;
 	}
 
-	filterStep.debug(`Found changesets:\n${JSON.stringify(filteredChangesets)}`);
+	filterStep.debug(() => `Found changesets:\n${JSON.stringify(filteredChangesets)}`);
 
 	if (affectedChoices.length !== choiceDependencies.length) {
 		logger.pause();


### PR DESCRIPTION
**Problem:**

Logging can be expensive. Often times we need to map & join large objects for logging, but don't necessarily have the verbosity high enough to even see the output. In that scenario, we have wasted CPU cycles looping over the object and building a string.

Over-simplified, something like this, using the default verbosity, will build up the string, but never write anywhere.

```ts
logger.debug(workspaces.map((ws) => `${ws.name}`).join('\n');
```

**Solution:**

If log methods receive a function, execute it if and only if the verbosity is high enough to expect the output:

```ts
logger.debug(() => workspaces.map((ws) => `${ws.name}`).join('\n'));
```

Fixes #588
