### PR TITLE
fix(onerepo): add stack trace to config/setup failure

### DIFF
--- a/modules/onerepo/.changes/002-pink-peaches-design.md
+++ b/modules/onerepo/.changes/002-pink-peaches-design.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+Clarify bootstrap configuration errors to include the full stack trace.

--- a/modules/onerepo/src/bin/one.ts
+++ b/modules/onerepo/src/bin/one.ts
@@ -81,10 +81,12 @@ async function getSetupAndRun() {
 	const app = setup(configRoot, config).catch((e: unknown) => {
 		process.stderr.write(`${'='.repeat(Math.min(process.stderr.columns, 120))}
   Unable to configure oneRepo in your working directory (${configRoot});
+	This is likely NOT a bug within oneRepo, but somewhere in the local repository’s commands
+	or one of the dependencies within the commands.
   Check your configuration & commands for syntax errors and ensure node_modules are installed.
 ${'⎯'.repeat(Math.min(process.stderr.columns, 120))}
 
-  ${e?.toString().replace(/\n/g, '\n  ')}
+  ${(e as Error)?.stack?.replace(/\n/g, '\n  ') ?? e?.toString().replace(/\n/g, '\n  ')}
 
 ${'='.repeat(Math.min(process.stderr.columns, 120))}`);
 		process.exit(1);


### PR DESCRIPTION
**Problem:**

Startup/configuration errors are missing full stack traces. They aren't super clear that it's not really oneRepo's fault.

**Solution:**

Use `(e as Error)?.stack` if available.

**Related issues:**


**Checklist:**

- [ ] Added or updated tests
- [ ] Added or updated documentation
- [ ] Ensured the pre-commit hooks ran successfully

_By opening this pull request, you agree that this submission can be released under the same [License](https://github.com/paularmstrong/onerepo/blob/main/LICENSE.md) that covers the project._
