### PR TITLE
feat(changes): left-pad change files with zeros

### DIFF
--- a/modules/onerepo/src/core/changes/__tests__/add.test.ts
+++ b/modules/onerepo/src/core/changes/__tests__/add.test.ts
@@ -26,7 +26,7 @@ describe('add changes', () => {
 			.mockResolvedValueOnce({ contents: 'This is the content' });
 		await run('');
 
-		const entry = graph.getByName('tacos').resolve('.changes/2-d2f3b1c5.md');
+		const entry = graph.getByName('tacos').resolve('.changes/002-d2f3b1c5.md');
 		expect(file.write).toHaveBeenCalledWith(
 			entry,
 			`---
@@ -46,7 +46,7 @@ This is the content`,
 			.mockResolvedValueOnce({ contents: 'This is the content' });
 		await run('--prompts=semver');
 
-		const entry = graph.getByName('tacos').resolve('.changes/2-d2f3b1c5.md');
+		const entry = graph.getByName('tacos').resolve('.changes/002-d2f3b1c5.md');
 		expect(file.write).toHaveBeenCalledWith(
 			entry,
 			`---

--- a/modules/onerepo/src/core/changes/__tests__/migrate.test.ts
+++ b/modules/onerepo/src/core/changes/__tests__/migrate.test.ts
@@ -1,0 +1,71 @@
+import path from 'node:path';
+import * as glob from 'glob';
+import * as file from '@onerepo/file';
+import { getCommand } from '@onerepo/test-cli';
+import { getGraph } from '@onerepo/graph';
+import { LogStep } from '@onerepo/logger';
+import * as migrate from '../migrate';
+
+const graph = getGraph(path.join(__dirname, '__fixtures__/with-entries'));
+const { run } = getCommand(migrate, graph);
+
+describe('migrate changes', () => {
+	beforeEach(() => {
+		vi.spyOn(Date, 'now').mockReturnValue(1706903142100);
+	});
+
+	test('copies changes to appropriate workspaces', async () => {
+		vi.spyOn(glob, 'glob').mockResolvedValue(['.changeset/asdf.md', '.changeset/qwer.md']);
+		vi.spyOn(file, 'write').mockResolvedValue();
+		vi.spyOn(file, 'read').mockResolvedValueOnce(`---
+cheese: minor
+lettuce: minor
+---
+
+Entry the first.`).mockResolvedValueOnce(`---
+lettuce: patch
+tacos: patch
+---
+
+Entry the second.`);
+		await run('');
+
+		expect(file.write).toHaveBeenCalledWith(
+			graph.getByName('cheese').resolve('.changes/000-2c3a33b1.md'),
+			`---
+type: minor
+---
+
+Entry the first.`,
+			{ step: expect.any(LogStep) },
+		);
+		expect(file.write).toHaveBeenCalledWith(
+			graph.getByName('lettuce').resolve('.changes/000-2c3a33b1.md'),
+			`---
+type: minor
+---
+
+Entry the first.`,
+			{ step: expect.any(LogStep) },
+		);
+
+		expect(file.write).toHaveBeenCalledWith(
+			graph.getByName('lettuce').resolve('.changes/001-e34f954d.md'),
+			`---
+type: patch
+---
+
+Entry the second.`,
+			{ step: expect.any(LogStep) },
+		);
+		expect(file.write).toHaveBeenCalledWith(
+			graph.getByName('tacos').resolve('.changes/001-e34f954d.md'),
+			`---
+type: patch
+---
+
+Entry the second.`,
+			{ step: expect.any(LogStep) },
+		);
+	});
+});

--- a/modules/onerepo/src/core/changes/add.ts
+++ b/modules/onerepo/src/core/changes/add.ts
@@ -162,7 +162,10 @@ ${pc.dim(
 				return memo;
 			}, [] as Array<number>),
 		);
-		const changesetFile = workspace.resolve('.changes', `${highestIndex + 1}-${filename}.md`);
+		const changesetFile = workspace.resolve(
+			'.changes',
+			`${(highestIndex + 1).toString().padStart(3, '0')}-${filename}.md`,
+		);
 		files.push(changesetFile);
 		await write(
 			changesetFile,

--- a/modules/onerepo/src/core/changes/migrate.ts
+++ b/modules/onerepo/src/core/changes/migrate.ts
@@ -63,7 +63,7 @@ export const handler: Handler<Argv> = async (argv, { graph, logger }) => {
 				continue;
 			}
 			await write(
-				ws.resolve(`.changes/${index}-${filename}.md`),
+				ws.resolve(`.changes/${index.toString().padStart(3, '0')}-${filename}.md`),
 				`---
 type: ${info[ws.name]}
 ---


### PR DESCRIPTION
**Problem:**

Some systems (eg, GitHub) do literal sorting on filenames, so `11-…` will come before `2-…`. This will make change entry files confusing.

**Solution:**

left-pad the filenames with zeroes so there are three digits.
