### PR TITLE
fix(eslint): rename quiet option to warnings

### DIFF
--- a/docs/src/content/docs/plugins/docgen/example.mdx
+++ b/docs/src/content/docs/plugins/docgen/example.mdx
@@ -13,7 +13,7 @@ The following content is auto-generated using the [official documentation plugin
 :::
 
 {/* start-auto-generated-from-cli */}
-{/* @generated SignedSource<<26a30cb2c4c6184662fb0386830ac469>> */}
+{/* @generated SignedSource<<49659e6314a214f0660696b8510fbecb>> */}
 
 ## `one`
 
@@ -526,19 +526,19 @@ Run eslint across files and Workspaces.
 one eslint [options...]
 ```
 
-| Option             | Type                                                            | Description                                                                                                                                                                 |
-| ------------------ | --------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `--add`            | `boolean`                                                       | Add modified files after write to the git stage.                                                                                                                            |
-| `--affected`       | `boolean`                                                       | Select all affected Workspaces. If no other inputs are chosen, this will default to `true`.                                                                                 |
-| `--all, -a`        | `boolean`                                                       | Run across all Workspaces                                                                                                                                                   |
-| `--cache`          | `boolean`, default: `true`                                      | Use cache if available                                                                                                                                                      |
-| `--extensions`     | `array`, default: `["ts","tsx","js","jsx","cjs","mjs","astro"]` | Make ESLint check files given these extensions.                                                                                                                             |
-| `--files, -f`      | `array`                                                         | Determine Workspaces from specific files                                                                                                                                    |
-| `--fix`            | `boolean`, default: `true`                                      | Apply auto-fixes if possible                                                                                                                                                |
-| `--pretty`         | `boolean`, default: `true`                                      | Control ESLint’s `--color` flag.                                                                                                                                            |
-| `--quiet`          | `boolean`                                                       | Report errors only                                                                                                                                                          |
-| `--staged`         | `boolean`                                                       | Use files on the git stage to calculate affected files or Workspaces. When unset or `--no-staged`, changes will be calculated from the entire branch, since its fork point. |
-| `--workspaces, -w` | `array`                                                         | List of Workspace names to run against                                                                                                                                      |
+| Option               | Type                                                            | Description                                                                                                                                                                 |
+| -------------------- | --------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--add`              | `boolean`                                                       | Add modified files after write to the git stage.                                                                                                                            |
+| `--affected`         | `boolean`                                                       | Select all affected Workspaces. If no other inputs are chosen, this will default to `true`.                                                                                 |
+| `--all, -a`          | `boolean`                                                       | Run across all Workspaces                                                                                                                                                   |
+| `--cache`            | `boolean`, default: `true`                                      | Use cache if available                                                                                                                                                      |
+| `--extensions`       | `array`, default: `["ts","tsx","js","jsx","cjs","mjs","astro"]` | Make ESLint check files given these extensions.                                                                                                                             |
+| `--files, -f`        | `array`                                                         | Determine Workspaces from specific files                                                                                                                                    |
+| `--fix`              | `boolean`, default: `true`                                      | Apply auto-fixes if possible                                                                                                                                                |
+| `--pretty`           | `boolean`, default: `true`                                      | Control ESLint’s `--color` flag.                                                                                                                                            |
+| `--staged`           | `boolean`                                                       | Use files on the git stage to calculate affected files or Workspaces. When unset or `--no-staged`, changes will be calculated from the entire branch, since its fork point. |
+| `--warnings, --warn` | `boolean`, default: `true`                                      | Report warnings from ESLint.                                                                                                                                                |
+| `--workspaces, -w`   | `array`                                                         | List of Workspace names to run against                                                                                                                                      |
 
 <details>
 

--- a/docs/src/content/docs/plugins/eslint.mdx
+++ b/docs/src/content/docs/plugins/eslint.mdx
@@ -40,7 +40,7 @@ import Tabs from '../../../components/Tabs.astro';
 ## Configuration
 
 {/* start-install-typedoc */}
-{/* @generated SignedSource<<cf6eb737699290c0e0a1c007855f9118>> */}
+{/* @generated SignedSource<<a0273ddffca00e4e3bbdc719b8606de1>> */}
 
 ### eslint()
 
@@ -71,7 +71,7 @@ type Options: {
   extensions: string[];
   githubAnnotate: boolean;
   name: string | string[];
-  quiet: boolean;
+  warnings: boolean;
 };
 ```
 
@@ -113,10 +113,10 @@ optional name: string | string[];
 
 The name of the eslint command. You might change this to `'lint'` or `['lint', 'eslint']` to keep things more familiar for most developers.
 
-##### quiet?
+##### warnings?
 
 ```ts
-optional quiet: boolean;
+optional warnings: boolean;
 ```
 
 Control the ESLint setting default to suppress warnings and only report errors.
@@ -160,7 +160,7 @@ export default {
 ## Commands
 
 {/* start-auto-generated-from-cli-eslint */}
-{/* @generated SignedSource<<607c2a94246fb1033dcf23d1a33f537d>> */}
+{/* @generated SignedSource<<8c1ba95f48e2963cc10413a04bbcc55c>> */}
 
 ### `one eslint`
 
@@ -172,19 +172,19 @@ Run eslint across files and Workspaces.
 one eslint [options...]
 ```
 
-| Option             | Type                       | Description                                                                                                                                                                 |
-| ------------------ | -------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `--add`            | `boolean`                  | Add modified files after write to the git stage.                                                                                                                            |
-| `--affected`       | `boolean`                  | Select all affected Workspaces. If no other inputs are chosen, this will default to `true`.                                                                                 |
-| `--all, -a`        | `boolean`                  | Run across all Workspaces                                                                                                                                                   |
-| `--cache`          | `boolean`, default: `true` | Use cache if available                                                                                                                                                      |
-| `--extensions`     | `array`                    | Make ESLint check files given these extensions.                                                                                                                             |
-| `--files, -f`      | `array`                    | Determine Workspaces from specific files                                                                                                                                    |
-| `--fix`            | `boolean`, default: `true` | Apply auto-fixes if possible                                                                                                                                                |
-| `--pretty`         | `boolean`, default: `true` | Control ESLint’s `--color` flag.                                                                                                                                            |
-| `--quiet`          | `boolean`                  | Report errors only                                                                                                                                                          |
-| `--staged`         | `boolean`                  | Use files on the git stage to calculate affected files or Workspaces. When unset or `--no-staged`, changes will be calculated from the entire branch, since its fork point. |
-| `--workspaces, -w` | `array`                    | List of Workspace names to run against                                                                                                                                      |
+| Option               | Type                       | Description                                                                                                                                                                 |
+| -------------------- | -------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--add`              | `boolean`                  | Add modified files after write to the git stage.                                                                                                                            |
+| `--affected`         | `boolean`                  | Select all affected Workspaces. If no other inputs are chosen, this will default to `true`.                                                                                 |
+| `--all, -a`          | `boolean`                  | Run across all Workspaces                                                                                                                                                   |
+| `--cache`            | `boolean`, default: `true` | Use cache if available                                                                                                                                                      |
+| `--extensions`       | `array`                    | Make ESLint check files given these extensions.                                                                                                                             |
+| `--files, -f`        | `array`                    | Determine Workspaces from specific files                                                                                                                                    |
+| `--fix`              | `boolean`, default: `true` | Apply auto-fixes if possible                                                                                                                                                |
+| `--pretty`           | `boolean`, default: `true` | Control ESLint’s `--color` flag.                                                                                                                                            |
+| `--staged`           | `boolean`                  | Use files on the git stage to calculate affected files or Workspaces. When unset or `--no-staged`, changes will be calculated from the entire branch, since its fork point. |
+| `--warnings, --warn` | `boolean`, default: `true` | Report warnings from ESLint.                                                                                                                                                |
+| `--workspaces, -w`   | `array`                    | List of Workspace names to run against                                                                                                                                      |
 
 <details>
 

--- a/plugins/eslint/.changes/001-kind-otters-make.md
+++ b/plugins/eslint/.changes/001-kind-otters-make.md
@@ -1,0 +1,5 @@
+---
+type: major
+---
+
+Renamed `--quiet`/`quiet` option to `--warnings` to be more clear and avoid conflict with the global `--quiet` flag.

--- a/plugins/eslint/src/commands/__tests__/eslint.test.ts
+++ b/plugins/eslint/src/commands/__tests__/eslint.test.ts
@@ -267,10 +267,23 @@ bar/**/*
 		expect(onerepo.git.updateIndex).toHaveBeenCalledWith(['bar.js']);
 	});
 
-	test('if --quiet, reports errors only', async () => {
+	test('if --warnings, reports warnings as well', async () => {
 		vi.spyOn(graph.packageManager, 'run').mockResolvedValue(['', '']);
 
-		await run('--all --quiet');
+		await run('--all --warnings');
+
+		expect(graph.packageManager.run).toHaveBeenCalledWith(
+			expect.objectContaining({
+				cmd: 'eslint',
+				args: expect.not.arrayContaining(['--quiet']),
+			}),
+		);
+	});
+
+	test('if not --warnings, does NOT report warnings', async () => {
+		vi.spyOn(graph.packageManager, 'run').mockResolvedValue(['', '']);
+
+		await run('--all --no-warnings');
 
 		expect(graph.packageManager.run).toHaveBeenCalledWith(
 			expect.objectContaining({

--- a/plugins/eslint/src/commands/eslint.ts
+++ b/plugins/eslint/src/commands/eslint.ts
@@ -14,7 +14,7 @@ type Args = builders.WithAllInputs & {
 	fix: boolean;
 	'github-annotate': boolean;
 	pretty: boolean;
-	quiet: boolean;
+	warnings: boolean;
 };
 
 export const builder: Builder<Args> = (yargs) =>
@@ -45,10 +45,11 @@ export const builder: Builder<Args> = (yargs) =>
 			default: true,
 			description: 'Control ESLint’s `--color` flag.',
 		})
-		.option('quiet', {
+		.option('warnings', {
+			alias: ['warn'],
 			type: 'boolean',
-			description: 'Report errors only',
-			default: false,
+			description: 'Report warnings from ESLint.',
+			default: true,
 		})
 		.option('github-annotate', {
 			description: 'Annotate files in GitHub with errors when failing lint checks in GitHub Actions',
@@ -72,7 +73,7 @@ export const handler: Handler<Args> = async function handler(argv, { getFilepath
 		fix,
 		'github-annotate': github,
 		pretty,
-		quiet,
+		warnings,
 		'--': passthrough = [],
 	} = argv;
 
@@ -124,7 +125,7 @@ export const handler: Handler<Args> = async function handler(argv, { getFilepath
 	if (!isDry && fix) {
 		args.push('--fix');
 	}
-	if (quiet) {
+	if (!warnings) {
 		args.push('--quiet');
 	}
 

--- a/plugins/eslint/src/index.ts
+++ b/plugins/eslint/src/index.ts
@@ -26,7 +26,7 @@ export type Options = {
 	/**
 	 * Control the ESLint setting default to suppress warnings and only report errors.
 	 */
-	quiet?: boolean;
+	warnings?: boolean;
 	/**
 	 * When `true` or unset and run in GitHub Actions, any files failing format checks will be annotated with an error in the GitHub user interface.
 	 */
@@ -65,8 +65,8 @@ export function eslint(opts: Options = {}): Plugin {
 					if (opts.extensions) {
 						y.default('extensions', opts.extensions);
 					}
-					if (opts.quiet) {
-						y.default('quiet', opts.quiet);
+					if (typeof opts.warnings === 'boolean') {
+						y.default('warnings', opts.warnings);
 					}
 					return y;
 				},


### PR DESCRIPTION
**Problem:**

The `--quiet` flag on `one eslint` is conflicting with the global `--quiet` flag on the `one` CLI, which sets the logger into silent mode (no output). This will make eslint look like nothing is happening and potentially fail silently.

**Solution:**

Switch from `quiet` to `warnings`. This should increase clarity of the flag and avoid conflicts.

**This is a breaking change!**

**Related issues:**

<!--
- Link the issue or issues being fixed so they are appropriately tracked and marked closed.
-->

Fixes #

**Checklist:**

- [x] Added or updated tests
- [x] Added or updated documentation
- [x] Ensured the pre-commit hooks ran successfully

_By opening this pull request, you agree that this submission can be released under the same [License](https://github.com/paularmstrong/onerepo/blob/main/LICENSE.md) that covers the project._
