### PR TITLE
fix(core): ensures full resolved config sent to handlerextra

### DIFF
--- a/docs/src/content/docs/api/index.md
+++ b/docs/src/content/docs/api/index.md
@@ -4,7 +4,7 @@ description: Full API documentation for oneRepo.
 ---
 
 <!-- start-onerepo-sentinel -->
-<!-- @generated SignedSource<<37d9d59c6eea9804efd663594bd87be2>> -->
+<!-- @generated SignedSource<<3a92b43b1f1f18111c274c26eaba8e87>> -->
 
 ## Namespaces
 
@@ -194,6 +194,7 @@ export const handler: Handler<Argv> = (argv, { logger }) => {
 
 ```ts
 type HandlerExtra: {
+  config: Required<RootConfig>;
   getAffected: (opts?) => Promise<Workspace[]>;
   getFilepaths: (opts?) => Promise<string[]>;
   getWorkspaces: (opts?) => Promise<Workspace[]>;
@@ -221,6 +222,14 @@ export const handler: Handler = (argv, { getFilepaths }) => {
 ```
 
 #### Type declaration
+
+##### config
+
+```ts
+config: Required<RootConfig>;
+```
+
+This repository’s oneRepo [config](#rootconfigcustomlifecycles), resolved with all defaults.
 
 ##### getAffected
 

--- a/modules/onerepo/.changes/003-witty-paws-shop.md
+++ b/modules/onerepo/.changes/003-witty-paws-shop.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+Ensures the resolved config is passed to command HandlerExtra.

--- a/modules/onerepo/.changes/004-good-roses-hide.md
+++ b/modules/onerepo/.changes/004-good-roses-hide.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+Removed the `@internal` flag from `config` on `HandlerExtra`, exposing the type information for consumers and documenting the available information.

--- a/modules/onerepo/src/setup/setup.ts
+++ b/modules/onerepo/src/setup/setup.ts
@@ -134,7 +134,7 @@ export async function setup({
 		graph,
 		exclude: resolvedConfig.commands.ignore,
 		startup,
-		config: config as Required<RootConfig>,
+		config: { ...resolvedConfig, plugins: userPlugins },
 		logger,
 	});
 

--- a/modules/yargs/.changes/000-good-roses-hide.md
+++ b/modules/yargs/.changes/000-good-roses-hide.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+Removed the `@internal` flag from `config` on `HandlerExtra`, exposing the type information for consumers and documenting the available information.

--- a/modules/yargs/src/yargs.ts
+++ b/modules/yargs/src/yargs.ts
@@ -307,7 +307,7 @@ export type HandlerExtra = {
 	 */
 	logger: Logger;
 	/**
-	 * @internal
+	 * This repository’s oneRepo {@link RootConfig | config}, resolved with all defaults.
 	 */
 	config: Required<RootConfig>;
 };


### PR DESCRIPTION
**Problem:**

When running `one change version` without customizing the config `changes` object:

```
TypeError: Cannot read properties of undefined (reading 'formatting')
```

**Solution:**

- Exposes the fully `resolvedConfig` (with `plugins`) back to `HandlerExtra`.
- Removes the `@internal` flag on the `config` key for `HandlerExtra` so that it's documented. We cannot remove it at this point, so might as well expose it.

**Related issues:**

Fixes #677
