### PR TITLE
chore: update jiti

### DIFF
--- a/bin/one.mjs
+++ b/bin/one.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import initJiti from 'jiti';
+import { createJiti } from 'jiti';
 
 /**
  * Important note: this file is only necessary for the oneRepo source repository
@@ -12,6 +12,6 @@ import initJiti from 'jiti';
  * the `one` CLI to point to this file.
  */
 
-const jiti = initJiti(import.meta.url, { interopDefault: true });
+const jiti = createJiti(import.meta.url, { interopDefault: true });
 
 jiti('onerepo/src/bin/one.ts');

--- a/modules/file/.changes/001-moody-doodles-hear.md
+++ b/modules/file/.changes/001-moody-doodles-hear.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+Update internal typescript resolution package (Jiti)

--- a/modules/file/package.json
+++ b/modules/file/package.json
@@ -22,7 +22,7 @@
 	],
 	"dependencies": {
 		"@onerepo/logger": "1.0.4",
-		"jiti": "^1.21.0"
+		"jiti": "^2.4.2"
 	},
 	"devDependencies": {
 		"@internal/tsconfig": "workspace:^",

--- a/modules/file/src/index.ts
+++ b/modules/file/src/index.ts
@@ -9,7 +9,7 @@ import { tmpdir } from 'node:os';
 import { existsSync } from 'node:fs';
 import { chmod as fsChmod, cp, lstat as fsLstat, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import type { OpenMode } from 'node:fs';
-import initJiti from 'jiti';
+import { createJiti } from 'jiti';
 import { stepWrapper } from '@onerepo/logger';
 import type { LogStep } from '@onerepo/logger';
 import { signFile, signingToken } from './signing';
@@ -395,7 +395,7 @@ function escapeRegExp(str: string) {
 async function format(filename: string, contents: string, options: Options = {}) {
 	const { step } = options;
 	return stepWrapper({ step, name: `Format ${normalizefilepath(filename)}` }, async (step) => {
-		const jiti = initJiti(process.cwd(), { interopDefault: true });
+		const jiti = createJiti(process.cwd(), { interopDefault: true });
 		let prettier;
 		try {
 			prettier = jiti('prettier');

--- a/modules/graph/.changes/001-moody-doodles-hear.md
+++ b/modules/graph/.changes/001-moody-doodles-hear.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+Update internal typescript resolution package (Jiti)

--- a/modules/graph/package.json
+++ b/modules/graph/package.json
@@ -25,7 +25,7 @@
 		"defaults": "^3.0.0",
 		"glob": "^10.1.0",
 		"graph-data-structure": "^3.2.0",
-		"jiti": "^1.21.0",
+		"jiti": "^2.4.2",
 		"js-yaml": "^4.1.0",
 		"minimatch": "^9.0.3"
 	},

--- a/modules/graph/src/Graph.ts
+++ b/modules/graph/src/Graph.ts
@@ -5,6 +5,7 @@ import { getPackageManager, getPackageManagerName } from '@onerepo/package-manag
 import { globSync } from 'glob';
 import { Graph as graph } from 'graph-data-structure';
 import type { PackageManager, PackageJson } from '@onerepo/package-manager';
+import type { Jiti } from 'jiti/lib/types';
 import { Workspace } from './Workspace';
 
 /**
@@ -88,13 +89,18 @@ export class Graph {
 	 * Separate map for aliases to locations to ensure the Graph only uses fully qualified names
 	 */
 	#nameByAlias: Map<string, string> = new Map();
-	#require: typeof require;
+	#require: NodeJS.Require | Jiti;
 	#packageManager: PackageManager;
 
 	/**
 	 * @internal
 	 */
-	constructor(location: string, packageJson: PackageJson, workspaces: Array<string>, moduleRequire = require) {
+	constructor(
+		location: string,
+		packageJson: PackageJson,
+		workspaces: Array<string>,
+		moduleRequire: NodeJS.Require | Jiti = require,
+	) {
 		this.#require = moduleRequire;
 		this.#rootLocation = location;
 		this.#addWorkspace(location, packageJson);

--- a/modules/graph/src/__tests__/Graph.test.ts
+++ b/modules/graph/src/__tests__/Graph.test.ts
@@ -1,14 +1,14 @@
 import path from 'path';
-import initJiti from 'jiti';
+import { createJiti } from 'jiti';
 import { getRootPackageJson } from '..';
 import { DependencyType, Graph } from '../Graph';
 
-const require = initJiti(process.cwd(), { interopDefault: true });
+const require = createJiti(process.cwd(), { interopDefault: true });
 
 describe('Graph', () => {
 	test('bucket', async () => {
 		const location = path.join(__dirname, '__fixtures__', 'repo');
-		const result = await getRootPackageJson(location);
+		const result = getRootPackageJson(location);
 		const repo = new Graph(location, result.json, result.json.workspaces!, require);
 		expect(repo.dependencies('burritos').map(({ name }) => name)).toEqual(['lettuce']);
 		expect(repo.dependencies('lettuce')).toEqual([]);
@@ -17,7 +17,7 @@ describe('Graph', () => {
 
 	test('cannot reuse an alias', async () => {
 		const location = path.join(__dirname, '__fixtures__', 'reused-alias');
-		const result = await getRootPackageJson(location);
+		const result = getRootPackageJson(location);
 
 		expect(() => new Graph(location, result.json, result.json.workspaces!, require)).toThrow(
 			new Error('Cannot add alias "leaf" for spinach because it is already used for lettuce.'),
@@ -26,7 +26,7 @@ describe('Graph', () => {
 
 	test('can get all dependencies', async () => {
 		const location = path.join(__dirname, '__fixtures__', 'repo');
-		const result = await getRootPackageJson(location);
+		const result = getRootPackageJson(location);
 		const repo = new Graph(location, result.json, result.json.workspaces!, require);
 
 		expect(repo.dependencies()).toEqual([
@@ -39,7 +39,7 @@ describe('Graph', () => {
 
 	test('can get isolated dependencies', async () => {
 		const location = path.join(__dirname, '__fixtures__', 'repo');
-		const result = await getRootPackageJson(location);
+		const result = getRootPackageJson(location);
 		const repo = new Graph(location, result.json, result.json.workspaces!, require);
 
 		expect(repo.dependencies('tacos')).toEqual([expect.objectContaining({ name: 'lettuce' })]);
@@ -47,7 +47,7 @@ describe('Graph', () => {
 
 	test('can get all dependents', async () => {
 		const location = path.join(__dirname, '__fixtures__', 'repo');
-		const result = await getRootPackageJson(location);
+		const result = getRootPackageJson(location);
 		const repo = new Graph(location, result.json, result.json.workspaces!, require);
 
 		expect(repo.dependents()).toEqual([
@@ -60,7 +60,7 @@ describe('Graph', () => {
 
 	test('can get isolated dependents', async () => {
 		const location = path.join(__dirname, '__fixtures__', 'repo');
-		const result = await getRootPackageJson(location);
+		const result = getRootPackageJson(location);
 		const repo = new Graph(location, result.json, result.json.workspaces!, require);
 
 		expect(repo.dependents('lettuce')).toEqual([
@@ -71,7 +71,7 @@ describe('Graph', () => {
 
 	test('can get all prod dependencies', async () => {
 		const location = path.join(__dirname, '__fixtures__', 'repo');
-		const result = await getRootPackageJson(location);
+		const result = getRootPackageJson(location);
 		const repo = new Graph(location, result.json, result.json.workspaces!, require);
 
 		expect(repo.dependencies(undefined, true, DependencyType.DEV).map((w) => w.name)).toEqual([
@@ -84,7 +84,7 @@ describe('Graph', () => {
 
 	test('can get prod-only isolated dependencies', async () => {
 		const location = path.join(__dirname, '__fixtures__', 'repo');
-		const result = await getRootPackageJson(location);
+		const result = getRootPackageJson(location);
 		const repo = new Graph(location, result.json, result.json.workspaces!, require);
 
 		expect(repo.dependencies('tacos', true, DependencyType.PROD).map((w) => w.name)).toEqual(['tacos']);
@@ -96,7 +96,7 @@ describe('Graph', () => {
 
 	test('can get prod-only isolated dependents', async () => {
 		const location = path.join(__dirname, '__fixtures__', 'repo');
-		const result = await getRootPackageJson(location);
+		const result = getRootPackageJson(location);
 		const repo = new Graph(location, result.json, result.json.workspaces!, require);
 
 		expect(repo.dependents('lettuce', true, DependencyType.PROD).map((w) => w.name)).toEqual(['lettuce', 'burritos']);
@@ -104,7 +104,7 @@ describe('Graph', () => {
 
 	test('can get all dev dependencies', async () => {
 		const location = path.join(__dirname, '__fixtures__', 'repo');
-		const result = await getRootPackageJson(location);
+		const result = getRootPackageJson(location);
 		const repo = new Graph(location, result.json, result.json.workspaces!, require);
 
 		expect(repo.dependencies(undefined, true, DependencyType.DEV).map((w) => w.name)).toEqual([
@@ -117,7 +117,7 @@ describe('Graph', () => {
 
 	test('can get dev-only isolated dependencies', async () => {
 		const location = path.join(__dirname, '__fixtures__', 'repo');
-		const result = await getRootPackageJson(location);
+		const result = getRootPackageJson(location);
 		const repo = new Graph(location, result.json, result.json.workspaces!, require);
 
 		expect(repo.dependencies('burritos', true, DependencyType.DEV).map((w) => w.name)).toEqual(['burritos']);
@@ -126,7 +126,7 @@ describe('Graph', () => {
 
 	test('can get dev-only isolated dependents', async () => {
 		const location = path.join(__dirname, '__fixtures__', 'repo');
-		const result = await getRootPackageJson(location);
+		const result = getRootPackageJson(location);
 		const repo = new Graph(location, result.json, result.json.workspaces!, require);
 
 		expect(repo.dependents('burritos', true, DependencyType.DEV).map((w) => w.name)).toEqual(['burritos']);

--- a/modules/graph/src/index.ts
+++ b/modules/graph/src/index.ts
@@ -3,7 +3,7 @@ import path from 'node:path';
 import yaml from 'js-yaml';
 import type { PackageJson } from '@onerepo/package-manager';
 import { getLockfile, getPackageManagerName } from '@onerepo/package-manager';
-import initJiti from 'jiti';
+import { createJiti } from 'jiti';
 import { Graph } from './Graph';
 
 export * from './Graph';
@@ -22,7 +22,7 @@ const PackageCache = new Map<string, PackageJson>();
  * @group Graph
  */
 export function getGraph(workingDir: string = process.cwd()) {
-	const jiti = initJiti(workingDir, { interopDefault: true });
+	const jiti = createJiti(workingDir, { interopDefault: true });
 	const { filePath, json } = getRootPackageJson(workingDir);
 	const pkgmanager = getPackageManagerName(filePath, json.packageManager);
 	let workspaces = json.workspaces ?? [];

--- a/modules/onerepo/.changes/001-moody-doodles-hear.md
+++ b/modules/onerepo/.changes/001-moody-doodles-hear.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+Update internal typescript resolution package (Jiti)

--- a/modules/onerepo/package.json
+++ b/modules/onerepo/package.json
@@ -47,7 +47,7 @@
 		"graph-data-structure": "^3.2.0",
 		"ignore": "^5.3.1",
 		"inquirer": "^9.1.4",
-		"jiti": "^1.21.0",
+		"jiti": "^2.4.2",
 		"js-yaml": "^4.1.0",
 		"minimatch": "^9.0.3",
 		"picocolors": "^1.0.0",

--- a/modules/onerepo/src/bin/one.ts
+++ b/modules/onerepo/src/bin/one.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import path from 'node:path';
 import { createRequire } from 'node:module';
-import initJiti from 'jiti';
+import { createJiti } from 'jiti';
 import createYargs from 'yargs/yargs';
 import { Graph, internalSetup, noRepoPlugins } from '..';
 import pkg from '../../package.json';
@@ -26,7 +26,7 @@ process.emitWarning = (warning, ...args) => {
 // @ts-ignore cannot use symbol on global in ts
 globalThis[Symbol.for('onerepo_installed_version')] = pkg.version;
 
-export const jiti = initJiti(process.cwd(), { interopDefault: true });
+export const jiti = createJiti(process.cwd(), { interopDefault: true });
 
 /**
  * Fall back on running `one` in global mode.

--- a/modules/onerepo/src/bin/utils/get-config.ts
+++ b/modules/onerepo/src/bin/utils/get-config.ts
@@ -1,11 +1,12 @@
 import path from 'node:path';
+import type { Jiti } from 'jiti/lib/types';
 import type { RootConfig } from '../../types';
 
 /**
  * Gets the configuration file and dirname of the file starting at the process.cwd() and working upward until hitting the root of the filesystem.
  * If not found, will return undefined.
  */
-export function getConfig(require: NodeRequire, cwd: string = process.cwd()) {
+export function getConfig(require: NodeJS.Require | Jiti, cwd: string = process.cwd()) {
 	// Find a root config starting at the current working directory, looking upward toward filesystem root
 	let configRoot = cwd;
 	let config: RootConfig | undefined;

--- a/modules/onerepo/src/bin/utils/update-node-modules.ts
+++ b/modules/onerepo/src/bin/utils/update-node-modules.ts
@@ -2,13 +2,14 @@ import { createHash } from 'node:crypto';
 import { performance } from 'node:perf_hooks';
 import { existsSync, readFileSync } from 'node:fs';
 import path from 'node:path';
+import type { Jiti } from 'jiti/lib/types';
 import { getLockfile, getLogger, Graph, file } from '../..';
 
 /**
  * Attempt to run the `install` command for the local package manager.
  * Bypass with env vars CI and ONEREPO_USE_HOOKS="0"
  */
-export async function updateNodeModules(configRoot: string, require: NodeRequire) {
+export async function updateNodeModules(configRoot: string, require: NodeJS.Require | Jiti) {
 	// Don't do this in CI or if the user does not like things auto-running
 	if (process.env.CI || process.env.ONEREPO_USE_HOOKS === '0') {
 		return;

--- a/modules/onerepo/src/core/generate/generate.ts
+++ b/modules/onerepo/src/core/generate/generate.ts
@@ -1,5 +1,5 @@
 import path from 'node:path';
-import initJiti from 'jiti';
+import { createJiti } from 'jiti';
 import pc from 'picocolors';
 import { glob } from 'glob';
 import inquirer from 'inquirer';
@@ -120,7 +120,7 @@ export interface Config<T extends Answers = Record<string, unknown>> {
 	prompts?: QuestionCollection<T>;
 }
 
-const jiti = initJiti(process.cwd(), { interopDefault: true });
+const jiti = createJiti(process.cwd(), { interopDefault: true });
 
 function loadConfig(configPath: string) {
 	try {

--- a/modules/onerepo/src/core/tasks/run-tasks.ts
+++ b/modules/onerepo/src/core/tasks/run-tasks.ts
@@ -1,5 +1,5 @@
 import createYargs from 'yargs/yargs';
-import initJiti from 'jiti';
+import { createJiti } from 'jiti';
 import type { Logger } from '@onerepo/logger';
 import { bufferSubLogger, getLogger } from '@onerepo/logger';
 import type { Graph } from '@onerepo/graph';
@@ -20,7 +20,7 @@ import type { Lifecycle } from '../../types';
  * @param logger Optional {@link Logger} instance. Defaults to the current `Logger` (usually there is only one).
  */
 export async function runTasks(lifecycle: Lifecycle, args: Array<string>, graph: Graph, logger: Logger = getLogger()) {
-	const jiti = initJiti(graph.root.location, { interopDefault: true });
+	const jiti = createJiti(graph.root.location, { interopDefault: true });
 
 	// IMPORTANT: this needs to be async-imported to avoid potential circular imports
 	const { tasks } = await import('.');
@@ -31,7 +31,12 @@ export async function runTasks(lifecycle: Lifecycle, args: Array<string>, graph:
 		require: jiti,
 		root: graph.root.location,
 		config: graph.root.config,
-		yargs: createYargs(['tasks', '--lifecycle', lifecycle, ...args], graph.root.location, jiti),
+		yargs: createYargs(
+			['tasks', '--lifecycle', lifecycle, ...args],
+			graph.root.location,
+			// @ts-expect-error Yargs only accepts NodeJS.Require
+			jiti,
+		),
 		corePlugins: [tasks],
 		logger: subLogger.logger,
 	});

--- a/modules/onerepo/src/core/tasks/tasks.ts
+++ b/modules/onerepo/src/core/tasks/tasks.ts
@@ -1,6 +1,6 @@
 import path from 'node:path';
 import { minimatch } from 'minimatch';
-import initJiti from 'jiti';
+import { createJiti } from 'jiti';
 import { batch, run } from '@onerepo/subprocess';
 import * as git from '@onerepo/git';
 import * as builders from '@onerepo/builders';
@@ -259,7 +259,7 @@ function taskToSpecs(
 	];
 }
 
-const jiti = initJiti(process.cwd(), { interopDefault: true });
+const jiti = createJiti(process.cwd(), { interopDefault: true });
 
 function singleTaskToSpec(
 	cliName: string,
@@ -291,7 +291,12 @@ function singleTaskToSpec(
 				require: jiti,
 				root: graph.root.location,
 				config,
-				yargs: createYargs([...args, ...passthrough], undefined, jiti),
+				yargs: createYargs(
+					[...args, ...passthrough],
+					undefined,
+					// @ts-expect-error Yargs only accepts NodeJS.Require
+					jiti,
+				),
 				corePlugins,
 				logger: subLogger.logger,
 			});

--- a/modules/onerepo/src/setup/index.ts
+++ b/modules/onerepo/src/setup/index.ts
@@ -1,5 +1,5 @@
 import createYargs from 'yargs/yargs';
-import initJiti from 'jiti';
+import { createJiti } from 'jiti';
 import type { Config, CorePlugins } from '../types';
 import { changes } from '../core/changes';
 import { codeowners } from '../core/codeowners';
@@ -21,12 +21,17 @@ export type { App } from './setup';
  */
 export async function setup(root: string, config: Config) {
 	performance.mark('onerepo_start_Program');
-	const jiti = initJiti(process.cwd(), { interopDefault: true });
+	const jiti = createJiti(process.cwd(), { interopDefault: true });
 	return await internalSetup({
 		require: jiti,
 		root,
 		config,
-		yargs: createYargs(process.argv.slice(2), process.cwd(), jiti),
+		yargs: createYargs(
+			process.argv.slice(2),
+			process.cwd(),
+			// @ts-expect-error yargs only accepts NodeRequire
+			jiti,
+		),
 		corePlugins,
 	});
 }

--- a/modules/onerepo/src/setup/setup.ts
+++ b/modules/onerepo/src/setup/setup.ts
@@ -13,6 +13,7 @@ import { Logger, getLogger } from '@onerepo/logger';
 import type { RequireDirectoryOptions, Argv as Yargv } from 'yargs';
 import type { Argv, DefaultArgv, Yargs } from '@onerepo/yargs';
 import { flushUpdateIndex } from '@onerepo/git';
+import type { Jiti } from 'jiti/lib/types';
 import type { Config, RootConfig, CorePlugins, PluginObject, Plugin } from '../types';
 import pkg from '../../package.json';
 
@@ -94,7 +95,7 @@ export async function setup({
 	logger: inputLogger,
 }: {
 	graph?: Graph;
-	require?: NodeRequire;
+	require?: NodeJS.Require | Jiti;
 	root: string;
 	config: Config;
 	yargs: Yargv;
@@ -112,7 +113,7 @@ export async function setup({
 	process.env.ONEREPO_HEAD_BRANCH = head;
 	process.env.ONEREPO_DRY_RUN = 'false';
 
-	const graph = await (inputGraph || getGraph(process.env.ONEREPO_ROOT));
+	const graph = inputGraph || getGraph(process.env.ONEREPO_ROOT);
 
 	const yargs = setupYargs(yargsInstance.scriptName('one'), { graph, logger });
 	yargs
@@ -225,7 +226,7 @@ export async function setup({
  * https://github.com/tc39/proposal-class-fields/issues/106
  */
 function patchCommandDir(
-	require: NodeRequire,
+	require: NodeJS.Require | Jiti,
 	options: RequireDirectoryOptions & { visit: NonNullable<RequireDirectoryOptions['visit']> },
 	commandDir: Yargs['commandDir'],
 ) {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
 		"glob": "^10.1.0",
 		"human-id": "^4.1.0",
 		"jest": "^29.7.0",
-		"jiti": "^1.21.0",
+		"jiti": "^2.4.2",
 		"onerepo": "workspace:^",
 		"prettier": "^3.4.2",
 		"typescript": "^5.7.2",

--- a/plugins/docgen/.changes/001-moody-doodles-hear.md
+++ b/plugins/docgen/.changes/001-moody-doodles-hear.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+Update internal typescript resolution package (Jiti)

--- a/plugins/docgen/package.json
+++ b/plugins/docgen/package.json
@@ -23,7 +23,7 @@
 	],
 	"dependencies": {
 		"glob": "^10.1.0",
-		"jiti": "^1.21.0",
+		"jiti": "^2.4.2",
 		"mdast-builder": "^1.1.1",
 		"remark-gfm": "^4.0.0",
 		"remark-parse": "^11.0.0",

--- a/plugins/docgen/src/yargs.ts
+++ b/plugins/docgen/src/yargs.ts
@@ -1,5 +1,5 @@
 import path from 'path';
-import initJiti from 'jiti';
+import { createJiti } from 'jiti';
 import { globSync } from 'glob';
 import type {
 	BuilderCallback,
@@ -81,7 +81,7 @@ export interface Docs {
 	usage: Array<string>;
 }
 
-const require = initJiti(process.cwd(), { interopDefault: true });
+const require = createJiti(process.cwd(), { interopDefault: true });
 
 export class Yargs {
 	_logger: LogStep;

--- a/plugins/eslint/.changes/001-moody-doodles-hear.md
+++ b/plugins/eslint/.changes/001-moody-doodles-hear.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+Update internal typescript resolution package (Jiti)

--- a/plugins/eslint/package.json
+++ b/plugins/eslint/package.json
@@ -32,7 +32,7 @@
 		"@onerepo/test-cli": "workspace:^",
 		"@types/eslint": "^8.56.12",
 		"eslint": "^8.56.0",
-		"jiti": "^1.21.0",
+		"jiti": "^2.4.2",
 		"onerepo": "workspace:^",
 		"typescript": "^5.7.2"
 	},

--- a/yarn.lock
+++ b/yarn.lock
@@ -2100,7 +2100,7 @@ __metadata:
     "@internal/tsconfig": "workspace:^"
     "@internal/vitest-config": "workspace:^"
     "@onerepo/logger": 1.0.4
-    jiti: ^1.21.0
+    jiti: ^2.4.2
     prettier: ^3.4.2
   peerDependencies:
     prettier: ^2 || ^3
@@ -2142,7 +2142,7 @@ __metadata:
     defaults: ^3.0.0
     glob: ^10.1.0
     graph-data-structure: ^3.2.0
-    jiti: ^1.21.0
+    jiti: ^2.4.2
     js-yaml: ^4.1.0
     minimatch: ^9.0.3
     typescript: ^5.7.2
@@ -2181,7 +2181,7 @@ __metadata:
     "@internal/tsconfig": "workspace:^"
     "@internal/vitest-config": "workspace:^"
     glob: ^10.1.0
-    jiti: ^1.21.0
+    jiti: ^2.4.2
     mdast-builder: ^1.1.1
     onerepo: "workspace:^"
     remark-gfm: ^4.0.0
@@ -2204,7 +2204,7 @@ __metadata:
     eslint: ^8.56.0
     eslint-formatter-onerepo: 1.0.4
     ignore: ^5.3.1
-    jiti: ^1.21.0
+    jiti: ^2.4.2
     onerepo: "workspace:^"
     typescript: ^5.7.2
   peerDependencies:
@@ -2307,7 +2307,7 @@ __metadata:
     glob: ^10.1.0
     human-id: ^4.1.0
     jest: ^29.7.0
-    jiti: ^1.21.0
+    jiti: ^2.4.2
     onerepo: "workspace:^"
     prettier: ^3.4.2
     typescript: ^5.7.2
@@ -10004,12 +10004,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jiti@npm:^1.21.0":
-  version: 1.21.7
-  resolution: "jiti@npm:1.21.7"
+"jiti@npm:^2.4.2":
+  version: 2.4.2
+  resolution: "jiti@npm:2.4.2"
   bin:
-    jiti: bin/jiti.js
-  checksum: 9cd20dabf82e3a4cceecb746a69381da7acda93d34eed0cdb9c9bdff3bce07e4f2f4a016ca89924392c935297d9aedc58ff9f7d3281bc5293319ad244926e0b7
+    jiti: lib/jiti-cli.mjs
+  checksum: c6c30c7b6b293e9f26addfb332b63d964a9f143cdd2cf5e946dbe5143db89f7c1b50ad9223b77fb1f6ddb0b9c5ecef995fea024ecf7d2861d285d779cde66e1e
   languageName: node
   linkType: hard
 
@@ -11999,7 +11999,7 @@ __metadata:
     human-id: ^4.1.0
     ignore: ^5.3.1
     inquirer: ^9.1.4
-    jiti: ^1.21.0
+    jiti: ^2.4.2
     js-yaml: ^4.1.0
     minimatch: ^9.0.3
     picocolors: ^1.0.0


### PR DESCRIPTION
<!--

Please make sure you have read the contributing guidelines and code of conduct before submitting a pull request:

1. Contributing guidlines: https://onerepo.tools/project/contributing/
2. Code of conduct: https://onerepo.tools/project/code-of-conduct/

-->

**Problem:**

Was looking at upgrading the ESLint plugin to v9, but it requires Jiti ^2 and will not work with TS eslint configs unless this is also upgraded.

**Solution:**

Upgrade Jiti

**Related issues:**

Replaces #752 

Fixes #

**Checklist:**

- [ ] Added or updated tests
- [ ] Added or updated documentation
- [ ] Ensured the pre-commit hooks ran successfully

_By opening this pull request, you agree that this submission can be released under the same [License](https://github.com/paularmstrong/onerepo/blob/main/LICENSE.md) that covers the project._
