### PR TITLE
feat(plugin-jest): default --passWithNoTests

### DIFF
--- a/.changeset/green-planets-nail.md
+++ b/.changeset/green-planets-nail.md
@@ -1,0 +1,5 @@
+---
+'@onerepo/plugin-jest': minor
+---
+
+Defaults to send `--passWithNoTests` to Jest, configurable in the plugin options.

--- a/docs/src/content/docs/plugins/docgen/example.mdx
+++ b/docs/src/content/docs/plugins/docgen/example.mdx
@@ -12,7 +12,7 @@ The following content is auto-generated using the [official documentation plugin
 :::
 
 {/* start-auto-generated-from-cli */}
-{/* @generated SignedSource<<20d792693f551fd42c691bd5a0edecf4>> */}
+{/* @generated SignedSource<<73df5de81dfb6aedc28fa4cc8d5872e3>> */}
 
 ## `one`
 
@@ -671,7 +671,7 @@ one install [options]
 
 ### `one jest`
 
-Run tests using Jest
+Run tests using Jest.
 
 ```sh
 one jest [options] -- [passthrough]
@@ -680,7 +680,7 @@ one jest [options]
 
 This test commad will automatically attempt to run only the test files related to the changes in your working state. If you have un-committed changes, only those related to files that are in a modified state will be run. If there are no un-committed changes, test files related to those modified since your git merge-base will be run. By passing specific filepaths as extra passthrough arguments an argument separator (two dasshes `--`), you can further restrict the tests to those files and paths.
 
-Additionally, any other [Jest CLI options](https://jestjs.io/docs/cli) can be passed as passthrough arguments as well after an argument separator (two dasshes `--`)
+Additionally, any other [Jest CLI options](https://jestjs.io/docs/cli) can be passed as passthrough arguments as well after an argument separator (two dashes `--`)
 
 | Option             | Type                       | Description                                                                                                                                                                 |
 | ------------------ | -------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -697,11 +697,12 @@ Additionally, any other [Jest CLI options](https://jestjs.io/docs/cli) can be pa
 
 <summary>Advanced options</summary>
 
-| Option          | Type                                    | Description                                               |
-| --------------- | --------------------------------------- | --------------------------------------------------------- |
-| `--config`      | `string`, default: `"./jest.config.js"` | Path to the jest.config file, relative to the repo root.  |
-| `--from-ref`    | `string`                                | Git ref to start looking for affected files or workspaces |
-| `--through-ref` | `string`                                | Git ref to start looking for affected files or workspaces |
+| Option              | Type                                    | Description                                                                                 |
+| ------------------- | --------------------------------------- | ------------------------------------------------------------------------------------------- |
+| `--config`          | `string`, default: `"./jest.config.js"` | Path to the jest.config file, relative to the repo root.                                    |
+| `--from-ref`        | `string`                                | Git ref to start looking for affected files or workspaces                                   |
+| `--passWithNoTests` | `boolean`, default: `true`              | Allows the test suite to pass when no files are found. See plugin configuration to disable. |
+| `--through-ref`     | `string`                                | Git ref to start looking for affected files or workspaces                                   |
 
 </details>
 

--- a/docs/src/content/docs/plugins/jest.mdx
+++ b/docs/src/content/docs/plugins/jest.mdx
@@ -51,7 +51,7 @@ export default {
 ```
 
 {/* start-install-typedoc */}
-{/* @generated SignedSource<<3f7bda6c35c14c24927548992d1793f4>> */}
+{/* @generated SignedSource<<2fcb2666c7621d908e99cc164904fb0d>> */}
 
 ### jest()
 
@@ -81,18 +81,23 @@ export default {
 type Options: {
   config: string;
   name: string | string[];
+  passWithNoTests: boolean;
 };
 ```
+
+Options for configuring the Jest oneRepo plugin.
 
 ```js title="onerepo.config.js"
 export default {
 	plugins: [
 		jest({
-			name: ['test', 'jest']
+			// optional configuration
 		}),
 	],
 });
 ```
+
+- **Default:** `{}`
 
 #### Type declaration
 
@@ -104,9 +109,13 @@ config?: string;
 
 Specify the main Jest configuration file, if different from `<repo>/jest.config.js`. This can be relative to the repository root.
 
-```js
-jest({
-	config: 'configs/jest/config.js',
+```js title="onerepo.config.js"
+export default {
+	plugins: [
+		jest({
+			config: 'configs/jest.config.js'
+		}),
+	],
 });
 ```
 
@@ -116,18 +125,50 @@ jest({
 name?: string | string[];
 ```
 
-Rename the default command name.
+- **Default:** `'jest'`
+
+Rename the default command name. This configuration is recommended, but not provided, to avoid potential conflicts with other commands.
+
+```js title="onerepo.config.js"
+export default {
+	plugins: [
+		jest({
+			name: ['test', 'jest']
+		}),
+	],
+});
+```
+
+##### passWithNoTests?
+
+```ts
+passWithNoTests?: boolean;
+```
+
+- **Default:** `true`
+
+Automatically include Jests's flag `--passWithNoTests` when running.
+
+```js title="onerepo.config.js"
+export default {
+	plugins: [
+		jest({
+			passWithNoTests: false,
+		}),
+	],
+});
+```
 
 {/* end-install-typedoc */}
 
 ## Commands
 
 {/* start-auto-generated-from-cli-jest */}
-{/* @generated SignedSource<<6285b7b62a98fde902106bd8c682cdc1>> */}
+{/* @generated SignedSource<<ee9828e4ce89cffb5ea06d76b6305762>> */}
 
 ### `one jest`
 
-Run tests using Jest
+Run tests using Jest.
 
 ```sh
 one jest [options] -- [passthrough]
@@ -136,7 +177,7 @@ one jest [options]
 
 This test commad will automatically attempt to run only the test files related to the changes in your working state. If you have un-committed changes, only those related to files that are in a modified state will be run. If there are no un-committed changes, test files related to those modified since your git merge-base will be run. By passing specific filepaths as extra passthrough arguments an argument separator (two dasshes `--`), you can further restrict the tests to those files and paths.
 
-Additionally, any other [Jest CLI options](https://jestjs.io/docs/cli) can be passed as passthrough arguments as well after an argument separator (two dasshes `--`)
+Additionally, any other [Jest CLI options](https://jestjs.io/docs/cli) can be passed as passthrough arguments as well after an argument separator (two dashes `--`)
 
 | Option             | Type                       | Description                                                                                                                                                                 |
 | ------------------ | -------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -153,11 +194,12 @@ Additionally, any other [Jest CLI options](https://jestjs.io/docs/cli) can be pa
 
 <summary>Advanced options</summary>
 
-| Option          | Type                                    | Description                                               |
-| --------------- | --------------------------------------- | --------------------------------------------------------- |
-| `--config`      | `string`, default: `"./jest.config.js"` | Path to the jest.config file, relative to the repo root.  |
-| `--from-ref`    | `string`                                | Git ref to start looking for affected files or workspaces |
-| `--through-ref` | `string`                                | Git ref to start looking for affected files or workspaces |
+| Option              | Type                                    | Description                                                                                 |
+| ------------------- | --------------------------------------- | ------------------------------------------------------------------------------------------- |
+| `--config`          | `string`, default: `"./jest.config.js"` | Path to the jest.config file, relative to the repo root.                                    |
+| `--from-ref`        | `string`                                | Git ref to start looking for affected files or workspaces                                   |
+| `--passWithNoTests` | `boolean`, default: `true`              | Allows the test suite to pass when no files are found. See plugin configuration to disable. |
+| `--through-ref`     | `string`                                | Git ref to start looking for affected files or workspaces                                   |
 
 </details>
 

--- a/docs/src/content/docs/plugins/vitest.mdx
+++ b/docs/src/content/docs/plugins/vitest.mdx
@@ -38,7 +38,7 @@ import Tabs from '../../../components/Tabs.astro';
 </Tabs>
 
 {/* start-install-typedoc */}
-{/* @generated SignedSource<<20e3dd0d6a120fddc5f7d1bf934ef5bf>> */}
+{/* @generated SignedSource<<12c4855cea236c5e298a4cfa5ebe6fe2>> */}
 
 ### vitest()
 
@@ -71,7 +71,9 @@ type Options: {
 };
 ```
 
-```js
+Options for configuring the Vitest oneRepo plugin.
+
+```js title="onerepo.config.js"
 export default {
 	plugins: [
 		vitest({
@@ -89,13 +91,37 @@ export default {
 config?: string;
 ```
 
+Specify the main Jest configuration file, if different from `<repo>/vitest.config.js`. This can be relative to the repository root.
+
+```js title="onerepo.config.js"
+export default {
+	plugins: [
+		vitest({
+			config: 'configs/vitest.config.js'
+		}),
+	],
+});
+```
+
 ##### name?
 
 ```ts
 name?: string | string[];
 ```
 
-The name of the vitest command. You might change this to `'test'` or `['test', 'vitest']` to keep things more familiar for most developers.
+- **Default:** `'vitest'`
+
+Rename the default command name. This configuration is recommended, but not provided, to avoid potential conflicts with other commands.
+
+```js title="onerepo.config.js"
+export default {
+	plugins: [
+		vitest({
+			name: ['test', 'vitest']
+		}),
+	],
+});
+```
 
 {/* end-install-typedoc */}
 

--- a/plugins/jest/src/commands/__tests__/jest.test.ts
+++ b/plugins/jest/src/commands/__tests__/jest.test.ts
@@ -21,7 +21,15 @@ describe('handler', () => {
 		expect(subprocess.run).toHaveBeenCalledWith(
 			expect.objectContaining({
 				cmd: 'node',
-				args: ['node_modules/.bin/jest', '--config', './jest.config.js', '--colors', '--changedSince', 'tacobase'],
+				args: [
+					'node_modules/.bin/jest',
+					'--config',
+					'./jest.config.js',
+					'--colors',
+					'--passWithNoTests',
+					'--changedSince',
+					'tacobase',
+				],
 				opts: { stdio: 'inherit' },
 			}),
 		);
@@ -38,6 +46,7 @@ describe('handler', () => {
 					'--config',
 					'./jest.config.js',
 					'--colors',
+					'--passWithNoTests',
 					expect.stringMatching(/modules\/burritos$/),
 				],
 				opts: { stdio: 'inherit' },
@@ -61,6 +70,7 @@ describe('handler', () => {
 					'--config',
 					'./jest.config.js',
 					'--colors',
+					'--passWithNoTests',
 					'--changedSince',
 					'burritobase',
 				],
@@ -74,7 +84,7 @@ describe('handler', () => {
 		expect(subprocess.run).toHaveBeenCalledWith(
 			expect.objectContaining({
 				cmd: 'node',
-				args: ['node_modules/.bin/jest', '--config', './jest.config.js', '--colors', '-w', 'foo'],
+				args: ['node_modules/.bin/jest', '--config', './jest.config.js', '--colors', '--passWithNoTests', '-w', 'foo'],
 			}),
 		);
 	});
@@ -85,7 +95,7 @@ describe('handler', () => {
 		expect(subprocess.run).toHaveBeenCalledWith(
 			expect.objectContaining({
 				cmd: 'node',
-				args: ['node_modules/.bin/jest', '--config', './jest.config.js', '--colors', '.'],
+				args: ['node_modules/.bin/jest', '--config', './jest.config.js', '--colors', '--passWithNoTests', '.'],
 			}),
 		);
 	});
@@ -96,6 +106,17 @@ describe('handler', () => {
 		expect(subprocess.run).toHaveBeenCalledWith(
 			expect.objectContaining({
 				args: expect.arrayContaining(['node_modules/.bin/jest', '--no-colors']),
+			}),
+		);
+	});
+
+	test('can disable --passWithNoTests', async () => {
+		await run('--all --no-passWithNoTests');
+
+		expect(subprocess.run).toHaveBeenCalledWith(
+			expect.objectContaining({
+				cmd: 'node',
+				args: ['node_modules/.bin/jest', '--config', './jest.config.js', '--colors', '.'],
 			}),
 		);
 	});

--- a/plugins/jest/src/index.ts
+++ b/plugins/jest/src/index.ts
@@ -2,31 +2,65 @@ import type { Plugin } from 'onerepo';
 import * as cmd from './commands/jest';
 
 /**
+ * Options for configuring the Jest oneRepo plugin.
  *
  * ```js title="onerepo.config.js"
  * export default {
  * 	plugins: [
  * 		jest({
- * 			name: ['test', 'jest']
+ * 			// optional configuration
  * 		}),
  * 	],
  * });
  * ```
+ *
+ * @default `{}`
  */
 export type Options = {
 	/**
 	 * Specify the main Jest configuration file, if different from `<repo>/jest.config.js`. This can be relative to the repository root.
-	 * ```js
-	 * jest({
-	 * 	config: 'configs/jest/config.js'
+	 *
+	 * ```js title="onerepo.config.js"
+	 * export default {
+	 * 	plugins: [
+	 * 		jest({
+	 * 			config: 'configs/jest.config.js'
+	 * 		}),
+	 * 	],
 	 * });
 	 * ```
 	 */
 	config?: string;
 	/**
-	 * Rename the default command name.
+	 * @default `'jest'`
+	 * Rename the default command name. This configuration is recommended, but not provided, to avoid potential conflicts with other commands.
+	 *
+	 * ```js title="onerepo.config.js"
+	 * export default {
+	 * 	plugins: [
+	 * 		jest({
+	 * 			name: ['test', 'jest']
+	 * 		}),
+	 * 	],
+	 * });
+	 * ```
 	 */
 	name?: string | Array<string>;
+	/**
+	 * @default `true`
+	 * Automatically include Jests's flag `--passWithNoTests` when running.
+	 *
+	 * ```js title="onerepo.config.js"
+	 * export default {
+	 * 	plugins: [
+	 * 		jest({
+	 * 			passWithNoTests: false,
+	 * 		}),
+	 * 	],
+	 * });
+	 * ```
+	 */
+	passWithNoTests?: boolean;
 };
 
 /**
@@ -54,6 +88,7 @@ export function jest(opts: Options = {}): Plugin {
 					if (opts.config) {
 						y.default('config', opts.config);
 					}
+					y.default('passWithNoTests', opts.passWithNoTests ?? true);
 					return y;
 				},
 				handler,

--- a/plugins/vitest/src/index.ts
+++ b/plugins/vitest/src/index.ts
@@ -2,8 +2,9 @@ import type { PluginObject } from 'onerepo';
 import * as cmd from './commands/vitest';
 
 /**
+ * Options for configuring the Vitest oneRepo plugin.
  *
- * ```js
+ * ```js title="onerepo.config.js"
  * export default {
  * 	plugins: [
  * 		vitest({
@@ -14,9 +15,33 @@ import * as cmd from './commands/vitest';
  * ```
  */
 export type Options = {
+	/**
+	 * Specify the main Jest configuration file, if different from `<repo>/vitest.config.js`. This can be relative to the repository root.
+	 *
+	 * ```js title="onerepo.config.js"
+	 * export default {
+	 * 	plugins: [
+	 * 		vitest({
+	 * 			config: 'configs/vitest.config.js'
+	 * 		}),
+	 * 	],
+	 * });
+	 * ```
+	 */
 	config?: string;
 	/**
-	 * The name of the vitest command. You might change this to `'test'` or `['test', 'vitest']` to keep things more familiar for most developers.
+	 * @default `'vitest'`
+	 * Rename the default command name. This configuration is recommended, but not provided, to avoid potential conflicts with other commands.
+	 *
+	 * ```js title="onerepo.config.js"
+	 * export default {
+	 * 	plugins: [
+	 * 		vitest({
+	 * 			name: ['test', 'vitest']
+	 * 		}),
+	 * 	],
+	 * });
+	 * ```
 	 */
 	name?: string | Array<string>;
 };


### PR DESCRIPTION
**Problem:**

In a monorepo, there are a lot of instances where we will set up the plumbing for tests in every Workspace, but not have any yet for some. When this happens, you need to manually pass `--passWithNoTests` to Jest

> [!NOTE]
> This apparently is not the case for Vitest, which exposes `passWithNoTests` as a configuration option, not just a CLI flag. Jest, however, does not expose a config option.

**Solution:**

Default to send `--passWithNoTests` to Jest.

**Related issues:**

Fixes #549

**Checklist:**

- [x] Added or updated tests
- [x] Added or updated documentation
- [x] Ensured the pre-commit hooks ran successfully

