### PR TITLE
fix: use ignore package for filtering against ignore files

### DIFF
--- a/plugins/eslint/.changes/000-twelve-jokes-stare.md
+++ b/plugins/eslint/.changes/000-twelve-jokes-stare.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+Fixes filtering input filepaths against the `.eslintignore` file ignores format.

--- a/plugins/eslint/package.json
+++ b/plugins/eslint/package.json
@@ -24,7 +24,7 @@
 	],
 	"dependencies": {
 		"eslint-formatter-onerepo": "1.0.0",
-		"minimatch": "^9.0.3"
+		"ignore": "^5.3.1"
 	},
 	"devDependencies": {
 		"@internal/tsconfig": "workspace:^",

--- a/plugins/prettier/.changes/000-twelve-jokes-stare.md
+++ b/plugins/prettier/.changes/000-twelve-jokes-stare.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+Fixes filtering input filepaths against the `.prettierignore` file ignores format.

--- a/plugins/prettier/package.json
+++ b/plugins/prettier/package.json
@@ -24,7 +24,7 @@
 	],
 	"dependencies": {
 		"@actions/core": "^1.10.1",
-		"minimatch": "^9.0.3"
+		"ignore": "^5.3.1"
 	},
 	"devDependencies": {
 		"@internal/tsconfig": "workspace:^",

--- a/plugins/prettier/src/commands/prettier.ts
+++ b/plugins/prettier/src/commands/prettier.ts
@@ -1,5 +1,4 @@
-import path from 'node:path';
-import { minimatch } from 'minimatch';
+import ignore from 'ignore';
 import * as core from '@actions/core';
 import { git, file, builders } from 'onerepo';
 import type { Builder, Handler } from 'onerepo';
@@ -48,7 +47,7 @@ export const builder: Builder<Args> = (yargs) =>
 export const handler: Handler<Args> = async function handler(argv, { getFilepaths, graph, logger }) {
 	const { add, all, cache, check, 'dry-run': isDry, 'github-annotate': github, $0: cmd, _: positionals } = argv;
 
-	const filteredPaths = [];
+	let filteredPaths: Array<string> = [];
 	if (!all) {
 		const ignoreStep = logger.createStep('Filtering ignored files');
 		const ignoreFile = graph.root.resolve('.prettierignore');
@@ -56,22 +55,9 @@ export const handler: Handler<Args> = async function handler(argv, { getFilepath
 		const rawIgnores = await (hasIgnores ? file.read(ignoreFile, 'r', { step: ignoreStep }) : '');
 		const ignores = rawIgnores.split('\n').filter((line) => Boolean(line.trim()) && !line.trim().startsWith('#'));
 
+		const matcher = ignore().add(ignores);
 		const paths = await getFilepaths({ step: ignoreStep });
-		for (const filepath of paths) {
-			const ext = path.extname(filepath);
-			if (!ext) {
-				const stat = await file.lstat(graph.root.resolve(filepath), { step: ignoreStep });
-				const isDirectory = stat && stat.isDirectory();
-				if (isDirectory) {
-					filteredPaths.push(filepath);
-				}
-				continue;
-			}
-
-			if (!ignores.some((pattern) => minimatch(filepath, pattern))) {
-				filteredPaths.push(filepath);
-			}
-		}
+		filteredPaths = matcher.filter(paths);
 
 		await ignoreStep.end();
 	}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1866,8 +1866,8 @@ __metadata:
     "@types/eslint": ^8.56.2
     eslint: ^8.56.0
     eslint-formatter-onerepo: 1.0.0
+    ignore: ^5.3.1
     jiti: ^1.21.0
-    minimatch: ^9.0.3
     onerepo: "workspace:^"
     typescript: ^5.3.3
   peerDependencies:
@@ -1911,7 +1911,7 @@ __metadata:
     "@internal/tsconfig": "workspace:^"
     "@internal/vitest-config": "workspace:^"
     "@onerepo/test-cli": "workspace:^"
-    minimatch: ^9.0.3
+    ignore: ^5.3.1
     onerepo: "workspace:^"
     typescript: ^5.3.3
   peerDependencies:


### PR DESCRIPTION
**Problem:**

TIL there's a fairly lightweight package that follows the actual `gitignore` spec for filtering filepaths. 

**Solution:**

This will avoid potential errors in the very naïve approach previously used in the eslint and prettier plugins.

