### PR TITLE
fix(package-manager): npm exec include --

### DIFF
--- a/modules/onerepo/.changes/007-chatty-buttons-cheat.md
+++ b/modules/onerepo/.changes/007-chatty-buttons-cheat.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+Fixes execution of subtasks in NPM repositories when commands use `graph.packageManager.run()`.

--- a/modules/package-manager/.changes/000-chatty-buttons-cheat.md
+++ b/modules/package-manager/.changes/000-chatty-buttons-cheat.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+Fixes execution of subtasks in NPM repositories when commands use `graph.packageManager.run()`.

--- a/modules/package-manager/src/npm.ts
+++ b/modules/package-manager/src/npm.ts
@@ -19,7 +19,7 @@ export const Npm = {
 			processes.map((proc) => ({
 				...proc,
 				cmd: 'npm',
-				args: ['exec', proc.cmd, ...(proc.args ?? [])],
+				args: ['exec', '--', proc.cmd, ...(proc.args ?? [])],
 			})),
 		);
 	},
@@ -141,7 +141,7 @@ export const Npm = {
 		return await run({
 			...opts,
 			cmd: 'npm',
-			args: ['exec', opts.cmd, ...(opts.args ?? [])],
+			args: ['exec', '--', opts.cmd, ...(opts.args ?? [])],
 		});
 	},
 } satisfies PackageManager;


### PR DESCRIPTION
**Problem:**

Trying to run `one eslint` in an NPM repository fails:

```
  DBG Resolved CLI arguments:
  DBG {
  DBG   "_": [
  DBG     "lint"
  DBG   ],
  DBG   "all": true,
  DBG   "verbosity": 4,
  DBG   "dry-run": false,
  DBG   "quiet": false,
  DBG   "skip-engine-check": false,
  DBG   "cache": true,
  DBG   "fix": true,
  DBG   "pretty": true,
  DBG   "github-annotate": true,
  DBG   "$0": "one"
  DBG }
 ┌ Lint files
 │ LOG Running: Lint …
 │ DBG Running command:
 │ DBG {
 │ DBG   "name": "Lint …",
 │ DBG   "cmd": "npm",
 │ DBG   "args": [
 │ DBG     "exec",
 │ DBG     "eslint",
 │ DBG     "--color",
 │ DBG     "--format",
 │ DBG     "onerepo",
 │ DBG     "--cache",
 │ DBG     "--cache-strategy=content",
 │ DBG     "--fix",
 │ DBG     "."
 │ DBG   ],
 │ DBG   "opts": {
 │ DBG     "env": {
 │ DBG       "ONEREPO_ESLINT_GITHUB_ANNOTATE": "true"
 │ DBG     }
 │ DBG   },
 │ DBG   "skipFailures": true
 │ DBG }
 │ DBG /...repo
 │ LOG Oops! Something went wrong! :(
 │ LOG
 │ LOG ESLint: 8.55.0
 │ LOG
 │ LOG No files matching the pattern "onerepo" were found.
 │ LOG Please check for typing mistakes in the pattern.
 │ LOG npm
 │ LOG notice
 │ LOG npm notice New patch version of npm available! 10.5.0 -> 10.5.2
 │ LOG npm notice Changelog: <https://github.com/npm/cli/releases/tag/v10.5.2>
 │ LOG npm notice
 │ LOG  Run `npm install -g npm@10.5.2` to update!
 │ LOG npm notice
 │ ERR Oops! Something went wrong! :(
 │ ERR
 │ ERR ESLint: 8.55.0
 │ ERR
 │ ERR No files matching the pattern "onerepo" were found.
 │ ERR Please check for typing mistakes in the pattern.
 │ ERR
 │ ERR npm notice
 │ ERR npm notice New patch version of npm available! 10.5.0 -> 10.5.2
 │ ERR npm notice Changelog: <https://github.com/npm/cli/releases/tag/v10.5.2>
 │ ERR npm notice Run `npm install -g npm@10.5.2` to update!
 │ ERR npm notice
 └ ✘ 801ms
 ■ ✘ Completed with errors 844ms
```

**Solution:**

`npm exec` and it seems that it's safer to use `npm exec -- command` instead of `npm exec command`: https://docs.npmjs.com/cli/v7/commands/npm-exec#examples
