### PR TITLE
fix(package-manager): pre-release publish tags

### DIFF
--- a/docs/src/content/docs/api/index.md
+++ b/docs/src/content/docs/api/index.md
@@ -8,7 +8,7 @@ oneRepo is in currently in public beta. Some APIs may not be specifically necess
 :::
 
 <!-- start-onerepo-sentinel -->
-<!-- @generated SignedSource<<63a0d106fb1ccba8d572719e83079db8>> -->
+<!-- @generated SignedSource<<860edfabf2c6cf6a9cc8b1f7425c7f99>> -->
 
 ## Namespaces
 
@@ -2995,7 +2995,7 @@ It is important to ensure every command passed through the `visitor` to enable a
 ### batch()
 
 ```ts
-batch(processes): Promise<([string, string] | Error)[]>
+batch(processes, options?): Promise<([string, string] | Error)[]>
 ```
 
 Batch multiple subprocesses, similar to `Promise.all`, but only run as many processes at a time fulfilling N-1 cores. If there are more processes than cores, as each process finishes, a new process will be picked to run, ensuring maximum CPU usage at all times.
@@ -3023,6 +3023,7 @@ expect(results).toEqual([
 | Parameter   | Type                                                   |
 | :---------- | :----------------------------------------------------- |
 | `processes` | ([`RunSpec`](#runspec) \| [`PromiseFn`](#promisefn))[] |
+| `options`?  | [`BatchOptions`](#batchoptions)                        |
 
 **Returns:** `Promise`\<([`string`, `string`] \| `Error`)[]\>
 
@@ -3320,11 +3321,37 @@ Create .stack property on a target object
 
 ---
 
+### BatchOptions
+
+```ts
+type BatchOptions: {
+  maxParallel: number;
+};
+```
+
+Options for running [`batch()`](#batch-1) subprocesses.
+
+#### Type declaration
+
+##### maxParallel?
+
+```ts
+optional maxParallel: number;
+```
+
+**Default:** ```ts
+{number of CPUs - 1}
+
+````
+
+**Source:** [modules/subprocess/src/index.ts](https://github.com/paularmstrong/onerepo/blob/main/modules/subprocess/src/index.ts)
+***
+
 ### PromiseFn
 
 ```ts
 type PromiseFn: () => Promise<[string, string]>;
-```
+````
 
 **Returns:** `Promise`\<[`string`, `string`]\>  
 **Source:** [modules/subprocess/src/index.ts](https://github.com/paularmstrong/onerepo/blob/main/modules/subprocess/src/index.ts)

--- a/docs/src/content/docs/api/index.md
+++ b/docs/src/content/docs/api/index.md
@@ -8,7 +8,7 @@ oneRepo is in currently in public beta. Some APIs may not be specifically necess
 :::
 
 <!-- start-onerepo-sentinel -->
-<!-- @generated SignedSource<<860edfabf2c6cf6a9cc8b1f7425c7f99>> -->
+<!-- @generated SignedSource<<d2155186502a348d6691838f52d6b7a9>> -->
 
 ## Namespaces
 
@@ -2600,7 +2600,7 @@ Get the package manager for the current working directory with _some_ confidence
 
 ### PackageManager
 
-Implementation details for all package managers. This interface defines a subset of common methods typically needed when interacting with a monorepo and its dependency [`Graph`](#graph) & graph.Workspace | `graph.Workspace`s.
+Implementation details for all package managers. This interface defines a subset of common methods typically needed when interacting with a monorepo and its dependency [`Graph`](#graph) & [`Workspace`](#workspace)s.
 
 #### Methods
 
@@ -2711,7 +2711,7 @@ Check if the current user is logged in to the external registry
 ##### publish()
 
 ```ts
-publish<T>(opts?): Promise<void>
+publish<T>(opts): Promise<void>
 ```
 
 Publish Workspaces to the external registry
@@ -2724,14 +2724,14 @@ Publish Workspaces to the external registry
 
 **Parameters:**
 
-| Parameter          | Type                         | Description                                                                                                                                                                              |
-| :----------------- | :--------------------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `opts`?            | `Object`                     | -                                                                                                                                                                                        |
-| `opts.access`?     | `"restricted"` \| `"public"` | Set the registry access level for the package<br /><br />**Default**<br />inferred from Workspaces `publishConfig.access` or `'public'`                                                  |
-| `opts.cwd`?        | `string`                     | Command working directory. Defaults to the repository root.                                                                                                                              |
-| `opts.otp`?        | `string`                     | This is a one-time password from a two-factor authenticator.                                                                                                                             |
-| `opts.tag`?        | `string`                     | If you ask npm to install a package and don't tell it a specific version, then it will install the specified tag.<br /><br />**Default**<br />`'latest'`                                 |
-| `opts.workspaces`? | `T`[]                        | Workspaces to publish. If not provided or empty array, only the given Workspace at `cwd` will be published. This type is generally compatible with graph.Workspace \| `graph.Workspace`. |
+| Parameter         | Type                         | Description                                                                                                                                                                   |
+| :---------------- | :--------------------------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `opts`            | `Object`                     | -                                                                                                                                                                             |
+| `opts.access`?    | `"restricted"` \| `"public"` | Set the registry access level for the package<br /><br />**Default**<br />inferred from Workspaces `publishConfig.access` or `'public'`                                       |
+| `opts.cwd`?       | `string`                     | Command working directory. Defaults to the repository root.                                                                                                                   |
+| `opts.otp`?       | `string`                     | This is a one-time password from a two-factor authenticator.                                                                                                                  |
+| `opts.tag`?       | `string`                     | If you ask npm to install a package and don't tell it a specific version, then it will install the specified tag.<br /><br />**Default**<br />`'latest'`                      |
+| `opts.workspaces` | `T`[]                        | Workspaces to publish. If not provided or empty array, only the given Workspace at `cwd` will be published. This type is generally compatible with [`Workspace`](#workspace). |
 
 **Returns:** `Promise`\<`void`\>  
 **Source:** [modules/package-manager/src/methods.ts](https://github.com/paularmstrong/onerepo/blob/main/modules/package-manager/src/methods.ts)
@@ -2752,9 +2752,9 @@ Filter Workspaces to the set of those that are actually publishable. This will c
 
 **Parameters:**
 
-| Parameter    | Type  | Description                                                      |
-| :----------- | :---- | :--------------------------------------------------------------- |
-| `workspaces` | `T`[] | List of compatible graph.Workspace \| `graph.Workspace` objects. |
+| Parameter    | Type  | Description                                           |
+| :----------- | :---- | :---------------------------------------------------- |
+| `workspaces` | `T`[] | List of compatible [`Workspace`](#workspace) objects. |
 
 **Returns:** `Promise`\<`T`[]\>  
 **Source:** [modules/package-manager/src/methods.ts](https://github.com/paularmstrong/onerepo/blob/main/modules/package-manager/src/methods.ts)
@@ -3339,19 +3339,18 @@ Options for running [`batch()`](#batch-1) subprocesses.
 optional maxParallel: number;
 ```
 
-**Default:** ```ts
-{number of CPUs - 1}
+The absolute maximum number of subprocesses to batch. This amount will always be limited by the number of CPUs/cores available on the current machine.
 
-````
-
+**Default:** `deterministic` Number of CPUs - 1  
 **Source:** [modules/subprocess/src/index.ts](https://github.com/paularmstrong/onerepo/blob/main/modules/subprocess/src/index.ts)
-***
+
+---
 
 ### PromiseFn
 
 ```ts
 type PromiseFn: () => Promise<[string, string]>;
-````
+```
 
 **Returns:** `Promise`\<[`string`, `string`]\>  
 **Source:** [modules/subprocess/src/index.ts](https://github.com/paularmstrong/onerepo/blob/main/modules/subprocess/src/index.ts)

--- a/modules/onerepo/.changes/000-cyan-plants-greet.md
+++ b/modules/onerepo/.changes/000-cyan-plants-greet.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+Adds option `maxParallel` to `batch()` processes to manually control the maximum number of parallel subprocesses to run. This number will still be limited by the number of CPU cores available.

--- a/modules/onerepo/.changes/001-major-zoos-wait.md
+++ b/modules/onerepo/.changes/001-major-zoos-wait.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+Prevents auto-adding `latest` as the dist-tag when publishing workspaces when their versions have pre-release suffixes.

--- a/modules/package-manager/.changes/000-major-zoos-wait.md
+++ b/modules/package-manager/.changes/000-major-zoos-wait.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+Prevents auto-adding `latest` as the dist-tag when publishing workspaces when their versions have pre-release suffixes.

--- a/modules/package-manager/package.json
+++ b/modules/package-manager/package.json
@@ -24,7 +24,8 @@
 		"./CHANGELOG.md"
 	],
 	"dependencies": {
-		"@onerepo/subprocess": "1.0.0-beta.0"
+		"@onerepo/subprocess": "1.0.0-beta.0",
+		"semver": "^7.5.4"
 	},
 	"devDependencies": {
 		"@internal/tsconfig": "workspace:^",

--- a/modules/package-manager/src/methods.ts
+++ b/modules/package-manager/src/methods.ts
@@ -1,7 +1,7 @@
 import type { RunSpec } from '@onerepo/subprocess';
 
 /**
- * Implementation details for all package managers. This interface defines a subset of common methods typically needed when interacting with a monorepo and its dependency {@link Graph | `Graph`} & {@link graph.Workspace | `graph.Workspace`}s.
+ * Implementation details for all package managers. This interface defines a subset of common methods typically needed when interacting with a monorepo and its dependency {@link Graph | `Graph`} & {@link Workspace | `Workspace`}s.
  *
  * @group Package management
  */
@@ -65,18 +65,18 @@ export interface PackageManager {
 
 	/**
 	 * Filter Workspaces to the set of those that are actually publishable. This will check both whether the package is not marked as "private" and if the current version is not in the external registry.
-	 * @param workspaces List of compatible {@link graph.Workspace | `graph.Workspace`} objects.
+	 * @param workspaces List of compatible {@link Workspace | `Workspace`} objects.
 	 */
 	publishable<T extends MinimalWorkspace>(workspaces: Array<T>): Promise<Array<T>>;
 
 	/**
 	 * Publish Workspaces to the external registry
 	 */
-	publish<T extends MinimalWorkspace>(opts?: {
+	publish<T extends MinimalWorkspace>(opts: {
 		/**
-		 * Workspaces to publish. If not provided or empty array, only the given Workspace at `cwd` will be published. This type is generally compatible with {@link graph.Workspace | `graph.Workspace`}.
+		 * Workspaces to publish. If not provided or empty array, only the given Workspace at `cwd` will be published. This type is generally compatible with {@link Workspace | `Workspace`}.
 		 */
-		workspaces?: Array<T>;
+		workspaces: Array<T>;
 		/**
 		 * Set the registry access level for the package
 		 * @default inferred from Workspaces `publishConfig.access` or `'public'`

--- a/modules/subprocess/.changes/000-cyan-plants-greet.md
+++ b/modules/subprocess/.changes/000-cyan-plants-greet.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+Adds option `maxParallel` to `batch()` processes to manually control the maximum number of parallel subprocesses to run. This number will still be limited by the number of CPU cores available.

--- a/modules/subprocess/src/index.ts
+++ b/modules/subprocess/src/index.ts
@@ -317,7 +317,9 @@ export async function sudo(options: Omit<RunSpec, 'opts'> & { reason?: string })
  */
 export type BatchOptions = {
 	/**
-	 * @default {number of CPUs - 1}
+	 * The absolute maximum number of subprocesses to batch. This amount will always be limited by the number of CPUs/cores available on the current machine.
+	 *
+	 * @default `deterministic` Number of CPUs - 1
 	 */
 	maxParallel?: number;
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2879,6 +2879,7 @@ __metadata:
     "@internal/tsconfig": "workspace:^"
     "@internal/vitest-config": "workspace:^"
     "@onerepo/subprocess": 1.0.0-beta.0
+    semver: ^7.5.4
     typescript: ^5.3.3
   languageName: unknown
   linkType: soft
@@ -16457,7 +16458,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss@npm:^8.4.14, postcss@npm:^8.4.21, postcss@npm:^8.4.23, postcss@npm:^8.4.32, postcss@npm:^8.4.35":
+"postcss@npm:^8.4.14, postcss@npm:^8.4.21, postcss@npm:^8.4.23, postcss@npm:^8.4.35":
   version: 8.4.35
   resolution: "postcss@npm:8.4.35"
   dependencies:
@@ -20310,47 +20311,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vite@npm:^5.0.0":
-  version: 5.0.12
-  resolution: "vite@npm:5.0.12"
-  dependencies:
-    esbuild: ^0.19.3
-    fsevents: ~2.3.3
-    postcss: ^8.4.32
-    rollup: ^4.2.0
-  peerDependencies:
-    "@types/node": ^18.0.0 || >=20.0.0
-    less: "*"
-    lightningcss: ^1.21.0
-    sass: "*"
-    stylus: "*"
-    sugarss: "*"
-    terser: ^5.4.0
-  dependenciesMeta:
-    fsevents:
-      optional: true
-  peerDependenciesMeta:
-    "@types/node":
-      optional: true
-    less:
-      optional: true
-    lightningcss:
-      optional: true
-    sass:
-      optional: true
-    stylus:
-      optional: true
-    sugarss:
-      optional: true
-    terser:
-      optional: true
-  bin:
-    vite: bin/vite.js
-  checksum: b97b6f1c204d9091d0973626827a6e9d8e8b1959ebd0877b6f76e7068e1e7adf9ecd3b1cc382cbab9d421e3eeca5e1a95f27f9c1734439b229f5a58ef2052fa4
-  languageName: node
-  linkType: hard
-
-"vite@npm:^5.1.2":
+"vite@npm:^5.0.0, vite@npm:^5.1.2":
   version: 5.1.3
   resolution: "vite@npm:5.1.3"
   dependencies:


### PR DESCRIPTION
**Problem:**

Publishing a `v1.0.0-beta.0` exposed an issue where `one change publish` added the dist-tag `latest`, despite it being a `beta` release.

**Solution:**

Rework the package-manager `publish()` function to:

1. Require `workspaces`
2. Use each workspace's version to determine what the tag should be, falling back on `latest` or the input `tag` option.

**Related issues:**

Fixes #622 

**Checklist:**

- [x] Added or updated tests
- [ ] Added or updated documentation
- [x] Ensured the pre-commit hooks ran successfully
