### PR TITLE
fix: translate paths to relative for ignores

### DIFF
--- a/modules/onerepo/.changes/000-funny-seals-rush.md
+++ b/modules/onerepo/.changes/000-funny-seals-rush.md
@@ -1,0 +1,9 @@
+---
+type: patch
+---
+
+When passing an absolute path to the `one codeowners show` command, eg `--file /home/dev/path/to/file`, matching the file to owners would throw an error:
+
+```
+RangeError: path should be a `path.relative()`d string, but got "."
+```

--- a/modules/onerepo/src/core/codeowners/show.ts
+++ b/modules/onerepo/src/core/codeowners/show.ts
@@ -1,3 +1,4 @@
+import path from 'node:path';
 import pc from 'picocolors';
 import type { Builder, Handler } from '@onerepo/yargs';
 import type { WithAllInputs } from '@onerepo/builders';
@@ -58,7 +59,7 @@ export const handler: Handler<Argv> = async (argv, { getFilepaths, graph, logger
 	for (const [pattern, owners] of Object.entries(codeowners)) {
 		const matcher = ignore().add(pattern);
 		for (const filepath of files) {
-			if (matcher.ignores(filepath)) {
+			if (matcher.ignores(path.isAbsolute(filepath) ? graph.root.relative(filepath) : filepath)) {
 				if (!(filepath in result)) {
 					result[filepath] = [];
 				}

--- a/plugins/eslint/.changes/000-polite-planets-call.md
+++ b/plugins/eslint/.changes/000-polite-planets-call.md
@@ -1,0 +1,9 @@
+---
+type: patch
+---
+
+When passing an absolute path to the command, eg `--file /home/dev/path/to/file`, ignores filtering would throw an error:
+
+```
+RangeError: path should be a `path.relative()`d string, but got "."
+```

--- a/plugins/eslint/src/commands/eslint.ts
+++ b/plugins/eslint/src/commands/eslint.ts
@@ -86,7 +86,7 @@ export const handler: Handler<Args> = async function handler(argv, { getFilepath
 
 		const matcher = ignore().add(ignores);
 		const paths = await getFilepaths({ step: ignoreStep });
-		filteredPaths = matcher.filter(paths);
+		filteredPaths = matcher.filter(paths.map((p) => (path.isAbsolute(p) ? graph.root.relative(p) : p)));
 
 		if (extensions && extensions.length) {
 			filteredPaths = filteredPaths.filter((filepath) => {

--- a/plugins/prettier/.changes/000-polite-planets-call.md
+++ b/plugins/prettier/.changes/000-polite-planets-call.md
@@ -1,0 +1,9 @@
+---
+type: patch
+---
+
+When passing an absolute path to the command, eg `--file /home/dev/path/to/file`, ignores filtering would throw an error:
+
+```
+RangeError: path should be a `path.relative()`d string, but got "."
+```

--- a/plugins/prettier/src/commands/__tests__/prettier.test.ts
+++ b/plugins/prettier/src/commands/__tests__/prettier.test.ts
@@ -1,3 +1,4 @@
+import path from 'node:path';
 import * as core from '@actions/core';
 import * as onerepo from 'onerepo';
 import { getCommand } from '@onerepo/test-cli';
@@ -103,6 +104,31 @@ bar/**/*
 			{ isDirectory: () => false },
 		);
 		await expect(run('-f foo.js -f bar/baz/bop.js')).resolves.toBeTruthy();
+
+		expect(onerepo.file.exists).toHaveBeenCalledWith(expect.stringMatching(/\.prettierignore$/), expect.any(Object));
+
+		expect(graph.packageManager.run).toHaveBeenCalledWith(
+			expect.objectContaining({
+				cmd: 'prettier',
+				args: ['--ignore-unknown', '--write', '--cache', '--cache-strategy', 'content', 'foo.js'],
+			}),
+		);
+	});
+
+	test('filtering works with absolute paths', async () => {
+		vi.spyOn(graph.packageManager, 'run').mockResolvedValue(['', '']);
+		vi.spyOn(onerepo.file, 'exists').mockResolvedValue(true);
+		vi.spyOn(onerepo.file, 'read').mockResolvedValue(`
+# ignore the comment
+bar/**/*
+`);
+		vi.spyOn(onerepo.file, 'lstat').mockResolvedValue(
+			// @ts-ignore mock
+			{ isDirectory: () => false },
+		);
+		await expect(
+			run(`-f ${path.join(graph.root.location, 'foo.js')} -f ${path.join(graph.root.location, 'bar/baz/bop.js')}`),
+		).resolves.toBeTruthy();
 
 		expect(onerepo.file.exists).toHaveBeenCalledWith(expect.stringMatching(/\.prettierignore$/), expect.any(Object));
 

--- a/plugins/prettier/src/commands/prettier.ts
+++ b/plugins/prettier/src/commands/prettier.ts
@@ -1,3 +1,4 @@
+import path from 'node:path';
 import ignore from 'ignore';
 import * as core from '@actions/core';
 import { git, file, builders } from 'onerepo';
@@ -57,7 +58,7 @@ export const handler: Handler<Args> = async function handler(argv, { getFilepath
 
 		const matcher = ignore().add(ignores);
 		const paths = await getFilepaths({ step: ignoreStep });
-		filteredPaths = matcher.filter(paths);
+		filteredPaths = matcher.filter(paths.map((p) => (path.isAbsolute(p) ? graph.root.relative(p) : p)));
 
 		await ignoreStep.end();
 	}


### PR DESCRIPTION
**Problem:**

Passing an absolute path to commands that match/filter files using the `ignore` package would throw an error:

```
one codeowners show -f /Users/paularmstrong/development/onerepo/modules/builders/src/index.ts
 ┌ Gathering inputs
 └ ✔ 0ms
  ERR RangeError: path should be a `path.relative()`d string, but got "/Users/paularmstrong/development/onerepo/modules/builders/src/index.ts"
 ■ ✘ Completed with errors 24ms
```

**Solution:**

Translate filepaths to be relative from the root before running through `ignore`
