### PR TITLE
refactor(logger): capture all output

### DIFF
--- a/commands/build.ts
+++ b/commands/build.ts
@@ -45,7 +45,7 @@ export const handler: Handler<Args> = async function handler(argv, { getWorkspac
 
 	for (const workspace of workspaces) {
 		if (workspace.private) {
-			buildableStep.warn(`Not building \`${workspace.name}\` because it is private`);
+			// buildableStep.warn(`Not building \`${workspace.name}\` because it is private`);
 			continue;
 		}
 

--- a/modules/logger/src/LogStep.ts
+++ b/modules/logger/src/LogStep.ts
@@ -254,9 +254,7 @@ export class LogStep {
 	info(contents: unknown) {
 		this.#onMessage('info');
 		this.hasInfo = true;
-		if (this.verbosity >= 1) {
-			this.#writeStream(this.#prefix(prefix.INFO, stringify(contents)));
-		}
+		this.#writeStream(this.#prefix(prefix.INFO, stringify(contents)), this.verbosity >= 1);
 	}
 
 	/**
@@ -278,9 +276,7 @@ export class LogStep {
 	error(contents: unknown) {
 		this.#onMessage('error');
 		this.hasError = true;
-		if (this.verbosity >= 1) {
-			this.#writeStream(this.#prefix(prefix.ERR, stringify(contents)));
-		}
+		this.#writeStream(this.#prefix(prefix.ERR, stringify(contents)), this.verbosity >= 1);
 	}
 
 	/**
@@ -302,9 +298,7 @@ export class LogStep {
 	warn(contents: unknown) {
 		this.#onMessage('warn');
 		this.hasWarning = true;
-		if (this.verbosity >= 2) {
-			this.#writeStream(this.#prefix(prefix.WARN, stringify(contents)));
-		}
+		this.#writeStream(this.#prefix(prefix.WARN, stringify(contents)), this.verbosity >= 2);
 	}
 
 	/**
@@ -326,9 +320,7 @@ export class LogStep {
 	log(contents: unknown) {
 		this.#onMessage('log');
 		this.hasLog = true;
-		if (this.verbosity >= 3) {
-			this.#writeStream(this.#prefix(this.name ? prefix.LOG : '', stringify(contents)));
-		}
+		this.#writeStream(this.#prefix(this.name ? prefix.LOG : '', stringify(contents)), this.verbosity >= 3);
 	}
 
 	/**
@@ -349,9 +341,7 @@ export class LogStep {
 	 */
 	debug(contents: unknown) {
 		this.#onMessage('debug');
-		if (this.verbosity >= 4) {
-			this.#writeStream(this.#prefix(prefix.DBG, stringify(contents)));
-		}
+		this.#writeStream(this.#prefix(prefix.DBG, stringify(contents)), this.verbosity >= 4);
 	}
 
 	/**
@@ -375,8 +365,11 @@ export class LogStep {
 		}
 	}
 
-	#writeStream(line: string) {
-		this.#buffer.write(ensureNewline(line));
+	#writeStream(line: string, toBuffer: boolean = true) {
+		if (toBuffer) {
+			this.#buffer.write(ensureNewline(line));
+		}
+
 		if (this.#active) {
 			const lines = line.split('\n');
 			const lastThree = lines.slice(-3);

--- a/modules/logger/src/Logger.ts
+++ b/modules/logger/src/Logger.ts
@@ -34,6 +34,10 @@ export type LoggerOptions = {
 	 * Advanced – override the writable stream in order to pipe logs elsewhere. Mostly used for dependency injection for `@onerepo/test-cli`.
 	 */
 	stream?: Writable;
+	/**
+	 * @experimental
+	 */
+	captureAll?: boolean;
 };
 
 const frames: Array<string> = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
@@ -64,6 +68,7 @@ export class Logger {
 	#hasWarning = false;
 	#hasInfo = false;
 	#hasLog = false;
+	#captureAll = false;
 
 	/**
 	 * @internal
@@ -73,6 +78,8 @@ export class Logger {
 
 		this.#stream = options.stream ?? process.stderr;
 		this.#updater = createLogUpdate(this.#stream);
+
+		this.#captureAll = !!options.captureAll;
 
 		this.#defaultLogger = new LogStep('', {
 			onEnd: this.#onEnd,
@@ -88,6 +95,13 @@ export class Logger {
 		}
 
 		setCurrent(this);
+	}
+
+	/**
+	 * @experimental
+	 */
+	get captureAll() {
+		return this.#captureAll;
 	}
 
 	/**

--- a/modules/logger/src/index.ts
+++ b/modules/logger/src/index.ts
@@ -91,7 +91,7 @@ export async function stepWrapper<T>(
 export function bufferSubLogger(step: LogStep): { logger: Logger; end: () => Promise<void> } {
 	const logger = getLogger();
 	const buffer = new LogBuffer();
-	const subLogger = new Logger({ verbosity: logger.verbosity, stream: buffer });
+	const subLogger = new Logger({ verbosity: logger.verbosity, stream: buffer, captureAll: true });
 	function proxyChunks(chunk: Buffer) {
 		if (subLogger.hasError) {
 			step.error(() => chunk.toString().trimEnd());

--- a/modules/onerepo/src/core/tasks/tasks.ts
+++ b/modules/onerepo/src/core/tasks/tasks.ts
@@ -279,7 +279,7 @@ function singleTaskToSpec(
 		cmd === '$0' && logger.verbosity ? `-${'v'.repeat(logger.verbosity)}` : '',
 	].filter(Boolean) as Array<string>;
 
-	const name = `${command.replace(/^\$0 /, `${cliName} `)} (${workspace.name})`;
+	const name = `${command.replace(/^\$0 /, `${cliName} `)}${!workspace.isRoot ? ` (${workspace.name})` : ''}`;
 
 	let fn: PromiseFn | undefined;
 	if (cmd === '$0') {


### PR DESCRIPTION
**Problem:**

When running with low verbosity, any output that requires higher verbosity is completely thrown out, making it impossible to trace after the fact or replay later. This is particularly apparent when running tasks and using `bufferSubLogger`.

**Solution:**

We could _capture_ all output from loggers without also writing it out to the output stream (stderr). This would enable future work to replay it if specific information is found in the output after completion.
