### PR TITLE
Add bugs metadata to TypeScript plugin package

### DIFF
--- a/plugins/typescript/package.json
+++ b/plugins/typescript/package.json
@@ -10,6 +10,9 @@
 		"directory": "plugins/typescript"
 	},
 	"homepage": "https://onerepo.tools/plugins/typescript",
+	"bugs": {
+		"url": "https://github.com/paularmstrong/onerepo/issues"
+	},
 	"type": "module",
 	"main": "./src/index.ts",
 	"publishConfig": {


### PR DESCRIPTION
Adds missing `bugs` metadata to the `@onerepo/plugin-typescript` package manifest.

Validation: parsed `plugins/typescript/package.json` as JSON successfully.