### PR TITLE
fix: capitalize Workspace

### DIFF
--- a/docs/src/content/docs/api/index.md
+++ b/docs/src/content/docs/api/index.md
@@ -4,7 +4,7 @@ description: Full API documentation for oneRepo.
 ---
 
 <!-- start-onerepo-sentinel -->
-<!-- @generated SignedSource<<784b04898a29c03df437c8d9ebc15ab4>> -->
+<!-- @generated SignedSource<<cb83a57132bfa1996076c30d8069562e>> -->
 
 ## Namespaces
 
@@ -608,7 +608,7 @@ export default {
 };
 ```
 
-Given the preceding configuration, commands will be searched for within the `commands/` directory at the root of the repository as well as a directory of the same name at the root of each workspace:
+Given the preceding configuration, commands will be searched for within the `commands/` directory at the root of the repository as well as a directory of the same name at the root of each Workspace:
 
 - `<root>/commands/*`
 - `<root>/<workspaces>/commands/*`
@@ -993,7 +993,7 @@ String command(s) to run. If provided as an array of strings, each command will 
 The commands can use replaced tokens:
 
 - `$0`: the oneRepo CLI for your repository
-- `${workspaces}`: replaced with a space-separated list of workspace names necessary for the given lifecycle
+- `${workspaces}`: replaced with a space-separated list of Workspace names necessary for the given lifecycle
 
 ##### match?
 
@@ -1115,7 +1115,7 @@ passthrough: Record<
 
 **Default:** `{}`
 
-Enable commands from installed dependencies. Similar to running `npx <command>`, but pulled into the oneRepo CLI and able to be limited by workspace. Passthrough commands _must_ have helpful descriptions.
+Enable commands from installed dependencies. Similar to running `npx <command>`, but pulled into the oneRepo CLI and able to be limited by Workspace. Passthrough commands _must_ have helpful descriptions.
 
 ```ts title="onerepo.config.ts"
 export default {
@@ -1484,7 +1484,7 @@ get codeowners(): Required<Record<string, string[]>>
 get config(): Required<RootConfig | WorkspaceConfig>
 ```
 
-Get the workspace's configuration
+Get the Workspace's configuration
 
 **Returns:** `Required`\<[`RootConfig`](#rootconfigcustomlifecycles) \| [`WorkspaceConfig`](#workspaceconfigcustomlifecycles)\>  
 **Source:** [modules/graph/src/Workspace.ts](https://github.com/paularmstrong/onerepo/blob/main/modules/graph/src/Workspace.ts)
@@ -1709,7 +1709,7 @@ Get a list of Workspace tasks for the given lifecycle
 relative(to): string
 ```
 
-Get the relative path of an absolute path to the workspace’s location root
+Get the relative path of an absolute path to the Workspace’s location root
 
 ```ts
 const relativePath = workspace.relative('/some/absolute/path');

--- a/docs/src/content/docs/core/changes.mdx
+++ b/docs/src/content/docs/core/changes.mdx
@@ -8,7 +8,7 @@ tableOfContents:
 import Tabs from '../../../components/Tabs.astro';
 import { FileTree, Steps, TabItem } from '@astrojs/starlight/components';
 
-In a typical monorepo, we want to build up changes for publishable workspaces over time while we work on features and major changes. Because we are using a monorepo with [_source dependencies_](/docs/source-dependencies/), we should not need to publish often, because our local Workspace's are benefitting from code changes immediately.
+In a typical monorepo, we want to build up changes for publishable Workspaces over time while we work on features and major changes. Because we are using a monorepo with [_source dependencies_](/docs/source-dependencies/), we should not need to publish often, because our local Workspace's are benefitting from code changes immediately.
 
 We still may have certain modules that we publish to a public or private registry. Developer workflows will have a few additional steps.
 
@@ -93,7 +93,7 @@ If you prefer something a little more fun, add the [human-id](https://www.npmjs.
    ```ansi
    [34m❯[0m one change add
 
-   📦 What workspace(s) would you like to
+   📦 What Workspace(s) would you like to
    add a change entry to?
 
    [2m↗ Modified Workspaces
@@ -110,7 +110,7 @@ If you prefer something a little more fun, add the [human-id](https://www.npmjs.
 
 1. **Commit files**
 
-   Add change entries will create Markdown files with the change entry content in each appropriate workspace. You will see these files in `<workspace>/.changes/*.md`. It is important to track and commit these files to the repository, as we will use them later on down the line when we're ready to publish a new version.
+   Add change entries will create Markdown files with the change entry content in each appropriate Workspace. You will see these files in `<workspace>/.changes/*.md`. It is important to track and commit these files to the repository, as we will use them later on down the line when we're ready to publish a new version.
 
    ```ansi
    [34m❯[0m git status
@@ -145,7 +145,7 @@ Eventually, we will need to publish one or more Workspaces to our registry for u
    ```ansi
    [34m❯[0m one change version
 
-   📦 What workspace(s) should be
+   📦 What Workspace(s) should be
    versioned for publishing?
 
    [2m↗ Workspaces with change entries
@@ -171,7 +171,7 @@ Eventually, we will need to publish one or more Workspaces to our registry for u
 
    [2m(…continued)[0m
 
-   ┌ Verify workspaces
+   ┌ Verify Workspaces
    │ [2mWorkspace                 Current  Type     New[0m
    │ [2m⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[0m
    │ @onerepo/graph            0.10.0   [33mminor[0m   0.11.0
@@ -207,13 +207,13 @@ Eventually, we will need to publish one or more Workspaces to our registry for u
 ## Commands
 
 {/* start-auto-generated-from-cli-changes */}
-{/* @generated SignedSource<<f529fa58fee56452257f226f54831a72>> */}
+{/* @generated SignedSource<<dc497473b71dea54aa55c43e68ad6464>> */}
 
 ### `one change`
 
 Aliases: `one changes`, `one changesets`
 
-Manage changes and changesets for publishable workspaces.
+Manage changes and changesets for publishable Workspaces.
 
 ```sh
 one change <command>
@@ -237,7 +237,7 @@ This command will prompt for appropriate Workspace(s), prompt for the release ty
 | ------------------ | ------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
 | `--add`            | `boolean`, default: `true`      | Add the modified `package.json` files to the git stage for committing.                                              |
 | `--affected`       | `boolean`                       | Select all affected Workspaces. If no other inputs are chosen, this will default to `true`.                         |
-| `--all, -a`        | `boolean`                       | Run across all workspaces                                                                                           |
+| `--all, -a`        | `boolean`                       | Run across all Workspaces                                                                                           |
 | `--type`           | `"major"`, `"minor"`, `"patch"` | Provide a semantic version bump type. If not given, a prompt will guide you through selecting the appropriate type. |
 | `--workspaces, -w` | `array`                         | List of Workspace names to run against                                                                              |
 
@@ -248,10 +248,10 @@ This command will prompt for appropriate Workspace(s), prompt for the release ty
 | Option          | Type                                        | Description                                                                                                                                                                 |
 | --------------- | ------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `--filenames`   | `"hash"`, `"human"`, default: `"hash"`      | Filename generation strategy for change files. If `'human'`, ensure you have the `human-id` package installed.                                                              |
-| `--from-ref`    | `string`                                    | Git ref to start looking for affected files or workspaces                                                                                                                   |
+| `--from-ref`    | `string`                                    | Git ref to start looking for affected files or Workspaces                                                                                                                   |
 | `--prompts`     | `"guided"`, `"semver"`, default: `"guided"` | Change the prompt question & answer style when adding change entries.                                                                                                       |
 | `--staged`      | `boolean`                                   | Use files on the git stage to calculate affected files or Workspaces. When unset or `--no-staged`, changes will be calculated from the entire branch, since its fork point. |
-| `--through-ref` | `string`                                    | Git ref to start looking for affected files or workspaces                                                                                                                   |
+| `--through-ref` | `string`                                    | Git ref to start looking for affected files or Workspaces                                                                                                                   |
 
 </details>
 
@@ -293,7 +293,7 @@ For each Workspace, the registry will be queried first to ensure the current ver
 
 | Option             | Type      | Description                                                                                |
 | ------------------ | --------- | ------------------------------------------------------------------------------------------ |
-| `--all, -a`        | `boolean` | Run across all workspaces                                                                  |
+| `--all, -a`        | `boolean` | Run across all Workspaces                                                                  |
 | `--otp`            | `boolean` | Set to true if your publishes require an OTP for NPM.                                      |
 | `--skip-auth`      | `boolean` | Skip auth checks. This may be necessary for some internal registries using PATs or tokens. |
 | `--workspaces, -w` | `array`   | List of Workspace names to run against                                                     |
@@ -306,9 +306,9 @@ For each Workspace, the registry will be queried first to ensure the current ver
 | --------------- | --------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `--affected`    | `boolean` | Select all affected Workspaces. If no other inputs are chosen, this will default to `true`.                                                                                 |
 | `--allow-dirty` | `boolean` | Bypass checks to ensure no there are no un-committed changes.                                                                                                               |
-| `--from-ref`    | `string`  | Git ref to start looking for affected files or workspaces                                                                                                                   |
+| `--from-ref`    | `string`  | Git ref to start looking for affected files or Workspaces                                                                                                                   |
 | `--staged`      | `boolean` | Use files on the git stage to calculate affected files or Workspaces. When unset or `--no-staged`, changes will be calculated from the entire branch, since its fork point. |
-| `--through-ref` | `string`  | Git ref to start looking for affected files or workspaces                                                                                                                   |
+| `--through-ref` | `string`  | Git ref to start looking for affected files or Workspaces                                                                                                                   |
 
 </details>
 
@@ -336,7 +336,7 @@ one change show
 
 | Option             | Type                                    | Description                              |
 | ------------------ | --------------------------------------- | ---------------------------------------- |
-| `--all, -a`        | `boolean`                               | Run across all workspaces                |
+| `--all, -a`        | `boolean`                               | Run across all Workspaces                |
 | `--format`         | `"json"`, `"plain"`, default: `"plain"` | Choose how the results will be returned. |
 | `--workspaces, -w` | `array`                                 | List of Workspace names to run against   |
 
@@ -356,7 +356,7 @@ Periodically you may want to publish a _snapshot_ release – something that nee
 
 | Option             | Type                              | Description                                                               |
 | ------------------ | --------------------------------- | ------------------------------------------------------------------------- |
-| `--all, -a`        | `boolean`                         | Run across all workspaces                                                 |
+| `--all, -a`        | `boolean`                         | Run across all Workspaces                                                 |
 | `--allow-dirty`    | `boolean`                         | Bypass checks to ensure no there are no un-committed changes.             |
 | `--otp`            | `boolean`                         | Prompt for one-time password before publishing to the registry            |
 | `--reset`          | `boolean`, default: `true`        | Reset `package.json` changes before exiting. Use `--no-reset` to disable. |
@@ -381,7 +381,7 @@ Add this to your pre-commit or pre-merge task lifecycles to ensure that changes 
 
 #### `one change version`
 
-Update version numbers for publishable workspaces
+Update version numbers for publishable Workspaces
 
 ```sh
 one change version
@@ -389,7 +389,7 @@ one change version
 
 | Option                               | Type      | Description                                                   |
 | ------------------------------------ | --------- | ------------------------------------------------------------- |
-| `--all, -a`                          | `boolean` | Run across all workspaces                                     |
+| `--all, -a`                          | `boolean` | Run across all Workspaces                                     |
 | `--allow-dirty`                      | `boolean` | Bypass checks to ensure no there are no un-committed changes. |
 | `--prerelease, --pre, --pre-release` | `string`  | Create a pre-release using the specified identifier.          |
 | `--workspaces, -w`                   | `array`   | List of Workspace names to run against                        |

--- a/docs/src/content/docs/core/codeowners.mdx
+++ b/docs/src/content/docs/core/codeowners.mdx
@@ -74,7 +74,7 @@ The following providers are currently enabled:
 ## Commands
 
 {/* start-auto-generated-from-cli-codeowners */}
-{/* @generated SignedSource<<a2e4e8f1a8131ac5a32dc80021a44a08>> */}
+{/* @generated SignedSource<<d1e51cac9a2b562ce05bd14c97615892>> */}
 
 ### `one codeowners`
 
@@ -99,7 +99,7 @@ one codeowners show [options]
 | Option             | Type                                    | Description                                                                                                                                                                 |
 | ------------------ | --------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `--affected`       | `boolean`                               | Select all affected Workspaces. If no other inputs are chosen, this will default to `true`.                                                                                 |
-| `--all, -a`        | `boolean`                               | Run across all workspaces                                                                                                                                                   |
+| `--all, -a`        | `boolean`                               | Run across all Workspaces                                                                                                                                                   |
 | `--files, -f`      | `array`                                 | Determine Workspaces from specific files                                                                                                                                    |
 | `--format`         | `"plain"`, `"json"`, default: `"plain"` | Choose how the results will be returned.                                                                                                                                    |
 | `--list`           | `boolean`                               | Just list the owners without the files                                                                                                                                      |
@@ -112,9 +112,9 @@ one codeowners show [options]
 
 | Option          | Type                                             | Description                                                                 | Required |
 | --------------- | ------------------------------------------------ | --------------------------------------------------------------------------- | -------- |
-| `--from-ref`    | `string`                                         | Git ref to start looking for affected files or workspaces                   |          |
+| `--from-ref`    | `string`                                         | Git ref to start looking for affected files or Workspaces                   |          |
 | `--provider`    | `"github"`, `"gitlab"`, `"gitea"`, `"bitbucket"` | Codeowner provider determines where the CODEOWNERS file(s) will be written. | ✅       |
-| `--through-ref` | `string`                                         | Git ref to start looking for affected files or workspaces                   |          |
+| `--through-ref` | `string`                                         | Git ref to start looking for affected files or Workspaces                   |          |
 
 </details>
 

--- a/docs/src/content/docs/core/dependencies.mdx
+++ b/docs/src/content/docs/core/dependencies.mdx
@@ -33,7 +33,7 @@ No configuration necessary! oneRepo automatically detects which package manager 
 </div>
 
 {/* start-auto-generated-from-cli-dependencies */}
-{/* @generated SignedSource<<010aefd30892a3a87886322f5b1af26e>> */}
+{/* @generated SignedSource<<a8fcd0920245c8ac7790511389321972>> */}
 
 ### `one dependencies`
 
@@ -63,7 +63,7 @@ Otherwise, the latest version will be requested from the registry.
 
 | Option             | Type                                               | Description                                                                                                                            |
 | ------------------ | -------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
-| `--all, -a`        | `boolean`                                          | Run across all workspaces                                                                                                              |
+| `--all, -a`        | `boolean`                                          | Run across all Workspaces                                                                                                              |
 | `--dedupe`         | `boolean`, default: `true`                         | Deduplicate dependencies across the repository after install is complete.                                                              |
 | `--dev, -d`        | `array`                                            | Add dependencies for development purposes only.                                                                                        |
 | `--mode`           | `"strict"`, `"loose"`, `"off"`, default: `"loose"` | Version selection mode. Use `strict` to use strict version numbers, `loose` to use caret (`^`) ranges, and `off` for nothing specific. |
@@ -100,7 +100,7 @@ one dependencies remove -w [workspaces...] -d [dependencies...] [options...]
 
 | Option               | Type                       | Description                                                               | Required |
 | -------------------- | -------------------------- | ------------------------------------------------------------------------- | -------- |
-| `--all, -a`          | `boolean`                  | Run across all workspaces                                                 |          |
+| `--all, -a`          | `boolean`                  | Run across all Workspaces                                                 |          |
 | `--dedupe`           | `boolean`, default: `true` | Deduplicate dependencies across the repository after install is complete. |          |
 | `--dependencies, -d` | `array`                    | Dependency names that should be removed.                                  | ✅       |
 | `--workspaces, -w`   | `array`                    | List of Workspace names to run against                                    |          |
@@ -109,7 +109,7 @@ one dependencies remove -w [workspaces...] -d [dependencies...] [options...]
 
 #### `one dependencies verify`
 
-Verify dependencies across workspaces.
+Verify dependencies across Workspaces.
 
 ```sh
 one dependencies verify [options...]
@@ -123,7 +123,7 @@ Dependencies across Workspaces can be validated using one of the various modes:
 
 | Option             | Type                                               | Description                                                                                                                                                   |
 | ------------------ | -------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `--all, -a`        | `boolean`                                          | Run across all workspaces                                                                                                                                     |
+| `--all, -a`        | `boolean`                                          | Run across all Workspaces                                                                                                                                     |
 | `--mode`           | `"strict"`, `"loose"`, `"off"`, default: `"loose"` | Version selection mode. Use `strict` to use exact version matches, `loose` to accept within defined ranges (`^` or `~` range), and `off` for no verification. |
 | `--workspaces, -w` | `array`                                            | List of Workspace names to run against                                                                                                                        |
 

--- a/docs/src/content/docs/core/graph.mdx
+++ b/docs/src/content/docs/core/graph.mdx
@@ -32,7 +32,7 @@ export default {
 ## Commands
 
 {/* start-auto-generated-from-cli-graph */}
-{/* @generated SignedSource<<b16e5557a670a39f00b1dfe38dbd866c>> */}
+{/* @generated SignedSource<<13b61356862f130d155348bbd3dfcd39>> */}
 
 ### `one graph`
 
@@ -59,7 +59,7 @@ Pass `--open` to auto-open your default browser with the URL or use one of the `
 | Option             | Type                             | Description                                                                                                                                                                 |
 | ------------------ | -------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `--affected`       | `boolean`                        | Select all affected Workspaces. If no other inputs are chosen, this will default to `true`.                                                                                 |
-| `--all, -a`        | `boolean`                        | Run across all workspaces                                                                                                                                                   |
+| `--all, -a`        | `boolean`                        | Run across all Workspaces                                                                                                                                                   |
 | `--format, -f`     | `"mermaid"`, `"plain"`, `"json"` | Output format for inspecting the Workspace Graph.                                                                                                                           |
 | `--open`           | `boolean`                        | Auto-open the browser for the online visualizer.                                                                                                                            |
 | `--staged`         | `boolean`                        | Use files on the git stage to calculate affected files or Workspaces. When unset or `--no-staged`, changes will be calculated from the entire branch, since its fork point. |
@@ -71,8 +71,8 @@ Pass `--open` to auto-open your default browser with the URL or use one of the `
 
 | Option          | Type                                                    | Description                                                                                                                                                           |
 | --------------- | ------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `--from-ref`    | `string`                                                | Git ref to start looking for affected files or workspaces                                                                                                             |
-| `--through-ref` | `string`                                                | Git ref to start looking for affected files or workspaces                                                                                                             |
+| `--from-ref`    | `string`                                                | Git ref to start looking for affected files or Workspaces                                                                                                             |
+| `--through-ref` | `string`                                                | Git ref to start looking for affected files or Workspaces                                                                                                             |
 | `--url`         | `string`, default: `"https://onerepo.tools/visualize/"` | Override the URL used to visualize the Graph. The Graph data will be attached the the `g` query parameter as a JSON string of the DAG, compressed using zLib deflate. |
 
 </details>

--- a/docs/src/content/docs/core/tasks.mdx
+++ b/docs/src/content/docs/core/tasks.mdx
@@ -127,7 +127,7 @@ Some tokens in tasks can be used as special replacement values that the `tasks` 
 ## Commands
 
 {/* start-auto-generated-from-cli-tasks */}
-{/* @generated SignedSource<<fa2d18fcdc273fcadecc80ad1682ee63>> */}
+{/* @generated SignedSource<<a6a6db8261018649e3216120583375fc>> */}
 
 ### `one tasks`
 
@@ -142,12 +142,12 @@ You can fine-tune the determination of affected Workspaces by providing a `--fro
 | Option              | Type                                                                                                                                            | Description                                                                                                                                      | Required |
 | ------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ | -------- |
 | `--affected`        | `boolean`                                                                                                                                       | Select all affected Workspaces. If no other inputs are chosen, this will default to `true`.                                                      |          |
-| `--all, -a`         | `boolean`                                                                                                                                       | Run across all workspaces                                                                                                                        |          |
+| `--all, -a`         | `boolean`                                                                                                                                       | Run across all Workspaces                                                                                                                        |          |
 | `--ignore-unstaged` | `boolean`                                                                                                                                       | Force staged-changes mode on or off. If `true`, task determination and runners will ignore unstaged changes.                                     |          |
 | `--lifecycle, -c`   | `"pre-commit"`, `"post-commit"`, `"post-checkout"`, `"pre-merge"`, `"post-merge"`, `"build"`, `"pre-deploy"`, `"pre-publish"`, `"post-publish"` | Task lifecycle to run. All tasks for the given lifecycle will be run as merged parallel tasks, followed by the merged set of serial tasks.       | ✅       |
 | `--list`            | `boolean`                                                                                                                                       | List found tasks. Implies dry run and will not actually run any tasks.                                                                           |          |
 | `--shard`           | `string`                                                                                                                                        | Shard the lifecycle across multiple instances. Format as `<shard-number>/<total-shards>`                                                         |          |
-| `--staged`          | `boolean`                                                                                                                                       | Backup unstaged files and use only those on the git stage to calculate affected files or workspaces. Will re-apply the unstaged files upon exit. |          |
+| `--staged`          | `boolean`                                                                                                                                       | Backup unstaged files and use only those on the git stage to calculate affected files or Workspaces. Will re-apply the unstaged files upon exit. |          |
 | `--workspaces, -w`  | `array`                                                                                                                                         | List of Workspace names to run against                                                                                                           |          |
 
 <details>
@@ -156,10 +156,10 @@ You can fine-tune the determination of affected Workspaces by providing a `--fro
 
 | Option            | Type                   | Description                                                               |
 | ----------------- | ---------------------- | ------------------------------------------------------------------------- |
-| `--from-ref`      | `string`               | Git ref to start looking for affected files or workspaces                 |
+| `--from-ref`      | `string`               | Git ref to start looking for affected files or Workspaces                 |
 | `--ignore`        | `array`, default: `[]` | List of filepath strings or globs to ignore when matching tasks to files. |
 | `--show-advanced` | `boolean`              | Pair with `--help` to show advanced options.                              |
-| `--through-ref`   | `string`               | Git ref to start looking for affected files or workspaces                 |
+| `--through-ref`   | `string`               | Git ref to start looking for affected files or Workspaces                 |
 
 </details>
 

--- a/docs/src/content/docs/docs/config.mdx
+++ b/docs/src/content/docs/docs/config.mdx
@@ -44,7 +44,7 @@ module.exports = {
 </Tabs>
 
 {/* start-usage-typedoc-root */}
-{/* @generated SignedSource<<1f3643e261011e773cdaf6e6c585f3e4>> */}
+{/* @generated SignedSource<<ca8dc91e01251ee0d745bc66fb09a598>> */}
 
 ### RootConfig\<CustomLifecycles\>
 
@@ -173,7 +173,7 @@ export default {
 };
 ```
 
-Given the preceding configuration, commands will be searched for within the `commands/` directory at the root of the repository as well as a directory of the same name at the root of each workspace:
+Given the preceding configuration, commands will be searched for within the `commands/` directory at the root of the repository as well as a directory of the same name at the root of each Workspace:
 
 - `<root>/commands/*`
 - `<root>/<workspaces>/commands/*`
@@ -448,7 +448,7 @@ module.exports = {
 </Tabs>
 
 {/* start-usage-typedoc-workspace */}
-{/* @generated SignedSource<<ae884de3eadba89c965d40c9a7f14055>> */}
+{/* @generated SignedSource<<d27f0bf3825d6602f2be44d2397a74fd>> */}
 
 ### WorkspaceConfig\<CustomLifecycles\>
 
@@ -487,7 +487,7 @@ Configuration for custom commands. To configure the commands directory, see [`Ro
 - **Type:** `Record`\<`string`, `Object`\>
 - **Default:** `{}`
 
-Enable commands from installed dependencies. Similar to running `npx <command>`, but pulled into the oneRepo CLI and able to be limited by workspace. Passthrough commands _must_ have helpful descriptions.
+Enable commands from installed dependencies. Similar to running `npx <command>`, but pulled into the oneRepo CLI and able to be limited by Workspace. Passthrough commands _must_ have helpful descriptions.
 
 ```ts title="onerepo.config.ts"
 export default {

--- a/docs/src/content/docs/plugins/docgen/example.mdx
+++ b/docs/src/content/docs/plugins/docgen/example.mdx
@@ -13,7 +13,7 @@ The following content is auto-generated using the [official documentation plugin
 :::
 
 {/* start-auto-generated-from-cli */}
-{/* @generated SignedSource<<08893ba03b34cdb9ab05787ac817a439>> */}
+{/* @generated SignedSource<<bb4cf3ab837c15132b2222657f089010>> */}
 
 ## `one`
 
@@ -53,7 +53,7 @@ one build [options...]
 | Option             | Type      | Description                                                                                                                                                                 |
 | ------------------ | --------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `--affected`       | `boolean` | Select all affected Workspaces. If no other inputs are chosen, this will default to `true`.                                                                                 |
-| `--all, -a`        | `boolean` | Run across all workspaces                                                                                                                                                   |
+| `--all, -a`        | `boolean` | Run across all Workspaces                                                                                                                                                   |
 | `--staged`         | `boolean` | Use files on the git stage to calculate affected files or Workspaces. When unset or `--no-staged`, changes will be calculated from the entire branch, since its fork point. |
 | `--workspaces, -w` | `array`   | List of Workspace names to run against                                                                                                                                      |
 
@@ -63,8 +63,8 @@ one build [options...]
 
 | Option          | Type     | Description                                               |
 | --------------- | -------- | --------------------------------------------------------- |
-| `--from-ref`    | `string` | Git ref to start looking for affected files or workspaces |
-| `--through-ref` | `string` | Git ref to start looking for affected files or workspaces |
+| `--from-ref`    | `string` | Git ref to start looking for affected files or Workspaces |
+| `--through-ref` | `string` | Git ref to start looking for affected files or Workspaces |
 
 </details>
 
@@ -92,7 +92,7 @@ one build -w graph cli logger
 
 Aliases: `one changes`, `one changesets`
 
-Manage changes and changesets for publishable workspaces.
+Manage changes and changesets for publishable Workspaces.
 
 ```sh
 one change <command>
@@ -116,7 +116,7 @@ This command will prompt for appropriate Workspace(s), prompt for the release ty
 | ------------------ | ------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
 | `--add`            | `boolean`, default: `true`      | Add the modified `package.json` files to the git stage for committing.                                              |
 | `--affected`       | `boolean`                       | Select all affected Workspaces. If no other inputs are chosen, this will default to `true`.                         |
-| `--all, -a`        | `boolean`                       | Run across all workspaces                                                                                           |
+| `--all, -a`        | `boolean`                       | Run across all Workspaces                                                                                           |
 | `--type`           | `"major"`, `"minor"`, `"patch"` | Provide a semantic version bump type. If not given, a prompt will guide you through selecting the appropriate type. |
 | `--workspaces, -w` | `array`                         | List of Workspace names to run against                                                                              |
 
@@ -127,10 +127,10 @@ This command will prompt for appropriate Workspace(s), prompt for the release ty
 | Option          | Type                                        | Description                                                                                                                                                                 |
 | --------------- | ------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `--filenames`   | `"hash"`, `"human"`, default: `"human"`     | Filename generation strategy for change files. If `'human'`, ensure you have the `human-id` package installed.                                                              |
-| `--from-ref`    | `string`                                    | Git ref to start looking for affected files or workspaces                                                                                                                   |
+| `--from-ref`    | `string`                                    | Git ref to start looking for affected files or Workspaces                                                                                                                   |
 | `--prompts`     | `"guided"`, `"semver"`, default: `"guided"` | Change the prompt question & answer style when adding change entries.                                                                                                       |
 | `--staged`      | `boolean`                                   | Use files on the git stage to calculate affected files or Workspaces. When unset or `--no-staged`, changes will be calculated from the entire branch, since its fork point. |
-| `--through-ref` | `string`                                    | Git ref to start looking for affected files or workspaces                                                                                                                   |
+| `--through-ref` | `string`                                    | Git ref to start looking for affected files or Workspaces                                                                                                                   |
 
 </details>
 
@@ -172,7 +172,7 @@ For each Workspace, the registry will be queried first to ensure the current ver
 
 | Option             | Type      | Description                                                                                |
 | ------------------ | --------- | ------------------------------------------------------------------------------------------ |
-| `--all, -a`        | `boolean` | Run across all workspaces                                                                  |
+| `--all, -a`        | `boolean` | Run across all Workspaces                                                                  |
 | `--otp`            | `boolean` | Set to true if your publishes require an OTP for NPM.                                      |
 | `--skip-auth`      | `boolean` | Skip auth checks. This may be necessary for some internal registries using PATs or tokens. |
 | `--workspaces, -w` | `array`   | List of Workspace names to run against                                                     |
@@ -185,9 +185,9 @@ For each Workspace, the registry will be queried first to ensure the current ver
 | --------------- | --------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `--affected`    | `boolean` | Select all affected Workspaces. If no other inputs are chosen, this will default to `true`.                                                                                 |
 | `--allow-dirty` | `boolean` | Bypass checks to ensure no there are no un-committed changes.                                                                                                               |
-| `--from-ref`    | `string`  | Git ref to start looking for affected files or workspaces                                                                                                                   |
+| `--from-ref`    | `string`  | Git ref to start looking for affected files or Workspaces                                                                                                                   |
 | `--staged`      | `boolean` | Use files on the git stage to calculate affected files or Workspaces. When unset or `--no-staged`, changes will be calculated from the entire branch, since its fork point. |
-| `--through-ref` | `string`  | Git ref to start looking for affected files or workspaces                                                                                                                   |
+| `--through-ref` | `string`  | Git ref to start looking for affected files or Workspaces                                                                                                                   |
 
 </details>
 
@@ -215,7 +215,7 @@ one change show
 
 | Option             | Type                                    | Description                              |
 | ------------------ | --------------------------------------- | ---------------------------------------- |
-| `--all, -a`        | `boolean`                               | Run across all workspaces                |
+| `--all, -a`        | `boolean`                               | Run across all Workspaces                |
 | `--format`         | `"json"`, `"plain"`, default: `"plain"` | Choose how the results will be returned. |
 | `--workspaces, -w` | `array`                                 | List of Workspace names to run against   |
 
@@ -235,7 +235,7 @@ Periodically you may want to publish a _snapshot_ release – something that nee
 
 | Option             | Type                              | Description                                                               |
 | ------------------ | --------------------------------- | ------------------------------------------------------------------------- |
-| `--all, -a`        | `boolean`                         | Run across all workspaces                                                 |
+| `--all, -a`        | `boolean`                         | Run across all Workspaces                                                 |
 | `--allow-dirty`    | `boolean`                         | Bypass checks to ensure no there are no un-committed changes.             |
 | `--otp`            | `boolean`                         | Prompt for one-time password before publishing to the registry            |
 | `--reset`          | `boolean`, default: `true`        | Reset `package.json` changes before exiting. Use `--no-reset` to disable. |
@@ -260,7 +260,7 @@ Add this to your pre-commit or pre-merge task lifecycles to ensure that changes 
 
 #### `one change version`
 
-Update version numbers for publishable workspaces
+Update version numbers for publishable Workspaces
 
 ```sh
 one change version
@@ -268,7 +268,7 @@ one change version
 
 | Option                               | Type      | Description                                                   |
 | ------------------------------------ | --------- | ------------------------------------------------------------- |
-| `--all, -a`                          | `boolean` | Run across all workspaces                                     |
+| `--all, -a`                          | `boolean` | Run across all Workspaces                                     |
 | `--allow-dirty`                      | `boolean` | Bypass checks to ensure no there are no un-committed changes. |
 | `--prerelease, --pre, --pre-release` | `string`  | Create a pre-release using the specified identifier.          |
 | `--workspaces, -w`                   | `array`   | List of Workspace names to run against                        |
@@ -304,7 +304,7 @@ one codeowners show [options]
 | Option             | Type                                    | Description                                                                                                                                                                 |
 | ------------------ | --------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `--affected`       | `boolean`                               | Select all affected Workspaces. If no other inputs are chosen, this will default to `true`.                                                                                 |
-| `--all, -a`        | `boolean`                               | Run across all workspaces                                                                                                                                                   |
+| `--all, -a`        | `boolean`                               | Run across all Workspaces                                                                                                                                                   |
 | `--files, -f`      | `array`                                 | Determine Workspaces from specific files                                                                                                                                    |
 | `--format`         | `"plain"`, `"json"`, default: `"plain"` | Choose how the results will be returned.                                                                                                                                    |
 | `--list`           | `boolean`                               | Just list the owners without the files                                                                                                                                      |
@@ -317,9 +317,9 @@ one codeowners show [options]
 
 | Option          | Type                                             | Description                                                                 | Required |
 | --------------- | ------------------------------------------------ | --------------------------------------------------------------------------- | -------- |
-| `--from-ref`    | `string`                                         | Git ref to start looking for affected files or workspaces                   |          |
+| `--from-ref`    | `string`                                         | Git ref to start looking for affected files or Workspaces                   |          |
 | `--provider`    | `"github"`, `"gitlab"`, `"gitea"`, `"bitbucket"` | Codeowner provider determines where the CODEOWNERS file(s) will be written. | ✅       |
-| `--through-ref` | `string`                                         | Git ref to start looking for affected files or workspaces                   |          |
+| `--through-ref` | `string`                                         | Git ref to start looking for affected files or Workspaces                   |          |
 
 </details>
 
@@ -416,7 +416,7 @@ Otherwise, the latest version will be requested from the registry.
 
 | Option             | Type                                               | Description                                                                                                                            |
 | ------------------ | -------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
-| `--all, -a`        | `boolean`                                          | Run across all workspaces                                                                                                              |
+| `--all, -a`        | `boolean`                                          | Run across all Workspaces                                                                                                              |
 | `--dedupe`         | `boolean`, default: `true`                         | Deduplicate dependencies across the repository after install is complete.                                                              |
 | `--dev, -d`        | `array`                                            | Add dependencies for development purposes only.                                                                                        |
 | `--mode`           | `"strict"`, `"loose"`, `"off"`, default: `"loose"` | Version selection mode. Use `strict` to use strict version numbers, `loose` to use caret (`^`) ranges, and `off` for nothing specific. |
@@ -453,7 +453,7 @@ one dependencies remove -w [workspaces...] -d [dependencies...] [options...]
 
 | Option               | Type                       | Description                                                               | Required |
 | -------------------- | -------------------------- | ------------------------------------------------------------------------- | -------- |
-| `--all, -a`          | `boolean`                  | Run across all workspaces                                                 |          |
+| `--all, -a`          | `boolean`                  | Run across all Workspaces                                                 |          |
 | `--dedupe`           | `boolean`, default: `true` | Deduplicate dependencies across the repository after install is complete. |          |
 | `--dependencies, -d` | `array`                    | Dependency names that should be removed.                                  | ✅       |
 | `--workspaces, -w`   | `array`                    | List of Workspace names to run against                                    |          |
@@ -462,7 +462,7 @@ one dependencies remove -w [workspaces...] -d [dependencies...] [options...]
 
 #### `one dependencies verify`
 
-Verify dependencies across workspaces.
+Verify dependencies across Workspaces.
 
 ```sh
 one dependencies verify [options...]
@@ -476,7 +476,7 @@ Dependencies across Workspaces can be validated using one of the various modes:
 
 | Option             | Type                                               | Description                                                                                                                                                   |
 | ------------------ | -------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `--all, -a`        | `boolean`                                          | Run across all workspaces                                                                                                                                     |
+| `--all, -a`        | `boolean`                                          | Run across all Workspaces                                                                                                                                     |
 | `--mode`           | `"strict"`, `"loose"`, `"off"`, default: `"loose"` | Version selection mode. Use `strict` to use exact version matches, `loose` to accept within defined ranges (`^` or `~` range), and `off` for no verification. |
 | `--workspaces, -w` | `array`                                            | List of Workspace names to run against                                                                                                                        |
 
@@ -520,7 +520,7 @@ Add this command to your one Repo tasks on pre-commit to ensure that your docume
 
 Aliases: `one lint`
 
-Run eslint across files and workspaces
+Run eslint across files and Workspaces.
 
 ```sh
 one eslint [options...]
@@ -530,7 +530,7 @@ one eslint [options...]
 | ------------------ | --------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `--add`            | `boolean`                                                       | Add modified files after write to the git stage.                                                                                                                            |
 | `--affected`       | `boolean`                                                       | Select all affected Workspaces. If no other inputs are chosen, this will default to `true`.                                                                                 |
-| `--all, -a`        | `boolean`                                                       | Run across all workspaces                                                                                                                                                   |
+| `--all, -a`        | `boolean`                                                       | Run across all Workspaces                                                                                                                                                   |
 | `--cache`          | `boolean`, default: `true`                                      | Use cache if available                                                                                                                                                      |
 | `--extensions`     | `array`, default: `["ts","tsx","js","jsx","cjs","mjs","astro"]` | Make ESLint check files given these extensions.                                                                                                                             |
 | `--files, -f`      | `array`                                                         | Determine Workspaces from specific files                                                                                                                                    |
@@ -546,9 +546,9 @@ one eslint [options...]
 
 | Option              | Type                       | Description                                                                     |
 | ------------------- | -------------------------- | ------------------------------------------------------------------------------- |
-| `--from-ref`        | `string`                   | Git ref to start looking for affected files or workspaces                       |
+| `--from-ref`        | `string`                   | Git ref to start looking for affected files or Workspaces                       |
 | `--github-annotate` | `boolean`, default: `true` | Annotate files in GitHub with errors when failing lint checks in GitHub Actions |
-| `--through-ref`     | `string`                   | Git ref to start looking for affected files or workspaces                       |
+| `--through-ref`     | `string`                   | Git ref to start looking for affected files or Workspaces                       |
 
 </details>
 
@@ -607,7 +607,7 @@ Pass `--open` to auto-open your default browser with the URL or use one of the `
 | Option             | Type                             | Description                                                                                                                                                                 |
 | ------------------ | -------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `--affected`       | `boolean`                        | Select all affected Workspaces. If no other inputs are chosen, this will default to `true`.                                                                                 |
-| `--all, -a`        | `boolean`                        | Run across all workspaces                                                                                                                                                   |
+| `--all, -a`        | `boolean`                        | Run across all Workspaces                                                                                                                                                   |
 | `--format, -f`     | `"mermaid"`, `"plain"`, `"json"` | Output format for inspecting the Workspace Graph.                                                                                                                           |
 | `--open`           | `boolean`                        | Auto-open the browser for the online visualizer.                                                                                                                            |
 | `--staged`         | `boolean`                        | Use files on the git stage to calculate affected files or Workspaces. When unset or `--no-staged`, changes will be calculated from the entire branch, since its fork point. |
@@ -619,8 +619,8 @@ Pass `--open` to auto-open your default browser with the URL or use one of the `
 
 | Option          | Type                                                    | Description                                                                                                                                                           |
 | --------------- | ------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `--from-ref`    | `string`                                                | Git ref to start looking for affected files or workspaces                                                                                                             |
-| `--through-ref` | `string`                                                | Git ref to start looking for affected files or workspaces                                                                                                             |
+| `--from-ref`    | `string`                                                | Git ref to start looking for affected files or Workspaces                                                                                                             |
+| `--through-ref` | `string`                                                | Git ref to start looking for affected files or Workspaces                                                                                                             |
 | `--url`         | `string`, default: `"https://onerepo.tools/visualize/"` | Override the URL used to visualize the Graph. The Graph data will be attached the the `g` query parameter as a JSON string of the DAG, compressed using zLib deflate. |
 
 </details>
@@ -769,7 +769,7 @@ Additionally, any other [Jest CLI options](https://jestjs.io/docs/cli) can be pa
 | Option             | Type                       | Description                                                                                                                                                                 |
 | ------------------ | -------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `--affected`       | `boolean`                  | Select all affected Workspaces. If no other inputs are chosen, this will default to `true`.                                                                                 |
-| `--all, -a`        | `boolean`                  | Run across all workspaces                                                                                                                                                   |
+| `--all, -a`        | `boolean`                  | Run across all Workspaces                                                                                                                                                   |
 | `--inspect`        | `boolean`                  | Break for the the Node inspector to debug tests.                                                                                                                            |
 | `--pretty`         | `boolean`, default: `true` | Control Jest’s `--colors` flag.                                                                                                                                             |
 | `--staged`         | `boolean`                  | Use files on the git stage to calculate affected files or Workspaces. When unset or `--no-staged`, changes will be calculated from the entire branch, since its fork point. |
@@ -783,9 +783,9 @@ Additionally, any other [Jest CLI options](https://jestjs.io/docs/cli) can be pa
 | Option              | Type                                    | Description                                                                                 |
 | ------------------- | --------------------------------------- | ------------------------------------------------------------------------------------------- |
 | `--config`          | `string`, default: `"./jest.config.js"` | Path to the jest.config file, relative to the repo root.                                    |
-| `--from-ref`        | `string`                                | Git ref to start looking for affected files or workspaces                                   |
+| `--from-ref`        | `string`                                | Git ref to start looking for affected files or Workspaces                                   |
 | `--passWithNoTests` | `boolean`, default: `true`              | Allows the test suite to pass when no files are found. See plugin configuration to disable. |
-| `--through-ref`     | `string`                                | Git ref to start looking for affected files or workspaces                                   |
+| `--through-ref`     | `string`                                | Git ref to start looking for affected files or Workspaces                                   |
 
 </details>
 
@@ -829,7 +829,7 @@ one prettier [options...]
 | ------------------ | --------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `--add`            | `boolean` | Add modified files after write                                                                                                                                              |
 | `--affected`       | `boolean` | Select all affected Workspaces. If no other inputs are chosen, this will default to `true`.                                                                                 |
-| `--all, -a`        | `boolean` | Run across all workspaces                                                                                                                                                   |
+| `--all, -a`        | `boolean` | Run across all Workspaces                                                                                                                                                   |
 | `--check`          | `boolean` | Check for changes.                                                                                                                                                          |
 | `--files, -f`      | `array`   | Determine Workspaces from specific files                                                                                                                                    |
 | `--staged`         | `boolean` | Use files on the git stage to calculate affected files or Workspaces. When unset or `--no-staged`, changes will be calculated from the entire branch, since its fork point. |
@@ -842,9 +842,9 @@ one prettier [options...]
 | Option              | Type                       | Description                                                                        |
 | ------------------- | -------------------------- | ---------------------------------------------------------------------------------- |
 | `--cache`           | `boolean`, default: `true` | Use Prettier’s built-in cache to determin whether files need formatting or not.    |
-| `--from-ref`        | `string`                   | Git ref to start looking for affected files or workspaces                          |
+| `--from-ref`        | `string`                   | Git ref to start looking for affected files or Workspaces                          |
 | `--github-annotate` | `boolean`, default: `true` | Annotate files in GitHub with errors when failing format checks in GitHub Actions. |
-| `--through-ref`     | `string`                   | Git ref to start looking for affected files or workspaces                          |
+| `--through-ref`     | `string`                   | Git ref to start looking for affected files or Workspaces                          |
 
 </details>
 
@@ -863,12 +863,12 @@ You can fine-tune the determination of affected Workspaces by providing a `--fro
 | Option              | Type                                                                                                                                            | Description                                                                                                                                      | Required |
 | ------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ | -------- |
 | `--affected`        | `boolean`                                                                                                                                       | Select all affected Workspaces. If no other inputs are chosen, this will default to `true`.                                                      |          |
-| `--all, -a`         | `boolean`                                                                                                                                       | Run across all workspaces                                                                                                                        |          |
+| `--all, -a`         | `boolean`                                                                                                                                       | Run across all Workspaces                                                                                                                        |          |
 | `--ignore-unstaged` | `boolean`                                                                                                                                       | Force staged-changes mode on or off. If `true`, task determination and runners will ignore unstaged changes.                                     |          |
 | `--lifecycle, -c`   | `"pre-commit"`, `"post-commit"`, `"post-checkout"`, `"pre-merge"`, `"post-merge"`, `"build"`, `"pre-deploy"`, `"pre-publish"`, `"post-publish"` | Task lifecycle to run. All tasks for the given lifecycle will be run as merged parallel tasks, followed by the merged set of serial tasks.       | ✅       |
 | `--list`            | `boolean`                                                                                                                                       | List found tasks. Implies dry run and will not actually run any tasks.                                                                           |          |
 | `--shard`           | `string`                                                                                                                                        | Shard the lifecycle across multiple instances. Format as `<shard-number>/<total-shards>`                                                         |          |
-| `--staged`          | `boolean`                                                                                                                                       | Backup unstaged files and use only those on the git stage to calculate affected files or workspaces. Will re-apply the unstaged files upon exit. |          |
+| `--staged`          | `boolean`                                                                                                                                       | Backup unstaged files and use only those on the git stage to calculate affected files or Workspaces. Will re-apply the unstaged files upon exit. |          |
 | `--workspaces, -w`  | `array`                                                                                                                                         | List of Workspace names to run against                                                                                                           |          |
 
 <details>
@@ -877,9 +877,9 @@ You can fine-tune the determination of affected Workspaces by providing a `--fro
 
 | Option          | Type                                                   | Description                                                               |
 | --------------- | ------------------------------------------------------ | ------------------------------------------------------------------------- |
-| `--from-ref`    | `string`                                               | Git ref to start looking for affected files or workspaces                 |
+| `--from-ref`    | `string`                                               | Git ref to start looking for affected files or Workspaces                 |
 | `--ignore`      | `array`, default: `["**/README.md","**/CHANGELOG.md"]` | List of filepath strings or globs to ignore when matching tasks to files. |
-| `--through-ref` | `string`                                               | Git ref to start looking for affected files or workspaces                 |
+| `--through-ref` | `string`                                               | Git ref to start looking for affected files or Workspaces                 |
 
 </details>
 
@@ -912,7 +912,7 @@ Checks for the existence of `tsconfig.json` file and batches running `tsc --noEm
 | Option             | Type                       | Description                                                                                                                                                                 |
 | ------------------ | -------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `--affected`       | `boolean`                  | Select all affected Workspaces. If no other inputs are chosen, this will default to `true`.                                                                                 |
-| `--all, -a`        | `boolean`                  | Run across all workspaces                                                                                                                                                   |
+| `--all, -a`        | `boolean`                  | Run across all Workspaces                                                                                                                                                   |
 | `--pretty`         | `boolean`, default: `true` | Control TypeScript’s `--pretty` flag.                                                                                                                                       |
 | `--staged`         | `boolean`                  | Use files on the git stage to calculate affected files or Workspaces. When unset or `--no-staged`, changes will be calculated from the entire branch, since its fork point. |
 | `--workspaces, -w` | `array`                    | List of Workspace names to run against                                                                                                                                      |
@@ -923,8 +923,8 @@ Checks for the existence of `tsconfig.json` file and batches running `tsc --noEm
 
 | Option                                                           | Type                                 | Description                                               |
 | ---------------------------------------------------------------- | ------------------------------------ | --------------------------------------------------------- |
-| `--from-ref`                                                     | `string`                             | Git ref to start looking for affected files or workspaces |
-| `--through-ref`                                                  | `string`                             | Git ref to start looking for affected files or workspaces |
+| `--from-ref`                                                     | `string`                             | Git ref to start looking for affected files or Workspaces |
+| `--through-ref`                                                  | `string`                             | Git ref to start looking for affected files or Workspaces |
 | `--tsconfig`                                                     | `string`, default: `"tsconfig.json"` | The filename of the tsconfig to find in each Workspace.   |
 | `--use-project-references, --project-references, --project-refs` | `boolean`, default: `true`           | Automatically sync and use typescript project references  |
 
@@ -950,7 +950,7 @@ Additionally, any other [Vitest CLI options](https://jest.dev/guide/cli.html) ca
 | Option             | Type      | Description                                                                                                                                                                 |
 | ------------------ | --------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `--affected`       | `boolean` | Select all affected Workspaces. If no other inputs are chosen, this will default to `true`.                                                                                 |
-| `--all, -a`        | `boolean` | Run across all workspaces                                                                                                                                                   |
+| `--all, -a`        | `boolean` | Run across all Workspaces                                                                                                                                                   |
 | `--inspect`        | `boolean` | Break for the the Node inspector to debug tests.                                                                                                                            |
 | `--staged`         | `boolean` | Use files on the git stage to calculate affected files or Workspaces. When unset or `--no-staged`, changes will be calculated from the entire branch, since its fork point. |
 | `--watch`          | `boolean` | Shortcut for vitest `--watch` mode.                                                                                                                                         |
@@ -963,8 +963,8 @@ Additionally, any other [Vitest CLI options](https://jest.dev/guide/cli.html) ca
 | Option          | Type                                      | Description                                                |
 | --------------- | ----------------------------------------- | ---------------------------------------------------------- |
 | `--config`      | `string`, default: `"./vitest.config.ts"` | Path to the vitest.config file, relative to the repo root. |
-| `--from-ref`    | `string`                                  | Git ref to start looking for affected files or workspaces  |
-| `--through-ref` | `string`                                  | Git ref to start looking for affected files or workspaces  |
+| `--from-ref`    | `string`                                  | Git ref to start looking for affected files or Workspaces  |
+| `--through-ref` | `string`                                  | Git ref to start looking for affected files or Workspaces  |
 
 </details>
 
@@ -1045,7 +1045,7 @@ Update changelogs from source files
 | ------------------ | --------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `--add`            | `boolean` | Add files to the git index                                                                                                                                                  |
 | `--affected`       | `boolean` | Select all affected Workspaces. If no other inputs are chosen, this will default to `true`.                                                                                 |
-| `--all, -a`        | `boolean` | Run across all workspaces                                                                                                                                                   |
+| `--all, -a`        | `boolean` | Run across all Workspaces                                                                                                                                                   |
 | `--files, -f`      | `array`   | Determine Workspaces from specific files                                                                                                                                    |
 | `--staged`         | `boolean` | Use files on the git stage to calculate affected files or Workspaces. When unset or `--no-staged`, changes will be calculated from the entire branch, since its fork point. |
 | `--workspaces, -w` | `array`   | List of Workspace names to run against                                                                                                                                      |
@@ -1056,8 +1056,8 @@ Update changelogs from source files
 
 | Option          | Type     | Description                                               |
 | --------------- | -------- | --------------------------------------------------------- |
-| `--from-ref`    | `string` | Git ref to start looking for affected files or workspaces |
-| `--through-ref` | `string` | Git ref to start looking for affected files or workspaces |
+| `--from-ref`    | `string` | Git ref to start looking for affected files or Workspaces |
+| `--through-ref` | `string` | Git ref to start looking for affected files or Workspaces |
 
 </details>
 
@@ -1077,7 +1077,7 @@ Generate docs for the oneRepo monorepo
 | ------------------ | --------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `--add`            | `boolean` | Add files to the git index                                                                                                                                                  |
 | `--affected`       | `boolean` | Select all affected Workspaces. If no other inputs are chosen, this will default to `true`.                                                                                 |
-| `--all, -a`        | `boolean` | Run across all workspaces                                                                                                                                                   |
+| `--all, -a`        | `boolean` | Run across all Workspaces                                                                                                                                                   |
 | `--files, -f`      | `array`   | Determine Workspaces from specific files                                                                                                                                    |
 | `--staged`         | `boolean` | Use files on the git stage to calculate affected files or Workspaces. When unset or `--no-staged`, changes will be calculated from the entire branch, since its fork point. |
 | `--workspaces, -w` | `array`   | List of Workspace names to run against                                                                                                                                      |
@@ -1088,8 +1088,8 @@ Generate docs for the oneRepo monorepo
 
 | Option          | Type     | Description                                               |
 | --------------- | -------- | --------------------------------------------------------- |
-| `--from-ref`    | `string` | Git ref to start looking for affected files or workspaces |
-| `--through-ref` | `string` | Git ref to start looking for affected files or workspaces |
+| `--from-ref`    | `string` | Git ref to start looking for affected files or Workspaces |
+| `--through-ref` | `string` | Git ref to start looking for affected files or Workspaces |
 
 </details>
 
@@ -1134,7 +1134,7 @@ one workspace github-action build [options...]
 | Option             | Type      | Description                                                                                                                                                                 |
 | ------------------ | --------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `--affected`       | `boolean` | Select all affected Workspaces. If no other inputs are chosen, this will default to `true`.                                                                                 |
-| `--all, -a`        | `boolean` | Run across all workspaces                                                                                                                                                   |
+| `--all, -a`        | `boolean` | Run across all Workspaces                                                                                                                                                   |
 | `--staged`         | `boolean` | Use files on the git stage to calculate affected files or Workspaces. When unset or `--no-staged`, changes will be calculated from the entire branch, since its fork point. |
 | `--workspaces, -w` | `array`   | List of Workspace names to run against                                                                                                                                      |
 
@@ -1144,8 +1144,8 @@ one workspace github-action build [options...]
 
 | Option          | Type     | Description                                               |
 | --------------- | -------- | --------------------------------------------------------- |
-| `--from-ref`    | `string` | Git ref to start looking for affected files or workspaces |
-| `--through-ref` | `string` | Git ref to start looking for affected files or workspaces |
+| `--from-ref`    | `string` | Git ref to start looking for affected files or Workspaces |
+| `--through-ref` | `string` | Git ref to start looking for affected files or Workspaces |
 
 </details>
 
@@ -1161,7 +1161,7 @@ Build the `graph` Workspace only.
 one workspace github-action build -w graph
 ```
 
-Build the `graph`, `cli`, and `logger` workspaces.
+Build the `graph`, `cli`, and `logger` Workspaces.
 
 ```sh
 one workspace github-action build -w graph cli logger

--- a/docs/src/content/docs/plugins/eslint.mdx
+++ b/docs/src/content/docs/plugins/eslint.mdx
@@ -160,13 +160,13 @@ export default {
 ## Commands
 
 {/* start-auto-generated-from-cli-eslint */}
-{/* @generated SignedSource<<5825ad0bd16255233ae82c06c0ab6a66>> */}
+{/* @generated SignedSource<<607c2a94246fb1033dcf23d1a33f537d>> */}
 
 ### `one eslint`
 
 Aliases: `one lint`
 
-Run eslint across files and workspaces
+Run eslint across files and Workspaces.
 
 ```sh
 one eslint [options...]
@@ -176,7 +176,7 @@ one eslint [options...]
 | ------------------ | -------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `--add`            | `boolean`                  | Add modified files after write to the git stage.                                                                                                                            |
 | `--affected`       | `boolean`                  | Select all affected Workspaces. If no other inputs are chosen, this will default to `true`.                                                                                 |
-| `--all, -a`        | `boolean`                  | Run across all workspaces                                                                                                                                                   |
+| `--all, -a`        | `boolean`                  | Run across all Workspaces                                                                                                                                                   |
 | `--cache`          | `boolean`, default: `true` | Use cache if available                                                                                                                                                      |
 | `--extensions`     | `array`                    | Make ESLint check files given these extensions.                                                                                                                             |
 | `--files, -f`      | `array`                    | Determine Workspaces from specific files                                                                                                                                    |
@@ -192,10 +192,10 @@ one eslint [options...]
 
 | Option              | Type                       | Description                                                                     |
 | ------------------- | -------------------------- | ------------------------------------------------------------------------------- |
-| `--from-ref`        | `string`                   | Git ref to start looking for affected files or workspaces                       |
+| `--from-ref`        | `string`                   | Git ref to start looking for affected files or Workspaces                       |
 | `--github-annotate` | `boolean`, default: `true` | Annotate files in GitHub with errors when failing lint checks in GitHub Actions |
 | `--show-advanced`   | `boolean`                  | Pair with `--help` to show advanced options.                                    |
-| `--through-ref`     | `string`                   | Git ref to start looking for affected files or workspaces                       |
+| `--through-ref`     | `string`                   | Git ref to start looking for affected files or Workspaces                       |
 
 </details>
 

--- a/docs/src/content/docs/plugins/jest.mdx
+++ b/docs/src/content/docs/plugins/jest.mdx
@@ -183,7 +183,7 @@ export default {
 ## Commands
 
 {/* start-auto-generated-from-cli-jest */}
-{/* @generated SignedSource<<28e3ef503a4683aaf3061c1921d17303>> */}
+{/* @generated SignedSource<<d07c05c84216258703af364d558385bb>> */}
 
 ### `one jest`
 
@@ -203,7 +203,7 @@ Additionally, any other [Jest CLI options](https://jestjs.io/docs/cli) can be pa
 | Option             | Type                       | Description                                                                                                                                                                 |
 | ------------------ | -------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `--affected`       | `boolean`                  | Select all affected Workspaces. If no other inputs are chosen, this will default to `true`.                                                                                 |
-| `--all, -a`        | `boolean`                  | Run across all workspaces                                                                                                                                                   |
+| `--all, -a`        | `boolean`                  | Run across all Workspaces                                                                                                                                                   |
 | `--inspect`        | `boolean`                  | Break for the the Node inspector to debug tests.                                                                                                                            |
 | `--pretty`         | `boolean`, default: `true` | Control Jest’s `--colors` flag.                                                                                                                                             |
 | `--staged`         | `boolean`                  | Use files on the git stage to calculate affected files or Workspaces. When unset or `--no-staged`, changes will be calculated from the entire branch, since its fork point. |
@@ -217,10 +217,10 @@ Additionally, any other [Jest CLI options](https://jestjs.io/docs/cli) can be pa
 | Option              | Type                                    | Description                                                                                 |
 | ------------------- | --------------------------------------- | ------------------------------------------------------------------------------------------- |
 | `--config`          | `string`, default: `"./jest.config.js"` | Path to the jest.config file, relative to the repo root.                                    |
-| `--from-ref`        | `string`                                | Git ref to start looking for affected files or workspaces                                   |
+| `--from-ref`        | `string`                                | Git ref to start looking for affected files or Workspaces                                   |
 | `--passWithNoTests` | `boolean`, default: `true`              | Allows the test suite to pass when no files are found. See plugin configuration to disable. |
 | `--show-advanced`   | `boolean`                               | Pair with `--help` to show advanced options.                                                |
-| `--through-ref`     | `string`                                | Git ref to start looking for affected files or workspaces                                   |
+| `--through-ref`     | `string`                                | Git ref to start looking for affected files or Workspaces                                   |
 
 </details>
 

--- a/docs/src/content/docs/plugins/prettier.mdx
+++ b/docs/src/content/docs/plugins/prettier.mdx
@@ -155,7 +155,7 @@ export default {
 ## Commands
 
 {/* start-auto-generated-from-cli-prettier */}
-{/* @generated SignedSource<<49ae120de3ddea0068757dc696a52da4>> */}
+{/* @generated SignedSource<<1383edc776b62732debb786e3be26363>> */}
 
 ### `one prettier`
 
@@ -171,7 +171,7 @@ one prettier [options...]
 | ------------------ | --------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `--add`            | `boolean` | Add modified files after write                                                                                                                                              |
 | `--affected`       | `boolean` | Select all affected Workspaces. If no other inputs are chosen, this will default to `true`.                                                                                 |
-| `--all, -a`        | `boolean` | Run across all workspaces                                                                                                                                                   |
+| `--all, -a`        | `boolean` | Run across all Workspaces                                                                                                                                                   |
 | `--check`          | `boolean` | Check for changes.                                                                                                                                                          |
 | `--files, -f`      | `array`   | Determine Workspaces from specific files                                                                                                                                    |
 | `--staged`         | `boolean` | Use files on the git stage to calculate affected files or Workspaces. When unset or `--no-staged`, changes will be calculated from the entire branch, since its fork point. |
@@ -184,10 +184,10 @@ one prettier [options...]
 | Option              | Type                       | Description                                                                        |
 | ------------------- | -------------------------- | ---------------------------------------------------------------------------------- |
 | `--cache`           | `boolean`, default: `true` | Use Prettier’s built-in cache to determin whether files need formatting or not.    |
-| `--from-ref`        | `string`                   | Git ref to start looking for affected files or workspaces                          |
+| `--from-ref`        | `string`                   | Git ref to start looking for affected files or Workspaces                          |
 | `--github-annotate` | `boolean`, default: `true` | Annotate files in GitHub with errors when failing format checks in GitHub Actions. |
 | `--show-advanced`   | `boolean`                  | Pair with `--help` to show advanced options.                                       |
-| `--through-ref`     | `string`                   | Git ref to start looking for affected files or workspaces                          |
+| `--through-ref`     | `string`                   | Git ref to start looking for affected files or Workspaces                          |
 
 </details>
 

--- a/docs/src/content/docs/plugins/typescript.mdx
+++ b/docs/src/content/docs/plugins/typescript.mdx
@@ -138,7 +138,7 @@ export default {
 ## Commands
 
 {/* start-auto-generated-from-cli-typescript */}
-{/* @generated SignedSource<<1ad99d476c20f192fdd426fadcc6afd0>> */}
+{/* @generated SignedSource<<953a0384d385c904949538d43045a425>> */}
 
 ### `one tsc`
 
@@ -155,7 +155,7 @@ Checks for the existence of `tsconfig.json` file and batches running `tsc --noEm
 | Option             | Type                       | Description                                                                                                                                                                 |
 | ------------------ | -------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `--affected`       | `boolean`                  | Select all affected Workspaces. If no other inputs are chosen, this will default to `true`.                                                                                 |
-| `--all, -a`        | `boolean`                  | Run across all workspaces                                                                                                                                                   |
+| `--all, -a`        | `boolean`                  | Run across all Workspaces                                                                                                                                                   |
 | `--pretty`         | `boolean`, default: `true` | Control TypeScript’s `--pretty` flag.                                                                                                                                       |
 | `--staged`         | `boolean`                  | Use files on the git stage to calculate affected files or Workspaces. When unset or `--no-staged`, changes will be calculated from the entire branch, since its fork point. |
 | `--workspaces, -w` | `array`                    | List of Workspace names to run against                                                                                                                                      |
@@ -166,9 +166,9 @@ Checks for the existence of `tsconfig.json` file and batches running `tsc --noEm
 
 | Option                                                           | Type                                 | Description                                               |
 | ---------------------------------------------------------------- | ------------------------------------ | --------------------------------------------------------- |
-| `--from-ref`                                                     | `string`                             | Git ref to start looking for affected files or workspaces |
+| `--from-ref`                                                     | `string`                             | Git ref to start looking for affected files or Workspaces |
 | `--show-advanced`                                                | `boolean`                            | Pair with `--help` to show advanced options.              |
-| `--through-ref`                                                  | `string`                             | Git ref to start looking for affected files or workspaces |
+| `--through-ref`                                                  | `string`                             | Git ref to start looking for affected files or Workspaces |
 | `--tsconfig`                                                     | `string`, default: `"tsconfig.json"` | The filename of the tsconfig to find in each Workspace.   |
 | `--use-project-references, --project-references, --project-refs` | `boolean`                            | Automatically sync and use typescript project references  |
 

--- a/docs/src/content/docs/plugins/vitest.mdx
+++ b/docs/src/content/docs/plugins/vitest.mdx
@@ -186,7 +186,7 @@ export default {
 ## Commands
 
 {/* start-auto-generated-from-cli-vitest */}
-{/* @generated SignedSource<<7e34c980ef18820e7e3e903f46df5a91>> */}
+{/* @generated SignedSource<<a17a1b75f3a21434a56e7a3e880f5213>> */}
 
 ### `one vitest`
 
@@ -206,7 +206,7 @@ Additionally, any other [Vitest CLI options](https://jest.dev/guide/cli.html) ca
 | Option             | Type      | Description                                                                                                                                                                 |
 | ------------------ | --------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `--affected`       | `boolean` | Select all affected Workspaces. If no other inputs are chosen, this will default to `true`.                                                                                 |
-| `--all, -a`        | `boolean` | Run across all workspaces                                                                                                                                                   |
+| `--all, -a`        | `boolean` | Run across all Workspaces                                                                                                                                                   |
 | `--inspect`        | `boolean` | Break for the the Node inspector to debug tests.                                                                                                                            |
 | `--staged`         | `boolean` | Use files on the git stage to calculate affected files or Workspaces. When unset or `--no-staged`, changes will be calculated from the entire branch, since its fork point. |
 | `--watch`          | `boolean` | Shortcut for vitest `--watch` mode.                                                                                                                                         |
@@ -219,9 +219,9 @@ Additionally, any other [Vitest CLI options](https://jest.dev/guide/cli.html) ca
 | Option            | Type                                      | Description                                                |
 | ----------------- | ----------------------------------------- | ---------------------------------------------------------- |
 | `--config`        | `string`, default: `"./vitest.config.ts"` | Path to the vitest.config file, relative to the repo root. |
-| `--from-ref`      | `string`                                  | Git ref to start looking for affected files or workspaces  |
+| `--from-ref`      | `string`                                  | Git ref to start looking for affected files or Workspaces  |
 | `--show-advanced` | `boolean`                                 | Pair with `--help` to show advanced options.               |
-| `--through-ref`   | `string`                                  | Git ref to start looking for affected files or workspaces  |
+| `--through-ref`   | `string`                                  | Git ref to start looking for affected files or Workspaces  |
 
 </details>
 

--- a/modules/builders/.changes/000-gentle-plums-do.md
+++ b/modules/builders/.changes/000-gentle-plums-do.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+Capitalized “Workspace” and “Workspaces” in documentation, help output, and tsdoc comments.

--- a/modules/builders/src/getters.ts
+++ b/modules/builders/src/getters.ts
@@ -235,7 +235,7 @@ export async function getFilepaths(
 					paths.push(...workspaces.map((ws) => graph.root.relative(ws.location)));
 				}
 			} else {
-				step.log('`affected` requested from workspaces');
+				step.log('`affected` requested from Workspaces');
 				const affected = await graph.affected(argv.workspaces!);
 				paths.push(...affected.map((ws) => ws.location));
 			}

--- a/modules/builders/src/with-affected.ts
+++ b/modules/builders/src/with-affected.ts
@@ -25,7 +25,7 @@ export const withAffected = <T>(yargs: Yargs<T>): Yargs<T & WithAffected> =>
 		})
 		.option('from-ref', {
 			type: 'string',
-			description: 'Git ref to start looking for affected files or workspaces',
+			description: 'Git ref to start looking for affected files or Workspaces',
 			conflicts: ['all'],
 			hidden: true,
 		})
@@ -37,7 +37,7 @@ export const withAffected = <T>(yargs: Yargs<T>): Yargs<T & WithAffected> =>
 		})
 		.option('through-ref', {
 			type: 'string',
-			description: 'Git ref to start looking for affected files or workspaces',
+			description: 'Git ref to start looking for affected files or Workspaces',
 			conflicts: ['all'],
 			hidden: true,
 		})

--- a/modules/builders/src/with-workspaces.ts
+++ b/modules/builders/src/with-workspaces.ts
@@ -18,7 +18,7 @@ export const withWorkspaces = <T>(yargs: Yargs<T>): Yargs<T & WithWorkspaces> =>
 		.option('all', {
 			alias: 'a',
 			type: 'boolean',
-			description: 'Run across all workspaces',
+			description: 'Run across all Workspaces',
 			conflicts: ['affected', 'workspaces'],
 		})
 		.option('workspaces', {

--- a/modules/github-action/commands/build.ts
+++ b/modules/github-action/commands/build.ts
@@ -18,7 +18,7 @@ export const builder: Builder<Args> = (yargs) =>
 				.usage('$0 build [options...]')
 				.example('$0 build', 'Build all Workspaces.')
 				.example('$0 build -w graph', 'Build the `graph` Workspace only.')
-				.example('$0 build -w graph cli logger', 'Build the `graph`, `cli`, and `logger` workspaces.'),
+				.example('$0 build -w graph cli logger', 'Build the `graph`, `cli`, and `logger` Workspaces.'),
 		),
 	);
 

--- a/modules/graph/.changes/000-gentle-plums-do.md
+++ b/modules/graph/.changes/000-gentle-plums-do.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+Capitalized “Workspace” and “Workspaces” in documentation, help output, and tsdoc comments.

--- a/modules/graph/src/Workspace.ts
+++ b/modules/graph/src/Workspace.ts
@@ -133,7 +133,7 @@ export class Workspace {
 	}
 
 	/**
-	 * Get the workspace's configuration
+	 * Get the Workspace's configuration
 	 */
 	get config(): Required<WorkspaceConfig | RootConfig> {
 		if (!this.#config) {
@@ -235,7 +235,7 @@ export class Workspace {
 	}
 
 	/**
-	 * Get the relative path of an absolute path to the workspace’s location root
+	 * Get the relative path of an absolute path to the Workspace’s location root
 	 *
 	 * ```ts
 	 * const relativePath = workspace.relative('/some/absolute/path');

--- a/modules/onerepo/.changes/002-gentle-plums-do.md
+++ b/modules/onerepo/.changes/002-gentle-plums-do.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+Capitalized “Workspace” and “Workspaces” in documentation, help output, and tsdoc comments.

--- a/modules/onerepo/src/core/changes/add.ts
+++ b/modules/onerepo/src/core/changes/add.ts
@@ -98,7 +98,7 @@ export const handler: Handler<Argv> = async (argv, { getWorkspaces, graph, logge
 			name: 'chosen',
 			type: 'checkbox',
 			prefix: '📦',
-			message: `What workspace(s) would you like to add a change entry to?
+			message: `What Workspace(s) would you like to add a change entry to?
 ${pc.dim(
 	'\n   Keep in mind that each changeset entry should be related to a single change. If you have made multiple changes, please run this command once for each change.\n',
 )}
@@ -107,7 +107,7 @@ ${pc.dim(
 			pageSize: Math.min(choices.length + 2, 12),
 			validate: (input) => {
 				if (!input.length) {
-					return `${pc.bold(pc.red('Error:'))} Please select at least one workspace.`;
+					return `${pc.bold(pc.red('Error:'))} Please select at least one Workspace.`;
 				}
 				return true;
 			},

--- a/modules/onerepo/src/core/changes/index.ts
+++ b/modules/onerepo/src/core/changes/index.ts
@@ -21,7 +21,7 @@ export const changes: Plugin = function codeowners(config) {
 
 			return yargs.command(
 				command,
-				'Manage changes and changesets for publishable workspaces.',
+				'Manage changes and changesets for publishable Workspaces.',
 				(yargs) => {
 					const y = yargs
 						.usage(`$0 ${command[0]} <command>`)

--- a/modules/onerepo/src/core/changes/migrate.ts
+++ b/modules/onerepo/src/core/changes/migrate.ts
@@ -59,7 +59,7 @@ export const handler: Handler<Argv> = async (argv, { graph, logger }) => {
 		const filename = await getFilename(graph, contents, filenameMethod, { step });
 		for (const ws of workspaces) {
 			if (ws.private) {
-				step.warn(`Not adding changeset "${changesetFilename}" to private workspace ${ws.name}`);
+				step.warn(`Not adding changeset "${changesetFilename}" to private Workspace ${ws.name}`);
 				continue;
 			}
 			await write(

--- a/modules/onerepo/src/core/changes/utils/get-versionable.ts
+++ b/modules/onerepo/src/core/changes/utils/get-versionable.ts
@@ -22,7 +22,7 @@ export type VersionPlan = {
 type VersionOptions = { prerelease?: boolean; identifier?: string; snapshot?: string; step?: LogStep };
 
 export async function getVersionable(graph: Graph, options: VersionOptions = {}) {
-	return stepWrapper({ step: options.step, name: 'Get versionable workspaces' }, async (step) => {
+	return stepWrapper({ step: options.step, name: 'Get versionable Workspaces' }, async (step) => {
 		const workspaces = graph.workspaces;
 
 		const versionable = new Map<Workspace, VersionPlan>();

--- a/modules/onerepo/src/core/changes/utils/request-versioned.ts
+++ b/modules/onerepo/src/core/changes/utils/request-versioned.ts
@@ -7,7 +7,7 @@ import type { getVersionable } from './get-versionable';
 export async function requestVersioned(
 	graph: Graph,
 	versionable: Awaited<ReturnType<typeof getVersionable>>,
-	message: string = 'Which workspaces should be versioned?',
+	message: string = 'Which Workspaces should be versioned?',
 ) {
 	const logger = getLogger();
 	logger.pause();

--- a/modules/onerepo/src/core/changes/version.ts
+++ b/modules/onerepo/src/core/changes/version.ts
@@ -11,7 +11,7 @@ import { applyVersions, getVersionable, confirmClean, requestVersioned, consumeC
 
 export const command = ['version'];
 
-export const description = 'Update version numbers for publishable workspaces';
+export const description = 'Update version numbers for publishable Workspaces';
 
 type Argv = WithWorkspaces & {
 	'allow-dirty': boolean;
@@ -57,7 +57,7 @@ export const handler: Handler<Argv> = async (argv, { config, getWorkspaces, grap
 	}
 
 	if (!requested.length) {
-		logger.error('No workspaces selected. Cancelling.');
+		logger.error('No Workspaces selected. Cancelling.');
 		return;
 	}
 
@@ -113,7 +113,7 @@ export async function requestedOkay(
 		{ text: pc.bold('New'), padding, width: newVersionWidth },
 	);
 	ui.div(pc.dim('⎯'.repeat(width)));
-	const step = logger.createStep('Verify workspaces');
+	const step = logger.createStep('Verify Workspaces');
 
 	requested.map(listItem);
 

--- a/modules/onerepo/src/core/create/create.ts
+++ b/modules/onerepo/src/core/create/create.ts
@@ -29,7 +29,7 @@ export const builder: Builder<Argv> = (yargs) =>
 			alias: 'w',
 			type: 'array',
 			string: true,
-			description: 'List of glob locations for workspaces',
+			description: 'List of glob locations for Workspaces',
 		});
 
 export const handler: Handler<Argv> = async (argv, { logger }) => {
@@ -107,7 +107,7 @@ export const handler: Handler<Argv> = async (argv, { logger }) => {
 		{
 			name: 'workspaces',
 			type: 'input',
-			message: 'Enter a comma-separated list of locations for workspaces:',
+			message: 'Enter a comma-separated list of locations for Workspaces:',
 			default: 'apps/*,modules/*',
 			when: () => !workspaces.length,
 		},

--- a/modules/onerepo/src/core/dependencies/verify.ts
+++ b/modules/onerepo/src/core/dependencies/verify.ts
@@ -5,7 +5,7 @@ import { verifyDependencies } from './utils/verify-dependencies';
 
 export const command = 'verify';
 
-export const description = 'Verify dependencies across workspaces.';
+export const description = 'Verify dependencies across Workspaces.';
 
 export const epilogue = `Dependencies across Workspaces can be validated using one of the various modes:
 

--- a/modules/onerepo/src/core/tasks/tasks.ts
+++ b/modules/onerepo/src/core/tasks/tasks.ts
@@ -105,7 +105,7 @@ export const builder: Builder<Argv> = (yargs) =>
 		})
 		.describe(
 			'staged',
-			'Backup unstaged files and use only those on the git stage to calculate affected files or workspaces. Will re-apply the unstaged files upon exit.',
+			'Backup unstaged files and use only those on the git stage to calculate affected files or Workspaces. Will re-apply the unstaged files upon exit.',
 		);
 
 export const handler: Handler<Argv> = async (argv, { getWorkspaces, graph, logger, config }) => {

--- a/modules/onerepo/src/types/config-root.ts
+++ b/modules/onerepo/src/types/config-root.ts
@@ -104,7 +104,7 @@ export type RootConfig<CustomLifecycles extends string | void = void> = {
 		 * };
 		 * ```
 		 *
-		 * Given the preceding configuration, commands will be searched for within the `commands/` directory at the root of the repository as well as a directory of the same name at the root of each workspace:
+		 * Given the preceding configuration, commands will be searched for within the `commands/` directory at the root of the repository as well as a directory of the same name at the root of each Workspace:
 		 *
 		 * - `<root>/commands/*`
 		 * - `<root>/<workspaces>/commands/*`

--- a/modules/onerepo/src/types/config-workspace.ts
+++ b/modules/onerepo/src/types/config-workspace.ts
@@ -27,7 +27,7 @@ export type WorkspaceConfig<CustomLifecycles extends string | void = void> = {
 		/**
 		 * @default `{}`
 		 *
-		 * Enable commands from installed dependencies. Similar to running `npx <command>`, but pulled into the oneRepo CLI and able to be limited by workspace. Passthrough commands _must_ have helpful descriptions.
+		 * Enable commands from installed dependencies. Similar to running `npx <command>`, but pulled into the oneRepo CLI and able to be limited by Workspace. Passthrough commands _must_ have helpful descriptions.
 		 *
 		 * ```ts title="onerepo.config.ts"
 		 * export default {

--- a/modules/onerepo/src/types/tasks.ts
+++ b/modules/onerepo/src/types/tasks.ts
@@ -27,7 +27,7 @@ export type TaskDef = {
 	 *
 	 * The commands can use replaced tokens:
 	 * - `$0`: the oneRepo CLI for your repository
-	 * - `${workspaces}`: replaced with a space-separated list of workspace names necessary for the given lifecycle
+	 * - `${workspaces}`: replaced with a space-separated list of Workspace names necessary for the given lifecycle
 	 */
 	cmd: string | Array<string>;
 	/**

--- a/plugins/eslint/.changes/001-gentle-plums-do.md
+++ b/plugins/eslint/.changes/001-gentle-plums-do.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+Capitalized “Workspace” and “Workspaces” in documentation, help output, and tsdoc comments.

--- a/plugins/eslint/src/commands/eslint.ts
+++ b/plugins/eslint/src/commands/eslint.ts
@@ -5,7 +5,7 @@ import type { Builder, Handler } from 'onerepo';
 
 export const command = ['eslint', 'lint'];
 
-export const description = 'Run eslint across files and workspaces';
+export const description = 'Run eslint across files and Workspaces.';
 
 type Args = builders.WithAllInputs & {
 	add?: boolean;


### PR DESCRIPTION
We should maintain consistency in documentation. "workspace" should always be capitalized as "Workspace".
