### PR TITLE
feat(onerepo): upgrade yargs to v18

### DIFF
--- a/docs/src/content/docs/docs/commands.mdx
+++ b/docs/src/content/docs/docs/commands.mdx
@@ -577,7 +577,11 @@ one my-command --all
 
 ### Automated tests
 
-Avoiding writing tooling that is easily mis-interpreted and prone to breaking by writing functional tests around your custom commands. The oneRepo suite includes the ability to set up a mock environment to run commands with CLI flags and assert on their behaviors within both [Jest](https://jestjs.io) and [Vitest](https://vitest.dev).
+Avoiding writing tooling that is easily mis-interpreted and prone to breaking by writing functional tests around your custom commands. The oneRepo suite includes the ability to set up a mock environment to run commands with CLI flags and assert on their behaviors within [Vitest](https://vitest.dev).
+
+:::caution[Jest]
+Jest may not be suitable for testing commands due to Jest’s poor ES Module support. This project used to support it, but maintenance overhead became too costly. We will accept PRs that bring back support if it can be proven to work correctly.
+:::
 
 To get started, install the `@onerepo/test-cli` package as a development dependency:
 

--- a/internal/jest-config/src/index.js
+++ b/internal/jest-config/src/index.js
@@ -32,9 +32,12 @@ export function makeConfig(config) {
 		modulePathIgnorePatterns: ['fixtures'],
 		setupFiles: [localPath('globals.js')],
 		testPathIgnorePatterns: ['/dist/'],
-		transformIgnorePatterns: ['/node_modules/(?!(inquirer|log-update))/', ...(config.transformIgnorePatterns ?? [])],
+		transformIgnorePatterns: [
+			'/node_modules/(?!(inquirer|log-update|yargs|yargs-parser))/',
+			...(config.transformIgnorePatterns ?? []),
+		],
 		transform: {
-			'\\.[jt]sx?$': ['esbuild-jest', { sourcemap: true }],
+			'\\.m?[jt]sx?$': ['esbuild-jest', { sourcemap: true }],
 			...config.transform,
 		},
 		watchPathIgnorePatterns: ['<rootDir>/node_modules/'],

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,5 @@
 /** @type {import('jest').Config} */
 export default {
 	collectCoverageFrom: ['**/*.{ts,js}', '!**/node_modules/**'],
-	projects: ['<rootDir>/modules/*/jest.config.js', '<rootDir>/plugins/*/jest.config.js'],
+	projects: ['<rootDir>/modules/*/jest.config.js'],
 };

--- a/modules/onerepo/.changes/005-gentle-spies-own.md
+++ b/modules/onerepo/.changes/005-gentle-spies-own.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+Upgrades Yargs to [v18.0.0](https://github.com/yargs/yargs/releases/tag/v18.0.0)

--- a/modules/onerepo/.changes/006-lazy-plants-happen.md
+++ b/modules/onerepo/.changes/006-lazy-plants-happen.md
@@ -1,0 +1,5 @@
+---
+type: major
+---
+
+Functional testing custom oneRepo commands is no longer supported through Jest. Please consider Vitest instead.

--- a/modules/onerepo/package.json
+++ b/modules/onerepo/package.json
@@ -52,8 +52,8 @@
 		"minimatch": "^9.0.3",
 		"picocolors": "^1.0.0",
 		"semver": "^7.5.4",
-		"yargs": "^17.6.2",
-		"yargs-parser": "^21.1.1",
+		"yargs": "^18.0.0",
+		"yargs-parser": "^22.0.0",
 		"yargs-unparser": "^2.0.0"
 	},
 	"devDependencies": {

--- a/modules/test-cli/.changes/004-gentle-spies-own.md
+++ b/modules/test-cli/.changes/004-gentle-spies-own.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+Upgrades Yargs to [v18.0.0](https://github.com/yargs/yargs/releases/tag/v18.0.0)

--- a/modules/test-cli/package.json
+++ b/modules/test-cli/package.json
@@ -25,7 +25,7 @@
 		"@onerepo/graph": "1.0.4",
 		"@onerepo/logger": "1.0.4",
 		"@onerepo/yargs": "1.0.4",
-		"yargs": "^17.6.2"
+		"yargs": "^18.0.0"
 	},
 	"devDependencies": {
 		"@internal/tsconfig": "workspace:^",

--- a/plugins/jest/.changes/003-rare-webs-shop.md
+++ b/plugins/jest/.changes/003-rare-webs-shop.md
@@ -1,0 +1,5 @@
+---
+type: major
+---
+
+Functional testing custom oneRepo commands is no longer supported through Jest. Please consider Vitest instead.

--- a/plugins/jest/jest.config.js
+++ b/plugins/jest/jest.config.js
@@ -1,8 +1,0 @@
-import { makeConfig } from '@internal/jest-config';
-
-const config = makeConfig({
-	displayName: 'jest',
-	rootDir: import.meta.url,
-});
-
-export default config;

--- a/plugins/jest/package.json
+++ b/plugins/jest/package.json
@@ -23,8 +23,8 @@
 		"./CHANGELOG.md"
 	],
 	"devDependencies": {
-		"@internal/jest-config": "workspace:^",
 		"@internal/tsconfig": "workspace:^",
+		"@internal/vitest-config": "workspace:^",
 		"@onerepo/test-cli": "workspace:^",
 		"onerepo": "workspace:^",
 		"typescript": "^5.7.2"

--- a/plugins/jest/src/commands/__tests__/jest.test.ts
+++ b/plugins/jest/src/commands/__tests__/jest.test.ts
@@ -4,23 +4,14 @@ import * as Jest from '../jest';
 
 const { run } = getCommand(Jest);
 
-jest.mock('onerepo', () => ({
-	__esModule: true,
-	...jest.requireActual('onerepo'),
-	git: {
-		__esModule: true,
-		...jest.requireActual('@onerepo/git'),
-	},
-}));
-
 describe('handler', () => {
 	beforeEach(() => {
-		jest.spyOn(onerepo, 'run').mockResolvedValue(['', '']);
+		vi.spyOn(onerepo, 'run').mockResolvedValue(['', '']);
 	});
 
 	test('runs files related to changes by default', async () => {
-		jest.spyOn(onerepo.git, 'isClean').mockResolvedValue(true);
-		jest.spyOn(onerepo.git, 'getMergeBase').mockResolvedValue('tacobase');
+		vi.spyOn(onerepo.git, 'isClean').mockResolvedValue(true);
+		vi.spyOn(onerepo.git, 'getMergeBase').mockResolvedValue('tacobase');
 		await run('');
 
 		expect(onerepo.run).toHaveBeenCalledWith(
@@ -60,8 +51,8 @@ describe('handler', () => {
 	});
 
 	test('can run the node inspector/debugger', async () => {
-		jest.spyOn(onerepo.git, 'isClean').mockResolvedValue(true);
-		jest.spyOn(onerepo.git, 'getMergeBase').mockResolvedValue('burritobase');
+		vi.spyOn(onerepo.git, 'isClean').mockResolvedValue(true);
+		vi.spyOn(onerepo.git, 'getMergeBase').mockResolvedValue('burritobase');
 
 		await run('--inspect');
 

--- a/plugins/jest/tsconfig.json
+++ b/plugins/jest/tsconfig.json
@@ -1,8 +1,7 @@
 {
 	"extends": "@internal/tsconfig/base.json",
 	"compilerOptions": {
-		"outDir": "./dist/",
-		"types": ["node", "@types/jest"]
+		"outDir": "./dist/"
 	},
 	"include": ["./**/*"],
 	"references": [

--- a/plugins/jest/vitest.config.js
+++ b/plugins/jest/vitest.config.js
@@ -1,0 +1,3 @@
+import { defineProject } from '@internal/vitest-config';
+
+export default defineProject({});

--- a/yarn.lock
+++ b/yarn.lock
@@ -2175,8 +2175,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@onerepo/plugin-jest@workspace:plugins/jest"
   dependencies:
-    "@internal/jest-config": "workspace:^"
     "@internal/tsconfig": "workspace:^"
+    "@internal/vitest-config": "workspace:^"
     "@onerepo/test-cli": "workspace:^"
     onerepo: "workspace:^"
     typescript: ^5.7.2

--- a/yarn.lock
+++ b/yarn.lock
@@ -2296,7 +2296,7 @@ __metadata:
     "@onerepo/logger": 1.0.4
     "@onerepo/yargs": 1.0.4
     typescript: ^5.7.2
-    yargs: ^17.6.2
+    yargs: ^18.0.0
   languageName: unknown
   linkType: soft
 
@@ -5060,6 +5060,17 @@ __metadata:
     strip-ansi: ^6.0.1
     wrap-ansi: ^7.0.0
   checksum: 79648b3b0045f2e285b76fb2e24e207c6db44323581e421c3acbd0e86454cba1b37aea976ab50195a49e7384b871e6dfb2247ad7dec53c02454ac6497394cb56
+  languageName: node
+  linkType: hard
+
+"cliui@npm:^9.0.1":
+  version: 9.0.1
+  resolution: "cliui@npm:9.0.1"
+  dependencies:
+    string-width: ^7.2.0
+    strip-ansi: ^7.1.0
+    wrap-ansi: ^9.0.0
+  checksum: 143879ae462bf76822f341bf40979f0225fdba8dde6dfe429018b13396fd0532752cc2a809ac48cecc0ea189406184ad7568c0af44eea73d2ac3b432c4c6431f
   languageName: node
   linkType: hard
 
@@ -11594,8 +11605,8 @@ __metadata:
     picocolors: ^1.0.0
     semver: ^7.5.4
     typescript: ^5.7.2
-    yargs: ^17.6.2
-    yargs-parser: ^21.1.1
+    yargs: ^18.0.0
+    yargs-parser: ^22.0.0
     yargs-unparser: ^2.0.0
   bin:
     one: ./src/bin/one.ts
@@ -15563,6 +15574,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"yargs-parser@npm:^22.0.0":
+  version: 22.0.0
+  resolution: "yargs-parser@npm:22.0.0"
+  checksum: 55df0d94f3f9f933f1349f244ddf72a6978a9d5a972b69332965cdfd5ec849ff26386965512f4179065b0573cc6e8df33ca44334958a892c47fedae08a967c99
+  languageName: node
+  linkType: hard
+
 "yargs-unparser@npm:^2.0.0":
   version: 2.0.0
   resolution: "yargs-unparser@npm:2.0.0"
@@ -15575,7 +15593,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"yargs@npm:^17.6.2, yargs@npm:^17.7.2":
+"yargs@npm:^17.7.2":
   version: 17.7.2
   resolution: "yargs@npm:17.7.2"
   dependencies:
@@ -15587,6 +15605,20 @@ __metadata:
     y18n: ^5.0.5
     yargs-parser: ^21.1.1
   checksum: 73b572e863aa4a8cbef323dd911d79d193b772defd5a51aab0aca2d446655216f5002c42c5306033968193bdbf892a7a4c110b0d77954a7fdf563e653967b56a
+  languageName: node
+  linkType: hard
+
+"yargs@npm:^18.0.0":
+  version: 18.0.0
+  resolution: "yargs@npm:18.0.0"
+  dependencies:
+    cliui: ^9.0.1
+    escalade: ^3.1.1
+    get-caller-file: ^2.0.5
+    string-width: ^7.2.0
+    y18n: ^5.0.5
+    yargs-parser: ^22.0.0
+  checksum: a7cf1b97cb4e81c059f78fd32a4160505d421ecdce5409f5e3840fdcc4c982885fc645b44af961eab94d673cb46f81207d831aa87862246907ffacf45884976a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
**Problem:**

Yargs 18 is available as an ESM-first package. This is a great stepping stone for us as we look toward the future of removing Jiti as a dependency for loading TypeScript files starting with Node 22's `--experimental-strip-types` support.

**Solution:**

Upgrade Yargs. This appears to work as a drop-in replacement with no real changes required on our end.
