### PR TITLE
fix(core): don't fail change verify when versioning

### DIFF
--- a/modules/onerepo/.changes/019-crazy-hairs-ask.md
+++ b/modules/onerepo/.changes/019-crazy-hairs-ask.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+`one change verify` will not fail if only `CHANGELOG.md` or `package.json`+`CHANGELOG.md` are modified.

--- a/modules/onerepo/src/core/changes/__tests__/verify.test.ts
+++ b/modules/onerepo/src/core/changes/__tests__/verify.test.ts
@@ -31,4 +31,22 @@ describe('verify', () => {
 
 		await expect(run()).resolves.toBeTruthy();
 	});
+
+	test('does not fail for changelog changes', async () => {
+		vi.spyOn(git, 'getModifiedFiles').mockResolvedValue(['modules/cheese/CHANGELOG.md']);
+
+		await expect(run()).resolves.toBeTruthy();
+	});
+
+	test('does not fail for changelog+package.json changes', async () => {
+		vi.spyOn(git, 'getModifiedFiles').mockResolvedValue(['modules/cheese/CHANGELOG.md', 'modules/cheese/package.json']);
+
+		await expect(run()).resolves.toBeTruthy();
+	});
+
+	test('fails for package.json changes', async () => {
+		vi.spyOn(git, 'getModifiedFiles').mockResolvedValue(['modules/cheese/package.json']);
+
+		await expect(run()).rejects.toMatch('Workspace "cheese" is missing a required change entry.');
+	});
 });


### PR DESCRIPTION
**Problem:**

Trying to version packages, I got caught by `change verify` failing.

**Solution:**

Don't fail if only `CHANGELOG.md` or `CHANGELOG.md` AND `package.json` are the only modified files.
