### PR TITLE
feat: warn on installed version mismatch

### DIFF
--- a/modules/onerepo/.changes/015-forty-chefs-tell.md
+++ b/modules/onerepo/.changes/015-forty-chefs-tell.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+When installed to the global path, a shutdown check will run comparing the global vs local version. If there is a mismatch, a warning will be prominently displayed prompting to fix the issue.

--- a/modules/onerepo/src/bin/one.ts
+++ b/modules/onerepo/src/bin/one.ts
@@ -4,6 +4,7 @@ import { createRequire } from 'node:module';
 import initJiti from 'jiti';
 import createYargs from 'yargs/yargs';
 import { Graph, internalSetup, noRepoPlugins } from '..';
+import pkg from '../../package.json';
 import { updateNodeModules } from './utils/update-node-modules';
 import { getConfig } from './utils/get-config';
 
@@ -21,6 +22,9 @@ process.emitWarning = (warning, ...args) => {
 	// @ts-ignore
 	emitWarning(warning, ...args);
 };
+
+// @ts-ignore cannot use symbol on global in ts
+globalThis[Symbol.for('onerepo_installed_version')] = pkg.version;
 
 export const jiti = initJiti(process.cwd(), { interopDefault: true });
 
@@ -68,7 +72,7 @@ async function getSetupAndRun() {
 		process.stderr.write(`${'='.repeat(Math.min(process.stderr.columns, 120))}
   Unable to configure oneRepo in your working directory (${configRoot});
   Check your configuration & commands for syntax errors and ensure node_modules are installed.
-${'-'.repeat(Math.min(process.stderr.columns, 120))}
+${'⎯'.repeat(Math.min(process.stderr.columns, 120))}
 
   ${e?.toString().replace(/\n/g, '\n  ')}
 

--- a/modules/onerepo/src/core/install/index.ts
+++ b/modules/onerepo/src/core/install/index.ts
@@ -1,4 +1,7 @@
+import { getLogger } from '@onerepo/logger';
+import { eq, gt, lt } from 'semver';
 import type { Plugin } from '../../types';
+import pkg from '../../../package.json';
 import * as cmd from './install';
 
 export const install: Plugin = function install() {
@@ -11,6 +14,55 @@ export const install: Plugin = function install() {
 				(yargs) => builder(yargs).usage(`$0 ${command} [options...]`),
 				handler,
 			);
+		},
+
+		shutdown: async () => {
+			const sym = Symbol.for('onerepo_installed_version');
+			if (!(sym in globalThis)) {
+				return;
+			}
+
+			const localVersion = pkg.version;
+			// @ts-ignore
+			const installedVersion = globalThis[sym] as string;
+
+			if (eq(installedVersion, localVersion)) {
+				return;
+			}
+
+			const logger = getLogger();
+			const oVerbosity = logger.verbosity;
+			logger.verbosity = 2;
+			const step = logger.createStep('Version mismatch detected!');
+
+			const bar = '⎯'.repeat(Math.min(process.stderr.columns, 70));
+			if (
+				// @ts-ignore
+				gt(installedVersion, localVersion)
+			) {
+				step.warn(`${bar}
+Globally installed version of the oneRepo CLI (${installedVersion})
+is newer than the version in this monorepo (${localVersion}).
+
+For the optimal experience, update your local dependency to
+${installedVersion} or newer.
+${bar}`);
+			}
+
+			if (lt(installedVersion, localVersion)) {
+				step.warn(`${bar}
+Globally installed version of the oneRepo CLI (${installedVersion})
+is older than the local version in this monorepo (${localVersion}).
+
+For the optimal experience, update the global version by re-installing:
+${bar}
+
+  $ one install
+
+${bar}`);
+			}
+			await step.end();
+			logger.verbosity = oVerbosity;
 		},
 	};
 };


### PR DESCRIPTION
**Problem:**

It would be great to ensure that the installed version of the oneRepo CLI is up to date and matches the version used in the monorepo.

**Solution:**

Give a warning when the versions mismatch.

```
 ┌ Version mismatch detected!
 │ WRN ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯
 │ WRN Globally installed version of the oneRepo CLI (0.15.0)
 │ WRN is older than the local version in this monorepo (0.16.0).
 │ WRN
 │ WRN For the optimal experience, update the global version by re-installing:
 │ WRN ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯
 │ WRN
 │ WRN   $ one install
 │ WRN
 │ WRN ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯
 └ ✔ 0ms
```

```
 ┌ Version mismatch detected!
 │ WRN ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯
 │ WRN Globally installed version of the oneRepo CLI (0.17.0)
 │ WRN is newer than the version in this monorepo (0.16.0).
 │ WRN
 │ WRN For the optimal experience, update your local dependency to
 │ WRN 0.17.0 or newer.
 │ WRN ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯
 └ ✔ 0ms
```

**Alternatives:**

- We might check `npm info onerepo` to see if there's a new version. Some other tools do this as well, but I'd like to avoid too much over-eager prompting to stay up to date.
- If global version is less than local version, we might consider auto-installing – which will require a bit of extra work to thread through the install location and have fairly good error handling if the install fails (or just silently? but we don't want to continually try this if it's failing)