### PR TITLE
fix(package-manager): pnpm dedupe

### DIFF
--- a/modules/package-manager/.changes/000-giant-waves-hope.md
+++ b/modules/package-manager/.changes/000-giant-waves-hope.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+Fixed issue in the package manager bridge for `pnpm dedupe`.

--- a/modules/package-manager/src/__tests__/npm.test.ts
+++ b/modules/package-manager/src/__tests__/npm.test.ts
@@ -315,6 +315,19 @@ describe('NPM', () => {
 		});
 	});
 
+	describe('dedupe', () => {
+		test('Runs dedupe', async () => {
+			await manager.dedupe();
+
+			expect(subprocess.run).toHaveBeenCalledWith(
+				expect.objectContaining({
+					cmd: 'npm',
+					args: ['dedupe'],
+				}),
+			);
+		});
+	});
+
 	describe('remove', () => {
 		test('Removes single packages', async () => {
 			await manager.remove('tacos');

--- a/modules/package-manager/src/__tests__/pnpm.test.ts
+++ b/modules/package-manager/src/__tests__/pnpm.test.ts
@@ -315,6 +315,19 @@ describe('PNPm', () => {
 		});
 	});
 
+	describe('dedupe', () => {
+		test('Runs dedupe', async () => {
+			await manager.dedupe();
+
+			expect(subprocess.run).toHaveBeenCalledWith(
+				expect.objectContaining({
+					cmd: 'pnpm',
+					args: ['dedupe'],
+				}),
+			);
+		});
+	});
+
 	describe('remove', () => {
 		test('Removes single packages', async () => {
 			await manager.remove('tacos');

--- a/modules/package-manager/src/__tests__/yarn.test.ts
+++ b/modules/package-manager/src/__tests__/yarn.test.ts
@@ -345,6 +345,19 @@ describe('Yarn', () => {
 		});
 	});
 
+	describe('dedupe', () => {
+		test('Runs dedupe', async () => {
+			await manager.dedupe();
+
+			expect(subprocess.run).toHaveBeenCalledWith(
+				expect.objectContaining({
+					cmd: 'yarn',
+					args: ['dedupe'],
+				}),
+			);
+		});
+	});
+
 	describe('remove', () => {
 		test('Removes single packages', async () => {
 			await manager.remove('tacos');

--- a/modules/package-manager/src/pnpm.ts
+++ b/modules/package-manager/src/pnpm.ts
@@ -18,7 +18,7 @@ export const Pnpm = {
 		return batch(
 			processes.map((proc) => ({
 				...proc,
-				cmd: 'pnpm',
+				cmd,
 				args: ['exec', proc.cmd, ...(proc.args ?? [])],
 			})),
 		);
@@ -27,7 +27,7 @@ export const Pnpm = {
 	dedupe: async () => {
 		await run({
 			name: 'Dedupe dependencies',
-			cmd: 'yapnpmrn',
+			cmd,
 			args: ['dedupe'],
 		});
 	},
@@ -141,7 +141,7 @@ export const Pnpm = {
 	run: async (opts) => {
 		return await run({
 			...opts,
-			cmd: 'pnpm',
+			cmd,
 			args: ['exec', opts.cmd, ...(opts.args ?? [])],
 		});
 	},


### PR DESCRIPTION
**Problem:**

pnpm dedupe in `package-manager` failes:
```
ERR Error: spawn yapnpmrn ENOENT
```

Root cause: typo in the code for the dedupe command in pnpm

**Solution:**

1. Fix the typo
2. Reduce risk of similar bugs by switching to use a module-level constant for the command name as is done for yarn and npm.

**Related issues:**

<!--
- Link the issue or issues being fixed so they are appropriately tracked and marked closed.
-->

Fixes #737 
Closes #739

**Checklist:**

- [x] Added or updated tests
- [x] Added or updated documentation (N/A)
- [x] Ensured the pre-commit hooks ran successfully

_By opening this pull request, you agree that this submission can be released under the same [License](https://github.com/paularmstrong/onerepo/blob/main/LICENSE.md) that covers the project._
