### PR TITLE
fix(file): JS/TS comment syntax & extra whitespace in read/writeSafe

### DIFF
--- a/modules/file/.changes/003-dirty-waves-start.md
+++ b/modules/file/.changes/003-dirty-waves-start.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+Adds comment syntax for more JavaScript and TypeScript files when using `file.writeSafe()`.

--- a/modules/file/.changes/004-giant-eyes-tan.md
+++ b/modules/file/.changes/004-giant-eyes-tan.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+Removes some extra whitespace added with `file.writeSafe()`.

--- a/modules/file/src/__tests__/index.test.ts
+++ b/modules/file/src/__tests__/index.test.ts
@@ -15,7 +15,6 @@ describe('file', () => {
 			expect(fs.writeFile).toHaveBeenCalledWith(
 				'tacos.txt',
 				`
-
 # start-onerepo-sentinel
 add some contents
 # end-onerepo-sentinel
@@ -32,7 +31,6 @@ add some contents
 			expect(fs.writeFile).toHaveBeenCalledWith(
 				'tacos.txt',
 				`original contents
-
 # start-onerepo-sentinel
 add some contents
 # end-onerepo-sentinel
@@ -58,6 +56,28 @@ add some contents
 # start-onerepo-sentinel
 this is new
 # end-onerepo-sentinel
+`,
+			);
+		});
+
+		test('replaces previous content with whitespace before sentinel', async () => {
+			vi.spyOn(fsSync, 'existsSync').mockReturnValue(true);
+			vi.spyOn(fs, 'readFile').mockResolvedValue(`const foo = {
+	// start-onerepo-sentinel
+	old: 'old',
+	// end-onerepo-sentinel
+};
+`);
+
+			await file.writeSafe('tacos.ts', "	new: 'new'");
+
+			expect(fs.writeFile).toHaveBeenCalledWith(
+				'tacos.ts',
+				`const foo = {
+	// start-onerepo-sentinel
+	new: 'new',
+	// end-onerepo-sentinel
+};
 `,
 			);
 		});
@@ -114,7 +134,6 @@ this is new
 			expect(fs.writeFile).toHaveBeenCalledWith(
 				'tacos.txt',
 				`
-
 # start-onerepo-sentinel
 # @generated SignedSource<<520142a648f037d8cb84834de6aef586>>
 
@@ -157,7 +176,7 @@ add some contents
 
 			const [portion, contents] = await file.readSafe('tacos.txt');
 
-			expect(portion).toEqual('add some contents');
+			expect(portion).toEqual('\nadd some contents\n');
 			expect(contents).toEqual(original);
 		});
 
@@ -173,7 +192,7 @@ add some contents
 
 			const [portion, contents] = await file.readSafe('tacos.txt', { sentinel: 'tacos' });
 
-			expect(portion).toEqual('add some contents');
+			expect(portion).toEqual('\nadd some contents\n');
 			expect(contents).toEqual(original);
 		});
 
@@ -189,7 +208,7 @@ add some contents
 
 			const [portion, contents] = await file.readSafe('tacos.mdx');
 
-			expect(portion).toEqual('add some contents');
+			expect(portion).toEqual('\nadd some contents\n');
 			expect(contents).toEqual(original);
 		});
 	});

--- a/modules/file/src/index.ts
+++ b/modules/file/src/index.ts
@@ -273,6 +273,13 @@ export async function remove(pathname: string, options: Options = {}) {
 
 const commentStyle: Record<string, [string, string]> = {
 	'.js': ['// ', ''],
+	'.jsx': ['// ', ''],
+	'.cjs': ['// ', ''],
+	'.mjs': ['// ', ''],
+	'.ts': ['// ', ''],
+	'.cts': ['// ', ''],
+	'.mts': ['// ', ''],
+	'.tsx': ['// ', ''],
 	'.md': ['<!-- ', ' -->'],
 	'.mdx': ['{/* ', ' */}'],
 	'.html': ['<!-- ', ' -->'],
@@ -339,8 +346,8 @@ export async function writeSafe(filename: string, contents: string, options: Wri
 		const writeContent = `${start}\n${finalContents}\n${end}`;
 		const output =
 			match !== null
-				? fileContents.replace(`${start}\n${match}\n${end}`, () => writeContent)
-				: `${fileContents.trimEnd()}\n\n${writeContent}\n`;
+				? fileContents.replace(`${start}${match}${end}`, () => writeContent)
+				: `${fileContents.trimEnd()}\n${writeContent}\n`;
 
 		return await write(filename, output, { step });
 	});
@@ -377,8 +384,8 @@ export async function readSafe(filename: string, options: ReadSafeOptions = {}):
 
 			const [start, end] = getSentinels(filename, sentinel);
 
-			const matches = fileContents.match(new RegExp(`${escapeRegExp(start)}\n(.*)\n${escapeRegExp(end)}`, 'ms'));
-			step.debug(matches);
+			const re = new RegExp(`${escapeRegExp(start)}(.*)${escapeRegExp(end)}`, 'ms');
+			const matches = fileContents.match(re);
 
 			return [matches && matches.length ? matches[1] : null, fileContents];
 		},


### PR DESCRIPTION
**Problem:**

Trying to use `file.writeSafe()` and `file.readSafe()` on JS/TS files results in invalid syntax errors when writing.

**Solution:**

Add comment start/end styles for all JS/TS file extensions.

Also reduces unnecessary newlines when writing content.

**Checklist:**

- [x] Added or updated tests
- [ ] Added or updated documentation
- [x] Ensured the pre-commit hooks ran successfully

_By opening this pull request, you agree that this submission can be released under the same [License](https://github.com/paularmstrong/onerepo/blob/main/LICENSE.md) that covers the project._
