### PR TITLE
feat(plugin-docgen): --use-defaults

### DIFF
--- a/.changeset/shy-dots-tap.md
+++ b/.changeset/shy-dots-tap.md
@@ -1,0 +1,5 @@
+---
+'@onerepo/plugin-docgen': minor
+---
+
+Adds advanced/hidden option `--use-defaults` to use the default root configuration when generating documentation.

--- a/docs/commands/collect-content.ts
+++ b/docs/commands/collect-content.ts
@@ -82,6 +82,7 @@ export const handler: Handler<Argv> = async (argv, { getWorkspaces, graph, logge
 			cmd: process.argv[1],
 			args: [
 				'docgen',
+				'--use-defaults',
 				'--format',
 				'markdown',
 				'--heading-level',
@@ -133,6 +134,7 @@ export const handler: Handler<Argv> = async (argv, { getWorkspaces, graph, logge
 				cmd: process.argv[1],
 				args: [
 					'docgen',
+					'--use-defaults',
 					'--format',
 					'markdown',
 					'--heading-level',

--- a/docs/src/content/docs/core/graph.mdx
+++ b/docs/src/content/docs/core/graph.mdx
@@ -35,7 +35,7 @@ export default {
 ## Commands
 
 {/* start-auto-generated-from-cli-graph */}
-{/* @generated SignedSource<<d4b2c55de5ea3a4a675dab441f5a2aa2>> */}
+{/* @generated SignedSource<<1d9c2a3716dcf00b4edf128d7ebb6f2b>> */}
 
 ### `one graph`
 
@@ -126,9 +126,9 @@ Dependencies across Workspaces can be validated using one of the various modes:
 
 <summary>Advanced options</summary>
 
-| Option            | Type                                          | Description                             |
-| ----------------- | --------------------------------------------- | --------------------------------------- |
-| `--custom-schema` | `string`, default: `"config/graph-schema.ts"` | Path to a custom JSON schema definition |
+| Option            | Type     | Description                             |
+| ----------------- | -------- | --------------------------------------- |
+| `--custom-schema` | `string` | Path to a custom JSON schema definition |
 
 </details>
 

--- a/docs/src/content/docs/core/tasks.mdx
+++ b/docs/src/content/docs/core/tasks.mdx
@@ -286,7 +286,7 @@ jobs:
 ## Commands
 
 {/* start-auto-generated-from-cli-tasks */}
-{/* @generated SignedSource<<859aa6ba9fc5cbcae460c585d1d04013>> */}
+{/* @generated SignedSource<<8fabfc51cc39e013d940877cbae9db3f>> */}
 
 ### `one tasks`
 
@@ -314,11 +314,11 @@ You can fine-tune the determination of affected Workspaces by providing a `--fro
 
 <summary>Advanced options</summary>
 
-| Option          | Type                                                                                   | Description                                                               |
-| --------------- | -------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
-| `--from-ref`    | `string`                                                                               | Git ref to start looking for affected files or workspaces                 |
-| `--ignore`      | `array`, default: `[".changesets/*","**/README.md","**/CHANGELOG.md",".changeset/**"]` | List of filepath strings or globs to ignore when matching tasks to files. |
-| `--through-ref` | `string`                                                                               | Git ref to start looking for affected files or workspaces                 |
+| Option          | Type                                  | Description                                                               |
+| --------------- | ------------------------------------- | ------------------------------------------------------------------------- |
+| `--from-ref`    | `string`                              | Git ref to start looking for affected files or workspaces                 |
+| `--ignore`      | `array`, default: `[".changesets/*"]` | List of filepath strings or globs to ignore when matching tasks to files. |
+| `--through-ref` | `string`                              | Git ref to start looking for affected files or workspaces                 |
 
 </details>
 

--- a/docs/src/content/docs/plugins/docgen.mdx
+++ b/docs/src/content/docs/plugins/docgen.mdx
@@ -145,7 +145,7 @@ Set to true to amend content to the given file using the file.writeSafe | `file.
 ## Commands
 
 {/* start-auto-generated-from-cli-docgen */}
-{/* @generated SignedSource<<4673a8de2f1d979aecc9b936d589a437>> */}
+{/* @generated SignedSource<<b03aeb7a64f69c7d001486004672831e>> */}
 
 ### `one docgen`
 
@@ -167,14 +167,16 @@ Add this command to your one Repo tasks on pre-commit to ensure that your docume
 | `--out-file`      | `string`, default: `"./docs/src/content/docs/plugins/docgen/example.mdx"` | File to write output to. If not provided, stdout will be used              |
 | `--out-workspace` | `string`, default: `"root"`                                               | Workspace name to write the --out-file to                                  |
 | `--safe-write`    | `boolean`, default: `true`                                                | Write documentation to a portion of the file with start and end sentinels. |
+| `--show-advanced` | `boolean`                                                                 | Pair with `--help` to show advanced options.                               |
 
 <details>
 
 <summary>Advanced options</summary>
 
-| Option      | Type     | Description                                              |
-| ----------- | -------- | -------------------------------------------------------- |
-| `--command` | `string` | Start at the given command, skip the root and any others |
+| Option           | Type      | Description                                                                          |
+| ---------------- | --------- | ------------------------------------------------------------------------------------ |
+| `--command`      | `string`  | Start at the given command, skip the root and any others                             |
+| `--use-defaults` | `boolean` | Use the oneRepo default configuration. Helpful for generating default documentation. |
 
 </details>
 

--- a/docs/src/content/docs/plugins/docgen/example.mdx
+++ b/docs/src/content/docs/plugins/docgen/example.mdx
@@ -12,7 +12,7 @@ The following content is auto-generated using the [official documentation plugin
 :::
 
 {/* start-auto-generated-from-cli */}
-{/* @generated SignedSource<<73df5de81dfb6aedc28fa4cc8d5872e3>> */}
+{/* @generated SignedSource<<4cc444a3b6f6cb42e95e2664f7884a61>> */}
 
 ## `one`
 
@@ -414,14 +414,16 @@ Add this command to your one Repo tasks on pre-commit to ensure that your docume
 | `--out-file`      | `string`, default: `"./docs/src/content/docs/plugins/docgen/example.mdx"` | File to write output to. If not provided, stdout will be used              |
 | `--out-workspace` | `string`, default: `"root"`                                               | Workspace name to write the --out-file to                                  |
 | `--safe-write`    | `boolean`, default: `true`                                                | Write documentation to a portion of the file with start and end sentinels. |
+| `--show-advanced` | `boolean`                                                                 | Pair with `--help` to show advanced options.                               |
 
 <details>
 
 <summary>Advanced options</summary>
 
-| Option      | Type     | Description                                              |
-| ----------- | -------- | -------------------------------------------------------- |
-| `--command` | `string` | Start at the given command, skip the root and any others |
+| Option           | Type      | Description                                                                          |
+| ---------------- | --------- | ------------------------------------------------------------------------------------ |
+| `--command`      | `string`  | Start at the given command, skip the root and any others                             |
+| `--use-defaults` | `boolean` | Use the oneRepo default configuration. Helpful for generating default documentation. |
 
 </details>
 


### PR DESCRIPTION
**Problem:**

Some docs generated by `one docgen` are using the local repository's configuration, but we don't actually want that for our documentation.

**Solution:**

Add an advanced argument: `--use-defaults` that will use the oneRepo default config.
