### PR TITLE
feat(docgen): hide advanced/globals

### DIFF
--- a/docs/src/content/docs/core/changes.mdx
+++ b/docs/src/content/docs/core/changes.mdx
@@ -245,7 +245,7 @@ Once ready, merge your pull request to your main branch.
 ## Commands
 
 {/* start-auto-generated-from-cli-changes */}
-{/* @generated SignedSource<<eaca5e1e4bd2838a3b132dda4e62a75e>> */}
+{/* @generated SignedSource<<aaf3ba825667d217308ab86cd6049c96>> */}
 
 ### `one change`
 
@@ -276,7 +276,6 @@ This command will prompt for appropriate Workspace(s), prompt for the release ty
 | `--add`            | `boolean`, default: `true`      | Add the modified `package.json` files to the git stage for committing.                                              |
 | `--affected`       | `boolean`                       | Select all affected Workspaces. If no other inputs are chosen, this will default to `true`.                         |
 | `--all, -a`        | `boolean`                       | Run across all workspaces                                                                                           |
-| `--show-advanced`  | `boolean`                       | Pair with `--help` to show advanced options.                                                                        |
 | `--type`           | `"major"`, `"minor"`, `"patch"` | Provide a semantic version bump type. If not given, a prompt will guide you through selecting the appropriate type. |
 | `--workspaces, -w` | `array`                         | List of Workspace names to run against                                                                              |
 
@@ -303,10 +302,6 @@ Migrate from Changesets to oneRepo changes.
 ```sh
 one change migrate
 ```
-
-| Option            | Type      | Description                                  |
-| ----------------- | --------- | -------------------------------------------- |
-| `--show-advanced` | `boolean` | Pair with `--help` to show advanced options. |
 
 <details>
 
@@ -338,7 +333,6 @@ For each Workspace, the registry will be queried first to ensure the current ver
 | ------------------ | --------- | ------------------------------------------------------------------------------------------ |
 | `--all, -a`        | `boolean` | Run across all workspaces                                                                  |
 | `--otp`            | `boolean` | Set to true if your publishes require an OTP for NPM.                                      |
-| `--show-advanced`  | `boolean` | Pair with `--help` to show advanced options.                                               |
 | `--skip-auth`      | `boolean` | Skip auth checks. This may be necessary for some internal registries using PATs or tokens. |
 | `--workspaces, -w` | `array`   | List of Workspace names to run against                                                     |
 
@@ -388,7 +382,6 @@ Periodically you may want to publish a _snapshot_ release – something that nee
 | `--allow-dirty`    | `boolean`                         | Bypass checks to ensure no there are no un-committed changes.             |
 | `--otp`            | `boolean`                         | Prompt for one-time password before publishing to the registry            |
 | `--reset`          | `boolean`, default: `true`        | Reset `package.json` changes before exiting. Use `--no-reset` to disable. |
-| `--show-advanced`  | `boolean`                         | Pair with `--help` to show advanced options.                              |
 | `--tag`            | `string`, default: `"prerelease"` | Distribution tag to apply when publishing the pre-release.                |
 | `--workspaces, -w` | `array`                           | List of Workspace names to run against                                    |
 
@@ -407,7 +400,6 @@ one change version
 | `--all, -a`                          | `boolean` | Run across all workspaces                                     |
 | `--allow-dirty`                      | `boolean` | Bypass checks to ensure no there are no un-committed changes. |
 | `--prerelease, --pre, --pre-release` | `string`  | Create a pre-release using the specified identifier.          |
-| `--show-advanced`                    | `boolean` | Pair with `--help` to show advanced options.                  |
 | `--workspaces, -w`                   | `array`   | List of Workspace names to run against                        |
 
 Create a prerelease for the next version the form of `1.2.3-alpha.0`.

--- a/docs/src/content/docs/core/codeowners.mdx
+++ b/docs/src/content/docs/core/codeowners.mdx
@@ -55,7 +55,7 @@ The following providers are currently enabled:
 ## Commands
 
 {/* start-auto-generated-from-cli-codeowners */}
-{/* @generated SignedSource<<edc3af3512a5479a6e609f5249739c9e>> */}
+{/* @generated SignedSource<<cff48ac9a67494c4eb16ba14cc97e975>> */}
 
 ### `one codeowners`
 
@@ -77,10 +77,9 @@ Sync code owners from Workspace configurations to the repository’s CODEOWNERS 
 one codeowners sync
 ```
 
-| Option            | Type      | Description                                       |
-| ----------------- | --------- | ------------------------------------------------- |
-| `--add`           | `boolean` | Add the updated CODEOWNERS file to the git stage. |
-| `--show-advanced` | `boolean` | Pair with `--help` to show advanced options.      |
+| Option  | Type      | Description                                       |
+| ------- | --------- | ------------------------------------------------- |
+| `--add` | `boolean` | Add the updated CODEOWNERS file to the git stage. |
 
 <details>
 
@@ -101,10 +100,6 @@ Verify the CODEOWNERS file is up to date and unmodified.
 ```sh
 one codeowners verify
 ```
-
-| Option            | Type      | Description                                  |
-| ----------------- | --------- | -------------------------------------------- |
-| `--show-advanced` | `boolean` | Pair with `--help` to show advanced options. |
 
 <details>
 

--- a/docs/src/content/docs/core/dependencies.mdx
+++ b/docs/src/content/docs/core/dependencies.mdx
@@ -37,7 +37,7 @@ No configuration necessary! oneRepo automatically detects which package manager 
 </div>
 
 {/* start-auto-generated-from-cli-dependencies */}
-{/* @generated SignedSource<<fd2516a190a5c215b9b3ad060184ef57>> */}
+{/* @generated SignedSource<<eb7cde3dc7e557bb584d4f4fcfe20628>> */}
 
 ### `one dependencies`
 
@@ -72,7 +72,6 @@ Otherwise, the latest version will be requested from the registry.
 | `--dev, -d`        | `array`                                            | Add dependencies for development purposes only.                                                                                        |
 | `--mode`           | `"strict"`, `"loose"`, `"off"`, default: `"loose"` | Version selection mode. Use `strict` to use strict version numbers, `loose` to use caret (`^`) ranges, and `off` for nothing specific. |
 | `--prod, -p`       | `array`                                            | Add dependencies for production purposes.                                                                                              |
-| `--show-advanced`  | `boolean`                                          | Pair with `--help` to show advanced options.                                                                                           |
 | `--workspaces, -w` | `array`                                            | One or more Workspaces to add dependencies into                                                                                        |
 
 Install the latest version of `normalizr` from the registry, using a strict version number.
@@ -108,7 +107,6 @@ one dependencies remove -w [workspaces...] -d [dependencies...] [options...]
 | `--all, -a`          | `boolean`                  | Run across all workspaces                                                 |          |
 | `--dedupe`           | `boolean`, default: `true` | Deduplicate dependencies across the repository after install is complete. |          |
 | `--dependencies, -d` | `array`                    | Dependency names that should be removed.                                  | ✅       |
-| `--show-advanced`    | `boolean`                  | Pair with `--help` to show advanced options.                              |          |
 | `--workspaces, -w`   | `array`                    | List of Workspace names to run against                                    |          |
 
 ---
@@ -131,7 +129,6 @@ Dependencies across Workspaces can be validated using one of the various modes:
 | ------------------ | -------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `--all, -a`        | `boolean`                                          | Run across all workspaces                                                                                                                                     |
 | `--mode`           | `"strict"`, `"loose"`, `"off"`, default: `"loose"` | Version selection mode. Use `strict` to use exact version matches, `loose` to accept within defined ranges (`^` or `~` range), and `off` for no verification. |
-| `--show-advanced`  | `boolean`                                          | Pair with `--help` to show advanced options.                                                                                                                  |
 | `--workspaces, -w` | `array`                                            | List of Workspace names to run against                                                                                                                        |
 
 {/* end-auto-generated-from-cli-dependencies */}

--- a/docs/src/content/docs/core/generate.mdx
+++ b/docs/src/content/docs/core/generate.mdx
@@ -110,7 +110,7 @@ Please see the [inquirer documentation](https://github.com/SBoudrias/Inquirer.js
 ## Commands
 
 {/* start-auto-generated-from-cli-generate */}
-{/* @generated SignedSource<<5e16c178886d49963ec634318a4ffb2f>> */}
+{/* @generated SignedSource<<a260bf83a250506650136e8cf21e3b94>> */}
 
 ### `one generate`
 
@@ -124,18 +124,18 @@ one generate [options]
 
 To create new templates add a new folder to config/templates and create a `.onegen.cjs` configuration file. Follow the instructions online for more: https\://onerepo.tools/plugins/generate/
 
-| Option            | Type      | Description                                                                         |
-| ----------------- | --------- | ----------------------------------------------------------------------------------- |
-| `--show-advanced` | `boolean` | Pair with `--help` to show advanced options.                                        |
-| `--type, -t`      | `string`  | Template type to generate. If not provided, a list will be provided to choose from. |
+| Option       | Type     | Description                                                                         |
+| ------------ | -------- | ----------------------------------------------------------------------------------- |
+| `--type, -t` | `string` | Template type to generate. If not provided, a list will be provided to choose from. |
 
 <details>
 
 <summary>Advanced options</summary>
 
-| Option            | Type                                    | Description           | Required |
-| ----------------- | --------------------------------------- | --------------------- | -------- |
-| `--templates-dir` | `string`, default: `"config/templates"` | Path to the templates | ✅       |
+| Option            | Type                                    | Description                                  | Required |
+| ----------------- | --------------------------------------- | -------------------------------------------- | -------- |
+| `--show-advanced` | `boolean`                               | Pair with `--help` to show advanced options. |          |
+| `--templates-dir` | `string`, default: `"config/templates"` | Path to the templates                        | ✅       |
 
 </details>
 

--- a/docs/src/content/docs/core/graph.mdx
+++ b/docs/src/content/docs/core/graph.mdx
@@ -35,7 +35,7 @@ export default {
 ## Commands
 
 {/* start-auto-generated-from-cli-graph */}
-{/* @generated SignedSource<<1d9c2a3716dcf00b4edf128d7ebb6f2b>> */}
+{/* @generated SignedSource<<a95cc376a48546154c9d3d9b27711294>> */}
 
 ### `one graph`
 
@@ -65,7 +65,6 @@ Pass `--open` to auto-open your default browser with the URL or use one of the `
 | `--all, -a`        | `boolean`                        | Run across all workspaces                                                                                                                                                   |
 | `--format, -f`     | `"mermaid"`, `"plain"`, `"json"` | Output format for inspecting the Workspace Graph.                                                                                                                           |
 | `--open`           | `boolean`                        | Auto-open the browser for the online visualizer.                                                                                                                            |
-| `--show-advanced`  | `boolean`                        | Pair with `--help` to show advanced options.                                                                                                                                |
 | `--staged`         | `boolean`                        | Use files on the git stage to calculate affected files or Workspaces. When unset or `--no-staged`, changes will be calculated from the entire branch, since its fork point. |
 | `--workspaces, -w` | `array`                          | List of Workspace names to run against                                                                                                                                      |
 
@@ -117,10 +116,9 @@ Dependencies across Workspaces can be validated using one of the various modes:
 - `loose`: Reused third-party dependencies will be required to have semantic version overlap across unique branches of the Graph.
 - `strict`: Versions of all dependencies across each discrete Workspace dependency tree must be strictly equal.
 
-| Option            | Type                                               | Description                                  |
-| ----------------- | -------------------------------------------------- | -------------------------------------------- |
-| `--mode`          | `"strict"`, `"loose"`, `"off"`, default: `"loose"` | Dependency overlap validation method.        |
-| `--show-advanced` | `boolean`                                          | Pair with `--help` to show advanced options. |
+| Option   | Type                                               | Description                           |
+| -------- | -------------------------------------------------- | ------------------------------------- |
+| `--mode` | `"strict"`, `"loose"`, `"off"`, default: `"loose"` | Dependency overlap validation method. |
 
 <details>
 

--- a/docs/src/content/docs/core/hooks.mdx
+++ b/docs/src/content/docs/core/hooks.mdx
@@ -81,7 +81,7 @@ git config --unset core.hooksPath
 ## Commands
 
 {/* start-auto-generated-from-cli-hooks */}
-{/* @generated SignedSource<<1398ccb2bc14058361a9d8f4e2bc9d45>> */}
+{/* @generated SignedSource<<ab3e3c1ba81fc5c4a6ba454e71a56156>> */}
 
 ### `one hooks`
 
@@ -101,12 +101,11 @@ Create git hooks
 one hooks create
 ```
 
-| Option            | Type                                                                                                                                                                                                                                                                                                                                                                                                                                          | Description                                                                |
-| ----------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
-| `--add`           | `boolean`, default: `true`                                                                                                                                                                                                                                                                                                                                                                                                                    | Add the hooks to the git stage for committing.                             |
-| `--hook`          | `"applypatch-msg"`, `"pre-applypatch"`, `"post-applypatch"`, `"pre-commit"`, `"pre-merge-commit"`, `"prepare-commit-msg"`, `"commit-msg"`, `"post-commit"`, `"pre-rebase"`, `"post-checkout"`, `"post-merge"`, `"pre-receive"`, `"update"`, `"post-receive"`, `"post-update"`, `"pre-auto-gc"`, `"post-rewrite"`, `"pre-push"`, `"proc-receive"`, `"push-to-checkout"`, default: `["pre-commit","post-checkout","post-merge","post-rewrite"]` | The git hook to create. Omit this option to auto-create recommended hooks. |
-| `--overwrite`     | `boolean`                                                                                                                                                                                                                                                                                                                                                                                                                                     | Overwrite existing hooks                                                   |
-| `--show-advanced` | `boolean`                                                                                                                                                                                                                                                                                                                                                                                                                                     | Pair with `--help` to show advanced options.                               |
+| Option        | Type                                                                                                                                                                                                                                                                                                                                                                                                                                          | Description                                                                |
+| ------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
+| `--add`       | `boolean`, default: `true`                                                                                                                                                                                                                                                                                                                                                                                                                    | Add the hooks to the git stage for committing.                             |
+| `--hook`      | `"applypatch-msg"`, `"pre-applypatch"`, `"post-applypatch"`, `"pre-commit"`, `"pre-merge-commit"`, `"prepare-commit-msg"`, `"commit-msg"`, `"post-commit"`, `"pre-rebase"`, `"post-checkout"`, `"post-merge"`, `"pre-receive"`, `"update"`, `"post-receive"`, `"post-update"`, `"pre-auto-gc"`, `"post-rewrite"`, `"pre-push"`, `"proc-receive"`, `"push-to-checkout"`, default: `["pre-commit","post-checkout","post-merge","post-rewrite"]` | The git hook to create. Omit this option to auto-create recommended hooks. |
+| `--overwrite` | `boolean`                                                                                                                                                                                                                                                                                                                                                                                                                                     | Overwrite existing hooks                                                   |
 
 <details>
 
@@ -129,10 +128,6 @@ Initialize and sync git hook settings for this repository.
 ```sh
 one hooks init
 ```
-
-| Option            | Type      | Description                                  |
-| ----------------- | --------- | -------------------------------------------- |
-| `--show-advanced` | `boolean` | Pair with `--help` to show advanced options. |
 
 <details>
 

--- a/docs/src/content/docs/core/install.mdx
+++ b/docs/src/content/docs/core/install.mdx
@@ -11,7 +11,7 @@ A helper command to enable you to _install_ global access to your oneRepo CLI. T
 ## Commands
 
 {/* start-auto-generated-from-cli-install */}
-{/* @generated SignedSource<<c98a806ff74e20f1e72fe2cbc2bff0c8>> */}
+{/* @generated SignedSource<<3209ae4182772e44aaa1f8e49de971af>> */}
 
 ### `one install`
 
@@ -21,11 +21,20 @@ Install the oneRepo CLI into your environment.
 one install [options]
 ```
 
-| Option            | Type                          | Description                                                                                                         |
-| ----------------- | ----------------------------- | ------------------------------------------------------------------------------------------------------------------- |
-| `--force`         | `boolean`                     | Force installation regardless of pre-existing command.                                                              |
-| `--location`      | `string`                      | Install location for the binary. Default location is chosen as default option for usr/bin dependent on the OS type. |
-| `--show-advanced` | `boolean`                     | Pair with `--help` to show advanced options.                                                                        |
-| `--version`       | `string`, default: `"0.16.0"` | Version of oneRepo to install. Defaults to the current version.                                                     |
+| Option       | Type                          | Description                                                                                                         |
+| ------------ | ----------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| `--force`    | `boolean`                     | Force installation regardless of pre-existing command.                                                              |
+| `--location` | `string`                      | Install location for the binary. Default location is chosen as default option for usr/bin dependent on the OS type. |
+| `--version`  | `string`, default: `"0.16.0"` | Version of oneRepo to install. Defaults to the current version.                                                     |
+
+<details>
+
+<summary>Advanced options</summary>
+
+| Option            | Type      | Description                                  |
+| ----------------- | --------- | -------------------------------------------- |
+| `--show-advanced` | `boolean` | Pair with `--help` to show advanced options. |
+
+</details>
 
 {/* end-auto-generated-from-cli-install */}

--- a/docs/src/content/docs/core/tasks.mdx
+++ b/docs/src/content/docs/core/tasks.mdx
@@ -286,7 +286,7 @@ jobs:
 ## Commands
 
 {/* start-auto-generated-from-cli-tasks */}
-{/* @generated SignedSource<<f61e31203cb384486c763f978bf9cf7f>> */}
+{/* @generated SignedSource<<34130cf9f827daa76e16e292d07bafdc>> */}
 
 ### `one tasks`
 
@@ -306,7 +306,6 @@ You can fine-tune the determination of affected Workspaces by providing a `--fro
 | `--lifecycle, -c`   | `"pre-commit"`, `"post-commit"`, `"post-checkout"`, `"pre-merge"`, `"post-merge"`, `"build"`, `"pre-deploy"`, `"pre-publish"`, `"post-publish"` | Task lifecycle to run. All tasks for the given lifecycle will be run as merged parallel tasks, followed by the merged set of serial tasks.       | ✅       |
 | `--list`            | `boolean`                                                                                                                                       | List found tasks. Implies dry run and will not actually run any tasks.                                                                           |          |
 | `--shard`           | `string`                                                                                                                                        | Shard the lifecycle across multiple instances. Format as `<shard-number>/<total-shards>`                                                         |          |
-| `--show-advanced`   | `boolean`                                                                                                                                       | Pair with `--help` to show advanced options.                                                                                                     |          |
 | `--staged`          | `boolean`                                                                                                                                       | Backup unstaged files and use only those on the git stage to calculate affected files or workspaces. Will re-apply the unstaged files upon exit. |          |
 | `--workspaces, -w`  | `array`                                                                                                                                         | List of Workspace names to run against                                                                                                           |          |
 
@@ -314,11 +313,12 @@ You can fine-tune the determination of affected Workspaces by providing a `--fro
 
 <summary>Advanced options</summary>
 
-| Option          | Type                                  | Description                                                               |
-| --------------- | ------------------------------------- | ------------------------------------------------------------------------- |
-| `--from-ref`    | `string`                              | Git ref to start looking for affected files or workspaces                 |
-| `--ignore`      | `array`, default: `[".changesets/*"]` | List of filepath strings or globs to ignore when matching tasks to files. |
-| `--through-ref` | `string`                              | Git ref to start looking for affected files or workspaces                 |
+| Option            | Type                                  | Description                                                               |
+| ----------------- | ------------------------------------- | ------------------------------------------------------------------------- |
+| `--from-ref`      | `string`                              | Git ref to start looking for affected files or workspaces                 |
+| `--ignore`        | `array`, default: `[".changesets/*"]` | List of filepath strings or globs to ignore when matching tasks to files. |
+| `--show-advanced` | `boolean`                             | Pair with `--help` to show advanced options.                              |
+| `--through-ref`   | `string`                              | Git ref to start looking for affected files or workspaces                 |
 
 </details>
 

--- a/docs/src/content/docs/plugins/changesets.mdx
+++ b/docs/src/content/docs/plugins/changesets.mdx
@@ -101,7 +101,7 @@ name?: string | string[];
 ## Commands
 
 {/* start-auto-generated-from-cli-changesets */}
-{/* @generated SignedSource<<eaca5e1e4bd2838a3b132dda4e62a75e>> */}
+{/* @generated SignedSource<<aaf3ba825667d217308ab86cd6049c96>> */}
 
 ### `one change`
 
@@ -132,7 +132,6 @@ This command will prompt for appropriate Workspace(s), prompt for the release ty
 | `--add`            | `boolean`, default: `true`      | Add the modified `package.json` files to the git stage for committing.                                              |
 | `--affected`       | `boolean`                       | Select all affected Workspaces. If no other inputs are chosen, this will default to `true`.                         |
 | `--all, -a`        | `boolean`                       | Run across all workspaces                                                                                           |
-| `--show-advanced`  | `boolean`                       | Pair with `--help` to show advanced options.                                                                        |
 | `--type`           | `"major"`, `"minor"`, `"patch"` | Provide a semantic version bump type. If not given, a prompt will guide you through selecting the appropriate type. |
 | `--workspaces, -w` | `array`                         | List of Workspace names to run against                                                                              |
 
@@ -159,10 +158,6 @@ Migrate from Changesets to oneRepo changes.
 ```sh
 one change migrate
 ```
-
-| Option            | Type      | Description                                  |
-| ----------------- | --------- | -------------------------------------------- |
-| `--show-advanced` | `boolean` | Pair with `--help` to show advanced options. |
 
 <details>
 
@@ -194,7 +189,6 @@ For each Workspace, the registry will be queried first to ensure the current ver
 | ------------------ | --------- | ------------------------------------------------------------------------------------------ |
 | `--all, -a`        | `boolean` | Run across all workspaces                                                                  |
 | `--otp`            | `boolean` | Set to true if your publishes require an OTP for NPM.                                      |
-| `--show-advanced`  | `boolean` | Pair with `--help` to show advanced options.                                               |
 | `--skip-auth`      | `boolean` | Skip auth checks. This may be necessary for some internal registries using PATs or tokens. |
 | `--workspaces, -w` | `array`   | List of Workspace names to run against                                                     |
 
@@ -244,7 +238,6 @@ Periodically you may want to publish a _snapshot_ release – something that nee
 | `--allow-dirty`    | `boolean`                         | Bypass checks to ensure no there are no un-committed changes.             |
 | `--otp`            | `boolean`                         | Prompt for one-time password before publishing to the registry            |
 | `--reset`          | `boolean`, default: `true`        | Reset `package.json` changes before exiting. Use `--no-reset` to disable. |
-| `--show-advanced`  | `boolean`                         | Pair with `--help` to show advanced options.                              |
 | `--tag`            | `string`, default: `"prerelease"` | Distribution tag to apply when publishing the pre-release.                |
 | `--workspaces, -w` | `array`                           | List of Workspace names to run against                                    |
 
@@ -263,7 +256,6 @@ one change version
 | `--all, -a`                          | `boolean` | Run across all workspaces                                     |
 | `--allow-dirty`                      | `boolean` | Bypass checks to ensure no there are no un-committed changes. |
 | `--prerelease, --pre, --pre-release` | `string`  | Create a pre-release using the specified identifier.          |
-| `--show-advanced`                    | `boolean` | Pair with `--help` to show advanced options.                  |
 | `--workspaces, -w`                   | `array`   | List of Workspace names to run against                        |
 
 Create a prerelease for the next version the form of `1.2.3-alpha.0`.

--- a/docs/src/content/docs/plugins/docgen.mdx
+++ b/docs/src/content/docs/plugins/docgen.mdx
@@ -145,7 +145,7 @@ Set to true to amend content to the given file using the file.writeSafe | `file.
 ## Commands
 
 {/* start-auto-generated-from-cli-docgen */}
-{/* @generated SignedSource<<b03aeb7a64f69c7d001486004672831e>> */}
+{/* @generated SignedSource<<c77979a5561db0286c41817e5700012c>> */}
 
 ### `one docgen`
 
@@ -167,16 +167,16 @@ Add this command to your one Repo tasks on pre-commit to ensure that your docume
 | `--out-file`      | `string`, default: `"./docs/src/content/docs/plugins/docgen/example.mdx"` | File to write output to. If not provided, stdout will be used              |
 | `--out-workspace` | `string`, default: `"root"`                                               | Workspace name to write the --out-file to                                  |
 | `--safe-write`    | `boolean`, default: `true`                                                | Write documentation to a portion of the file with start and end sentinels. |
-| `--show-advanced` | `boolean`                                                                 | Pair with `--help` to show advanced options.                               |
 
 <details>
 
 <summary>Advanced options</summary>
 
-| Option           | Type      | Description                                                                          |
-| ---------------- | --------- | ------------------------------------------------------------------------------------ |
-| `--command`      | `string`  | Start at the given command, skip the root and any others                             |
-| `--use-defaults` | `boolean` | Use the oneRepo default configuration. Helpful for generating default documentation. |
+| Option            | Type      | Description                                                                          |
+| ----------------- | --------- | ------------------------------------------------------------------------------------ |
+| `--command`       | `string`  | Start at the given command, skip the root and any others                             |
+| `--show-advanced` | `boolean` | Pair with `--help` to show advanced options.                                         |
+| `--use-defaults`  | `boolean` | Use the oneRepo default configuration. Helpful for generating default documentation. |
 
 </details>
 

--- a/docs/src/content/docs/plugins/docgen/example.mdx
+++ b/docs/src/content/docs/plugins/docgen/example.mdx
@@ -12,7 +12,7 @@ The following content is auto-generated using the [official documentation plugin
 :::
 
 {/* start-auto-generated-from-cli */}
-{/* @generated SignedSource<<56492a8f42fe375bcc1f00eb3ab96597>> */}
+{/* @generated SignedSource<<87a5011d7c705a56261716333d653a0f>> */}
 
 ## `one`
 
@@ -22,11 +22,9 @@ one <command> [options]
 
 | Option            | Type                  | Description                                                                                                                            |
 | ----------------- | --------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
-| `--0.16.0`        | `boolean`             | Show this CLI’s version number                                                                                                         |
 | `--dry-run`       | `boolean`             | Run without actually making modifications or destructive operations                                                                    |
-| `--show-advanced` | `boolean`             | Pair with `--help` to show advanced options.                                                                                           |
 | `--verbosity, -v` | `count`, default: `2` | Set the verbosity of the script output. Increase verbosity with `-vvv`, `-vvvv`, or `-vvvvv`. Reduce verbosity with `-v` or `--silent` |
-| ``                | ``                    | Show the oneRepo CLI version.                                                                                                          |
+| `--version`       | `boolean`             | Show the oneRepo CLI version.                                                                                                          |
 
 <details>
 
@@ -35,6 +33,7 @@ one <command> [options]
 | Option                | Type      | Description                                                                                     |
 | --------------------- | --------- | ----------------------------------------------------------------------------------------------- |
 | `--help, -h`          | `boolean` | Show this help screen                                                                           |
+| `--show-advanced`     | `boolean` | Pair with `--help` to show advanced options.                                                    |
 | `--silent`            | `boolean` | Silence all output from the logger. Effectively sets verbosity to 0.                            |
 | `--skip-engine-check` | `boolean` | Skip the engines check, which ensures the current Node.js version is within the expected range. |
 
@@ -54,7 +53,6 @@ one build [options]
 | ------------------ | --------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `--affected`       | `boolean` | Select all affected Workspaces. If no other inputs are chosen, this will default to `true`.                                                                                 |
 | `--all, -a`        | `boolean` | Run across all workspaces                                                                                                                                                   |
-| `--show-advanced`  | `boolean` | Pair with `--help` to show advanced options.                                                                                                                                |
 | `--staged`         | `boolean` | Use files on the git stage to calculate affected files or Workspaces. When unset or `--no-staged`, changes will be calculated from the entire branch, since its fork point. |
 | `--workspaces, -w` | `array`   | List of Workspace names to run against                                                                                                                                      |
 
@@ -118,7 +116,6 @@ This command will prompt for appropriate Workspace(s), prompt for the release ty
 | `--add`            | `boolean`, default: `true`      | Add the modified `package.json` files to the git stage for committing.                                              |
 | `--affected`       | `boolean`                       | Select all affected Workspaces. If no other inputs are chosen, this will default to `true`.                         |
 | `--all, -a`        | `boolean`                       | Run across all workspaces                                                                                           |
-| `--show-advanced`  | `boolean`                       | Pair with `--help` to show advanced options.                                                                        |
 | `--type`           | `"major"`, `"minor"`, `"patch"` | Provide a semantic version bump type. If not given, a prompt will guide you through selecting the appropriate type. |
 | `--workspaces, -w` | `array`                         | List of Workspace names to run against                                                                              |
 
@@ -145,10 +142,6 @@ Migrate from Changesets to oneRepo changes.
 ```sh
 one change migrate
 ```
-
-| Option            | Type      | Description                                  |
-| ----------------- | --------- | -------------------------------------------- |
-| `--show-advanced` | `boolean` | Pair with `--help` to show advanced options. |
 
 <details>
 
@@ -180,7 +173,6 @@ For each Workspace, the registry will be queried first to ensure the current ver
 | ------------------ | --------- | ------------------------------------------------------------------------------------------ |
 | `--all, -a`        | `boolean` | Run across all workspaces                                                                  |
 | `--otp`            | `boolean` | Set to true if your publishes require an OTP for NPM.                                      |
-| `--show-advanced`  | `boolean` | Pair with `--help` to show advanced options.                                               |
 | `--skip-auth`      | `boolean` | Skip auth checks. This may be necessary for some internal registries using PATs or tokens. |
 | `--workspaces, -w` | `array`   | List of Workspace names to run against                                                     |
 
@@ -230,7 +222,6 @@ Periodically you may want to publish a _snapshot_ release – something that nee
 | `--allow-dirty`    | `boolean`                         | Bypass checks to ensure no there are no un-committed changes.             |
 | `--otp`            | `boolean`                         | Prompt for one-time password before publishing to the registry            |
 | `--reset`          | `boolean`, default: `true`        | Reset `package.json` changes before exiting. Use `--no-reset` to disable. |
-| `--show-advanced`  | `boolean`                         | Pair with `--help` to show advanced options.                              |
 | `--tag`            | `string`, default: `"prerelease"` | Distribution tag to apply when publishing the pre-release.                |
 | `--workspaces, -w` | `array`                           | List of Workspace names to run against                                    |
 
@@ -249,7 +240,6 @@ one change version
 | `--all, -a`                          | `boolean` | Run across all workspaces                                     |
 | `--allow-dirty`                      | `boolean` | Bypass checks to ensure no there are no un-committed changes. |
 | `--prerelease, --pre, --pre-release` | `string`  | Create a pre-release using the specified identifier.          |
-| `--show-advanced`                    | `boolean` | Pair with `--help` to show advanced options.                  |
 | `--workspaces, -w`                   | `array`   | List of Workspace names to run against                        |
 
 Create a prerelease for the next version the form of `1.2.3-alpha.0`.
@@ -280,10 +270,9 @@ Sync code owners from Workspace configurations to the repository’s CODEOWNERS 
 one codeowners sync
 ```
 
-| Option            | Type      | Description                                       |
-| ----------------- | --------- | ------------------------------------------------- |
-| `--add`           | `boolean` | Add the updated CODEOWNERS file to the git stage. |
-| `--show-advanced` | `boolean` | Pair with `--help` to show advanced options.      |
+| Option  | Type      | Description                                       |
+| ------- | --------- | ------------------------------------------------- |
+| `--add` | `boolean` | Add the updated CODEOWNERS file to the git stage. |
 
 <details>
 
@@ -304,10 +293,6 @@ Verify the CODEOWNERS file is up to date and unmodified.
 ```sh
 one codeowners verify
 ```
-
-| Option            | Type      | Description                                  |
-| ----------------- | --------- | -------------------------------------------- |
-| `--show-advanced` | `boolean` | Pair with `--help` to show advanced options. |
 
 <details>
 
@@ -354,7 +339,6 @@ Otherwise, the latest version will be requested from the registry.
 | `--dev, -d`        | `array`                                            | Add dependencies for development purposes only.                                                                                        |
 | `--mode`           | `"strict"`, `"loose"`, `"off"`, default: `"loose"` | Version selection mode. Use `strict` to use strict version numbers, `loose` to use caret (`^`) ranges, and `off` for nothing specific. |
 | `--prod, -p`       | `array`                                            | Add dependencies for production purposes.                                                                                              |
-| `--show-advanced`  | `boolean`                                          | Pair with `--help` to show advanced options.                                                                                           |
 | `--workspaces, -w` | `array`                                            | One or more Workspaces to add dependencies into                                                                                        |
 
 Install the latest version of `normalizr` from the registry, using a strict version number.
@@ -390,7 +374,6 @@ one dependencies remove -w [workspaces...] -d [dependencies...] [options...]
 | `--all, -a`          | `boolean`                  | Run across all workspaces                                                 |          |
 | `--dedupe`           | `boolean`, default: `true` | Deduplicate dependencies across the repository after install is complete. |          |
 | `--dependencies, -d` | `array`                    | Dependency names that should be removed.                                  | ✅       |
-| `--show-advanced`    | `boolean`                  | Pair with `--help` to show advanced options.                              |          |
 | `--workspaces, -w`   | `array`                    | List of Workspace names to run against                                    |          |
 
 ---
@@ -413,7 +396,6 @@ Dependencies across Workspaces can be validated using one of the various modes:
 | ------------------ | -------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `--all, -a`        | `boolean`                                          | Run across all workspaces                                                                                                                                     |
 | `--mode`           | `"strict"`, `"loose"`, `"off"`, default: `"loose"` | Version selection mode. Use `strict` to use exact version matches, `loose` to accept within defined ranges (`^` or `~` range), and `off` for no verification. |
-| `--show-advanced`  | `boolean`                                          | Pair with `--help` to show advanced options.                                                                                                                  |
 | `--workspaces, -w` | `array`                                            | List of Workspace names to run against                                                                                                                        |
 
 ---
@@ -438,7 +420,6 @@ Add this command to your one Repo tasks on pre-commit to ensure that your docume
 | `--out-file`      | `string`, default: `"./docs/src/content/docs/plugins/docgen/example.mdx"` | File to write output to. If not provided, stdout will be used              |
 | `--out-workspace` | `string`, default: `"root"`                                               | Workspace name to write the --out-file to                                  |
 | `--safe-write`    | `boolean`, default: `true`                                                | Write documentation to a portion of the file with start and end sentinels. |
-| `--show-advanced` | `boolean`                                                                 | Pair with `--help` to show advanced options.                               |
 
 <details>
 
@@ -470,7 +451,6 @@ one format [options]
 | `--all, -a`        | `boolean` | Run across all workspaces                                                                                                                                                   |
 | `--check`          | `boolean` | Check for changes.                                                                                                                                                          |
 | `--files, -f`      | `array`   | Determine Workspaces from specific files                                                                                                                                    |
-| `--show-advanced`  | `boolean` | Pair with `--help` to show advanced options.                                                                                                                                |
 | `--staged`         | `boolean` | Use files on the git stage to calculate affected files or Workspaces. When unset or `--no-staged`, changes will be calculated from the entire branch, since its fork point. |
 | `--workspaces, -w` | `array`   | List of Workspace names to run against                                                                                                                                      |
 
@@ -501,10 +481,9 @@ one generate [options]
 
 To create new templates add a new folder to config/templates and create a `.onegen.cjs` configuration file. Follow the instructions online for more: https\://onerepo.tools/plugins/generate/
 
-| Option            | Type      | Description                                                                         |
-| ----------------- | --------- | ----------------------------------------------------------------------------------- |
-| `--show-advanced` | `boolean` | Pair with `--help` to show advanced options.                                        |
-| `--type, -t`      | `string`  | Template type to generate. If not provided, a list will be provided to choose from. |
+| Option       | Type     | Description                                                                         |
+| ------------ | -------- | ----------------------------------------------------------------------------------- |
+| `--type, -t` | `string` | Template type to generate. If not provided, a list will be provided to choose from. |
 
 <details>
 
@@ -546,7 +525,6 @@ Pass `--open` to auto-open your default browser with the URL or use one of the `
 | `--all, -a`        | `boolean`                        | Run across all workspaces                                                                                                                                                   |
 | `--format, -f`     | `"mermaid"`, `"plain"`, `"json"` | Output format for inspecting the Workspace Graph.                                                                                                                           |
 | `--open`           | `boolean`                        | Auto-open the browser for the online visualizer.                                                                                                                            |
-| `--show-advanced`  | `boolean`                        | Pair with `--help` to show advanced options.                                                                                                                                |
 | `--staged`         | `boolean`                        | Use files on the git stage to calculate affected files or Workspaces. When unset or `--no-staged`, changes will be calculated from the entire branch, since its fork point. |
 | `--workspaces, -w` | `array`                          | List of Workspace names to run against                                                                                                                                      |
 
@@ -598,10 +576,9 @@ Dependencies across Workspaces can be validated using one of the various modes:
 - `loose`: Reused third-party dependencies will be required to have semantic version overlap across unique branches of the Graph.
 - `strict`: Versions of all dependencies across each discrete Workspace dependency tree must be strictly equal.
 
-| Option            | Type                                               | Description                                  |
-| ----------------- | -------------------------------------------------- | -------------------------------------------- |
-| `--mode`          | `"strict"`, `"loose"`, `"off"`, default: `"loose"` | Dependency overlap validation method.        |
-| `--show-advanced` | `boolean`                                          | Pair with `--help` to show advanced options. |
+| Option   | Type                                               | Description                           |
+| -------- | -------------------------------------------------- | ------------------------------------- |
+| `--mode` | `"strict"`, `"loose"`, `"off"`, default: `"loose"` | Dependency overlap validation method. |
 
 <details>
 
@@ -633,12 +610,11 @@ Create git hooks
 one hooks create
 ```
 
-| Option            | Type                                                                                                                                                                                                                                                                                                                                                                                                                                          | Description                                                                |
-| ----------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
-| `--add`           | `boolean`, default: `true`                                                                                                                                                                                                                                                                                                                                                                                                                    | Add the hooks to the git stage for committing.                             |
-| `--hook`          | `"applypatch-msg"`, `"pre-applypatch"`, `"post-applypatch"`, `"pre-commit"`, `"pre-merge-commit"`, `"prepare-commit-msg"`, `"commit-msg"`, `"post-commit"`, `"pre-rebase"`, `"post-checkout"`, `"post-merge"`, `"pre-receive"`, `"update"`, `"post-receive"`, `"post-update"`, `"pre-auto-gc"`, `"post-rewrite"`, `"pre-push"`, `"proc-receive"`, `"push-to-checkout"`, default: `["pre-commit","post-checkout","post-merge","post-rewrite"]` | The git hook to create. Omit this option to auto-create recommended hooks. |
-| `--overwrite`     | `boolean`                                                                                                                                                                                                                                                                                                                                                                                                                                     | Overwrite existing hooks                                                   |
-| `--show-advanced` | `boolean`                                                                                                                                                                                                                                                                                                                                                                                                                                     | Pair with `--help` to show advanced options.                               |
+| Option        | Type                                                                                                                                                                                                                                                                                                                                                                                                                                          | Description                                                                |
+| ------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
+| `--add`       | `boolean`, default: `true`                                                                                                                                                                                                                                                                                                                                                                                                                    | Add the hooks to the git stage for committing.                             |
+| `--hook`      | `"applypatch-msg"`, `"pre-applypatch"`, `"post-applypatch"`, `"pre-commit"`, `"pre-merge-commit"`, `"prepare-commit-msg"`, `"commit-msg"`, `"post-commit"`, `"pre-rebase"`, `"post-checkout"`, `"post-merge"`, `"pre-receive"`, `"update"`, `"post-receive"`, `"post-update"`, `"pre-auto-gc"`, `"post-rewrite"`, `"pre-push"`, `"proc-receive"`, `"push-to-checkout"`, default: `["pre-commit","post-checkout","post-merge","post-rewrite"]` | The git hook to create. Omit this option to auto-create recommended hooks. |
+| `--overwrite` | `boolean`                                                                                                                                                                                                                                                                                                                                                                                                                                     | Overwrite existing hooks                                                   |
 
 <details>
 
@@ -662,10 +638,6 @@ Initialize and sync git hook settings for this repository.
 one hooks init
 ```
 
-| Option            | Type      | Description                                  |
-| ----------------- | --------- | -------------------------------------------- |
-| `--show-advanced` | `boolean` | Pair with `--help` to show advanced options. |
-
 <details>
 
 <summary>Advanced options</summary>
@@ -686,12 +658,11 @@ Install the oneRepo CLI into your environment.
 one install [options]
 ```
 
-| Option            | Type                          | Description                                                                                                         |
-| ----------------- | ----------------------------- | ------------------------------------------------------------------------------------------------------------------- |
-| `--force`         | `boolean`                     | Force installation regardless of pre-existing command.                                                              |
-| `--location`      | `string`                      | Install location for the binary. Default location is chosen as default option for usr/bin dependent on the OS type. |
-| `--show-advanced` | `boolean`                     | Pair with `--help` to show advanced options.                                                                        |
-| `--version`       | `string`, default: `"0.16.0"` | Version of oneRepo to install. Defaults to the current version.                                                     |
+| Option       | Type                          | Description                                                                                                         |
+| ------------ | ----------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| `--force`    | `boolean`                     | Force installation regardless of pre-existing command.                                                              |
+| `--location` | `string`                      | Install location for the binary. Default location is chosen as default option for usr/bin dependent on the OS type. |
+| `--version`  | `string`, default: `"0.16.0"` | Version of oneRepo to install. Defaults to the current version.                                                     |
 
 ---
 
@@ -714,7 +685,6 @@ Additionally, any other [Jest CLI options](https://jestjs.io/docs/cli) can be pa
 | `--all, -a`        | `boolean`                  | Run across all workspaces                                                                                                                                                   |
 | `--inspect`        | `boolean`                  | Break for the the Node inspector to debug tests.                                                                                                                            |
 | `--pretty`         | `boolean`, default: `true` | Control Jest’s `--colors` flag.                                                                                                                                             |
-| `--show-advanced`  | `boolean`                  | Pair with `--help` to show advanced options.                                                                                                                                |
 | `--staged`         | `boolean`                  | Use files on the git stage to calculate affected files or Workspaces. When unset or `--no-staged`, changes will be calculated from the entire branch, since its fork point. |
 | `--watch`          | `boolean`                  | Shortcut for jest `--watch` mode.                                                                                                                                           |
 | `--workspaces, -w` | `array`                    | List of Workspace names to run against                                                                                                                                      |
@@ -779,7 +749,6 @@ one lint [options]
 | `--fix`            | `boolean`, default: `true`                                      | Apply auto-fixes if possible                                                                                                                                                |
 | `--pretty`         | `boolean`, default: `true`                                      | Control ESLint’s `--color` flag.                                                                                                                                            |
 | `--quiet`          | `boolean`                                                       | Report errors only                                                                                                                                                          |
-| `--show-advanced`  | `boolean`                                                       | Pair with `--help` to show advanced options.                                                                                                                                |
 | `--staged`         | `boolean`                                                       | Use files on the git stage to calculate affected files or Workspaces. When unset or `--no-staged`, changes will be calculated from the entire branch, since its fork point. |
 | `--workspaces, -w` | `array`                                                         | List of Workspace names to run against                                                                                                                                      |
 
@@ -815,7 +784,6 @@ You can fine-tune the determination of affected Workspaces by providing a `--fro
 | `--lifecycle, -c`   | `"pre-commit"`, `"post-commit"`, `"post-checkout"`, `"pre-merge"`, `"post-merge"`, `"build"`, `"pre-deploy"`, `"pre-publish"`, `"post-publish"` | Task lifecycle to run. All tasks for the given lifecycle will be run as merged parallel tasks, followed by the merged set of serial tasks.       | ✅       |
 | `--list`            | `boolean`                                                                                                                                       | List found tasks. Implies dry run and will not actually run any tasks.                                                                           |          |
 | `--shard`           | `string`                                                                                                                                        | Shard the lifecycle across multiple instances. Format as `<shard-number>/<total-shards>`                                                         |          |
-| `--show-advanced`   | `boolean`                                                                                                                                       | Pair with `--help` to show advanced options.                                                                                                     |          |
 | `--staged`          | `boolean`                                                                                                                                       | Backup unstaged files and use only those on the git stage to calculate affected files or workspaces. Will re-apply the unstaged files upon exit. |          |
 | `--workspaces, -w`  | `array`                                                                                                                                         | List of Workspace names to run against                                                                                                           |          |
 
@@ -865,7 +833,6 @@ Additionally, any other [Vitest CLI options](https://jest.dev/guide/cli.html) ca
 | `--affected`       | `boolean` | Select all affected Workspaces. If no other inputs are chosen, this will default to `true`.                                                                                 |
 | `--all, -a`        | `boolean` | Run across all workspaces                                                                                                                                                   |
 | `--inspect`        | `boolean` | Break for the the Node inspector to debug tests.                                                                                                                            |
-| `--show-advanced`  | `boolean` | Pair with `--help` to show advanced options.                                                                                                                                |
 | `--staged`         | `boolean` | Use files on the git stage to calculate affected files or Workspaces. When unset or `--no-staged`, changes will be calculated from the entire branch, since its fork point. |
 | `--watch`          | `boolean` | Shortcut for vitest `--watch` mode.                                                                                                                                         |
 | `--workspaces, -w` | `array`   | List of Workspace names to run against                                                                                                                                      |
@@ -925,7 +892,6 @@ Checks for the existence of `tsconfig.json` file and batches running `tsc --noEm
 | `--affected`       | `boolean`                  | Select all affected Workspaces. If no other inputs are chosen, this will default to `true`.                                                                                 |
 | `--all, -a`        | `boolean`                  | Run across all workspaces                                                                                                                                                   |
 | `--pretty`         | `boolean`, default: `true` | Control TypeScript’s `--pretty` flag.                                                                                                                                       |
-| `--show-advanced`  | `boolean`                  | Pair with `--help` to show advanced options.                                                                                                                                |
 | `--staged`         | `boolean`                  | Use files on the git stage to calculate affected files or Workspaces. When unset or `--no-staged`, changes will be calculated from the entire branch, since its fork point. |
 | `--workspaces, -w` | `array`                    | List of Workspace names to run against                                                                                                                                      |
 
@@ -977,19 +943,11 @@ Runs commands in the "@onerepo/docs" Workspace.
 
 Run Astro directly.
 
-| Option            | Type      | Description                                  |
-| ----------------- | --------- | -------------------------------------------- |
-| `--show-advanced` | `boolean` | Pair with `--help` to show advanced options. |
-
 ---
 
 ##### `one workspace docs build`
 
 Build the documentation site for production.
-
-| Option            | Type      | Description                                  |
-| ----------------- | --------- | -------------------------------------------- |
-| `--show-advanced` | `boolean` | Pair with `--help` to show advanced options. |
 
 ---
 
@@ -1025,10 +983,6 @@ Update changelogs from source files
 
 Check Astro pages for errors.
 
-| Option            | Type      | Description                                  |
-| ----------------- | --------- | -------------------------------------------- |
-| `--show-advanced` | `boolean` | Pair with `--help` to show advanced options. |
-
 ---
 
 ##### `one workspace docs collect-content`
@@ -1060,10 +1014,6 @@ Generate docs for the oneRepo monorepo
 ##### `one workspace docs start`
 
 Start the Astro dev server.
-
-| Option            | Type      | Description                                  |
-| ----------------- | --------- | -------------------------------------------- |
-| `--show-advanced` | `boolean` | Pair with `--help` to show advanced options. |
 
 ---
 

--- a/plugins/docgen/.changes/014-large-brooms-tease.md
+++ b/plugins/docgen/.changes/014-large-brooms-tease.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+`--show-advanced` will no longer appear in option lists outside of the global command. Other globals will also be removed from sub-commands.

--- a/plugins/docgen/src/yargs.ts
+++ b/plugins/docgen/src/yargs.ts
@@ -426,6 +426,7 @@ export class Yargs {
 		this.option(key, {
 			description: description || 'Show hidden arguments.',
 			type: 'boolean',
+			hidden: true,
 		});
 	}
 
@@ -454,7 +455,7 @@ export class Yargs {
 		if (!name) {
 			return;
 		}
-		this.option(name, { type: 'boolean', description });
+		this.option('version', { type: 'boolean', description });
 	}
 
 	wrap() {}


### PR DESCRIPTION
**Problem:**

`--show-advanced` is showing in every command options table. It's annoying.

**Solution:**

Hide it and other globals except at the root command.
