### PR TITLE
feat(changes): add 'verify' command

### DIFF
--- a/docs/src/content/docs/core/changes.mdx
+++ b/docs/src/content/docs/core/changes.mdx
@@ -245,7 +245,7 @@ Once ready, merge your pull request to your main branch.
 ## Commands
 
 {/* start-auto-generated-from-cli-changes */}
-{/* @generated SignedSource<<aaf3ba825667d217308ab86cd6049c96>> */}
+{/* @generated SignedSource<<2cef7301040e6163ff018e4ad7cf33c3>> */}
 
 ### `one change`
 
@@ -384,6 +384,20 @@ Periodically you may want to publish a _snapshot_ release – something that nee
 | `--reset`          | `boolean`, default: `true`        | Reset `package.json` changes before exiting. Use `--no-reset` to disable. |
 | `--tag`            | `string`, default: `"prerelease"` | Distribution tag to apply when publishing the pre-release.                |
 | `--workspaces, -w` | `array`                           | List of Workspace names to run against                                    |
+
+---
+
+#### `one change verify`
+
+Aliases: `one change required`
+
+Ensure there are change entries for every modified public Workspace.
+
+```sh
+one change verify
+```
+
+Add this to your pre-commit or pre-merge task lifecycles to ensure that changes to public & publishabled Workspaces are always accompanied with change entries.
 
 ---
 

--- a/docs/src/content/docs/core/dependencies.mdx
+++ b/docs/src/content/docs/core/dependencies.mdx
@@ -37,7 +37,7 @@ No configuration necessary! oneRepo automatically detects which package manager 
 </div>
 
 {/* start-auto-generated-from-cli-dependencies */}
-{/* @generated SignedSource<<eb7cde3dc7e557bb584d4f4fcfe20628>> */}
+{/* @generated SignedSource<<c757e7e195c75ac452d0b77c1c7ff85a>> */}
 
 ### `one dependencies`
 
@@ -56,7 +56,7 @@ one dependencies <command> [options...]
 Add dependencies to Workspaces.
 
 ```sh
-one dependencies add -w [workspaces...] --dev [devDependencies...] --prod [prodDependencies...] [options...]
+one dependencies add -w <workspace-names...> --dev [devDependencies...] --prod [prodDependencies...] [options...]
 ```
 
 If a version is not provided with the command-line input, this command will look for currently installed versions of the requested dependencies throughout all Workspaces within the Workspace Graph. If only one version is found, it will be used, regardless of the `--mode` provided.

--- a/docs/src/content/docs/plugins/changesets.mdx
+++ b/docs/src/content/docs/plugins/changesets.mdx
@@ -101,7 +101,7 @@ name?: string | string[];
 ## Commands
 
 {/* start-auto-generated-from-cli-changesets */}
-{/* @generated SignedSource<<aaf3ba825667d217308ab86cd6049c96>> */}
+{/* @generated SignedSource<<2cef7301040e6163ff018e4ad7cf33c3>> */}
 
 ### `one change`
 
@@ -240,6 +240,20 @@ Periodically you may want to publish a _snapshot_ release – something that nee
 | `--reset`          | `boolean`, default: `true`        | Reset `package.json` changes before exiting. Use `--no-reset` to disable. |
 | `--tag`            | `string`, default: `"prerelease"` | Distribution tag to apply when publishing the pre-release.                |
 | `--workspaces, -w` | `array`                           | List of Workspace names to run against                                    |
+
+---
+
+#### `one change verify`
+
+Aliases: `one change required`
+
+Ensure there are change entries for every modified public Workspace.
+
+```sh
+one change verify
+```
+
+Add this to your pre-commit or pre-merge task lifecycles to ensure that changes to public & publishabled Workspaces are always accompanied with change entries.
 
 ---
 

--- a/docs/src/content/docs/plugins/docgen/example.mdx
+++ b/docs/src/content/docs/plugins/docgen/example.mdx
@@ -12,7 +12,7 @@ The following content is auto-generated using the [official documentation plugin
 :::
 
 {/* start-auto-generated-from-cli */}
-{/* @generated SignedSource<<87a5011d7c705a56261716333d653a0f>> */}
+{/* @generated SignedSource<<f75c5064dddcb8228c9fcea0b5e42f1f>> */}
 
 ## `one`
 
@@ -227,6 +227,20 @@ Periodically you may want to publish a _snapshot_ release – something that nee
 
 ---
 
+#### `one change verify`
+
+Aliases: `one change required`
+
+Ensure there are change entries for every modified public Workspace.
+
+```sh
+one change verify
+```
+
+Add this to your pre-commit or pre-merge task lifecycles to ensure that changes to public & publishabled Workspaces are always accompanied with change entries.
+
+---
+
 #### `one change version`
 
 Update version numbers for publishable workspaces
@@ -323,7 +337,7 @@ one dependencies <command> [options...]
 Add dependencies to Workspaces.
 
 ```sh
-one dependencies add -w [workspaces...] --dev [devDependencies...] --prod [prodDependencies...] [options...]
+one dependencies add -w <workspace-names...> --dev [devDependencies...] --prod [prodDependencies...] [options...]
 ```
 
 If a version is not provided with the command-line input, this command will look for currently installed versions of the requested dependencies throughout all Workspaces within the Workspace Graph. If only one version is found, it will be used, regardless of the `--mode` provided.

--- a/modules/onerepo/src/core/changes/__tests__/__fixtures__/with-entries/modules/private/package.json
+++ b/modules/onerepo/src/core/changes/__tests__/__fixtures__/with-entries/modules/private/package.json
@@ -1,0 +1,4 @@
+{
+	"name": "internal-private",
+	"private": true
+}

--- a/modules/onerepo/src/core/changes/index.ts
+++ b/modules/onerepo/src/core/changes/index.ts
@@ -3,6 +3,7 @@ import * as Add from './add';
 import * as Migrate from './migrate';
 import * as Publish from './publish';
 import * as Snapshot from './snapshot';
+import * as Verify from './verify';
 import * as Version from './version';
 
 export const changes: Plugin = function codeowners(config) {
@@ -13,6 +14,7 @@ export const changes: Plugin = function codeowners(config) {
 			const migrate = visitor(Migrate);
 			const publish = visitor(Publish);
 			const snapshot = visitor(Snapshot);
+			const verify = visitor(Verify);
 			const version = visitor(Version);
 
 			return yargs.command(
@@ -39,6 +41,7 @@ export const changes: Plugin = function codeowners(config) {
 						)
 						.command(publish.command, publish.description, publish.builder, publish.handler)
 						.command(snapshot.command, snapshot.description, snapshot.builder, snapshot.handler)
+						.command(verify.command, verify.description, verify.builder, verify.handler)
 						.command(version.command, version.description, version.builder, version.handler)
 						.demandCommand(1);
 

--- a/modules/onerepo/src/core/changes/verify.ts
+++ b/modules/onerepo/src/core/changes/verify.ts
@@ -1,0 +1,47 @@
+import path from 'node:path';
+import { getModifiedFiles } from '@onerepo/git';
+import type { Workspace } from '@onerepo/graph';
+import type { Builder, Handler } from '@onerepo/yargs';
+
+export const command = ['verify', 'required'];
+
+export const description = 'Ensure there are change entries for every modified public Workspace.';
+
+export const builder: Builder = (yargs) =>
+	yargs
+		.usage(`$0 ${command[0]}`)
+		.epilogue(
+			'Add this to your pre-commit or pre-merge task lifecycles to ensure that changes to public & publishabled Workspaces are always accompanied with change entries.',
+		);
+
+export const handler: Handler = async (argv, { graph, logger }) => {
+	const files = await getModifiedFiles();
+
+	const hasEntry = new Set<Workspace>();
+	const workspaces = new Set<Workspace>();
+
+	for (const filepath of files) {
+		const fullFilepath = path.join(graph.root.resolve(filepath));
+		const ws = graph.getByLocation(fullFilepath);
+		if (ws.private) {
+			continue;
+		}
+
+		workspaces.add(ws);
+		if (fullFilepath.startsWith(ws.resolve('.changes'))) {
+			hasEntry.add(ws);
+		}
+	}
+
+	const missing = new Set<Workspace>();
+	for (const workspace of workspaces) {
+		if (!hasEntry.has(workspace)) {
+			logger.error(`Workspace "${workspace.name}" is missing a required change entry.`);
+			missing.add(workspace);
+		}
+	}
+
+	if (logger.hasError) {
+		logger.error(`\u0000\nAdd change entries to continue:\n\n  $ one change add\n\u0000`);
+	}
+};

--- a/modules/onerepo/src/core/dependencies/add.ts
+++ b/modules/onerepo/src/core/dependencies/add.ts
@@ -22,7 +22,7 @@ type Args = {
 
 export const builder: Builder<Args> = (yargs) =>
 	withWorkspaces(yargs)
-		.usage('$0 add -w [workspaces...] --dev [devDependencies...] --prod [prodDependencies...] [options...]')
+		.usage('$0 add -w <workspace-names...> --dev [devDependencies...] --prod [prodDependencies...] [options...]')
 		.describe('workspaces', 'One or more Workspaces to add dependencies into')
 		.demandOption('workspaces')
 		.option('dedupe', {


### PR DESCRIPTION
**Problem:**

Some workflows will benefit from enforcing change entries are always present along with changes.

**Solution:**

Add `one change verify` to ensure every modified public/publishable Workspace includes change entries.

**Related issues:**

Fixes #537
