### PR TITLE
fix(logger): use pipes instead of listeners

### DIFF
--- a/modules/logger/.changes/000-ready-phones-grab.md
+++ b/modules/logger/.changes/000-ready-phones-grab.md
@@ -1,0 +1,12 @@
+---
+type: patch
+---
+
+Prevents an EventEmitter memory leak stemming from the logger's internal `LogBuffer` by piping streams instead of adding and removing listeners.
+
+Previously, you may experience the following error when receiving a lot of output from subprocesses (particularly eslint):
+
+```
+(node:30394) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 data listeners added to [LogBuffer]. Use emitter.setMaxListeners() to increase limit
+(Use `node --trace-warnings ...` to show where the warning was created)
+```

--- a/modules/logger/src/__tests__/LogStep.test.ts
+++ b/modules/logger/src/__tests__/LogStep.test.ts
@@ -2,15 +2,6 @@ import { PassThrough } from 'node:stream';
 import pc from 'picocolors';
 import { LogStep } from '../LogStep';
 
-async function waitStreamEnd(stream: PassThrough) {
-	return new Promise<void>((resolve) => {
-		stream.on('end', () => {
-			resolve();
-		});
-		stream.end();
-	});
-}
-
 describe('LogStep', () => {
 	let runId: string | undefined;
 
@@ -56,7 +47,6 @@ describe('LogStep', () => {
 		step.log('hello');
 		await step.end();
 		await step.flush();
-		await waitStreamEnd(stream);
 
 		expect(out).toMatch(/^::group::tacos\n/);
 		expect(out).toMatch(/::endgroup::\n$/);
@@ -77,7 +67,6 @@ describe('LogStep', () => {
 		step.activate();
 		await step.end();
 		await step.flush();
-		await waitStreamEnd(stream);
 
 		expect(out).toEqual(
 			` ┌ tacos
@@ -132,8 +121,6 @@ describe('LogStep', () => {
 		if (verbosity === 0) {
 			stream.end();
 		}
-
-		await waitStreamEnd(stream);
 
 		for (const [method, str] of Object.entries(logs)) {
 			// @ts-ignore
@@ -190,7 +177,6 @@ describe('LogStep', () => {
 		step.activate();
 		await step.end();
 		await step.flush();
-		await waitStreamEnd(stream);
 
 		expect(out).toMatch(exp);
 	});
@@ -213,7 +199,6 @@ describe('LogStep', () => {
 		step.activate();
 		await step.end();
 		await step.flush();
-		await waitStreamEnd(stream);
 
 		expect(out).toEqual(` ┌ tacos
  │error

--- a/modules/logger/src/index.ts
+++ b/modules/logger/src/index.ts
@@ -93,18 +93,15 @@ export function bufferSubLogger(step: LogStep): { logger: Logger; end: () => Pro
 	const buffer = new LogBuffer();
 	const subLogger = new Logger({ verbosity: logger.verbosity, stream: buffer });
 	function proxyChunks(chunk: Buffer) {
-		if (!step.writable) {
-			return;
-		}
-		if (subLogger.hasError && logger.verbosity >= 1) {
+		if (subLogger.hasError) {
 			step.error(() => chunk.toString().trimEnd());
-		} else if (subLogger.hasInfo && logger.verbosity >= 1) {
+		} else if (subLogger.hasInfo) {
 			step.info(() => chunk.toString().trimEnd());
-		} else if (subLogger.hasWarning && logger.verbosity >= 2) {
+		} else if (subLogger.hasWarning) {
 			step.warn(() => chunk.toString().trimEnd());
-		} else if (subLogger.hasLog && logger.verbosity >= 3) {
+		} else if (subLogger.hasLog) {
 			step.log(() => chunk.toString().trimEnd());
-		} else if (logger.verbosity >= 4) {
+		} else {
 			step.debug(() => chunk.toString().trimEnd());
 		}
 	}

--- a/modules/onerepo/.changes/001-ready-phones-grab.md
+++ b/modules/onerepo/.changes/001-ready-phones-grab.md
@@ -1,0 +1,12 @@
+---
+type: patch
+---
+
+Prevents an EventEmitter memory leak stemming from the logger's internal `LogBuffer` by piping streams instead of adding and removing listeners.
+
+Previously, you may experience the following error when receiving a lot of output from subprocesses (particularly eslint):
+
+```
+(node:30394) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 data listeners added to [LogBuffer]. Use emitter.setMaxListeners() to increase limit
+(Use `node --trace-warnings ...` to show where the warning was created)
+```


### PR DESCRIPTION
**Problem:**

Got a report on Discord with this error when getting lots of eslint output:

```
(node:30394) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 data listeners added to [LogBuffer]. Use emitter.setMaxListeners() to increase limit
(Use `node --trace-warnings ...` to show where the warning was created)
```

**Solution:**

Had always wanted to be using `pipe` for the `LogBuffer` internally, as it's faster and uses less memory. This should resolve those issues.
