### PR TITLE
chore: add plugin bugs metadata

### DIFF
--- a/plugins/jest/package.json
+++ b/plugins/jest/package.json
@@ -9,6 +9,9 @@
 		"url": "git://github.com/paularmstrong/onerepo.git",
 		"directory": "plugins/jest"
 	},
+	"bugs": {
+		"url": "https://github.com/paularmstrong/onerepo/issues"
+	},
 	"homepage": "https://onerepo.tools/plugins/vitest/",
 	"type": "module",
 	"main": "./src/index.ts",

--- a/plugins/typescript/package.json
+++ b/plugins/typescript/package.json
@@ -9,6 +9,9 @@
 		"url": "git://github.com/paularmstrong/onerepo.git",
 		"directory": "plugins/typescript"
 	},
+	"bugs": {
+		"url": "https://github.com/paularmstrong/onerepo/issues"
+	},
 	"homepage": "https://onerepo.tools/plugins/typescript",
 	"type": "module",
 	"main": "./src/index.ts",


### PR DESCRIPTION
## Summary
- add `bugs.url` metadata for `@onerepo/plugin-typescript`
- add `bugs.url` metadata for `@onerepo/plugin-jest`

## Why
These npm packages already include repository and homepage metadata, but do not currently expose the repository issue tracker through the standard `bugs` field.

## Validation
- `node` manifest assertion for both package files
- `npm pack --dry-run --ignore-scripts --json ./plugins/typescript`
- `npm pack --dry-run --ignore-scripts --json ./plugins/jest`
- `git diff --check`